### PR TITLE
(docs) Change npm commands to yarn equivalents

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ Which is should be fine if your are not working on custom components (Make sure 
 
 `$ cd ngx-openmrs-formentry `
 
-`$ npm install`
+`$ yarn`
 
-`$ npm start `
+`$ yarn start`
 
 ### Build the library by running:
 
-`$ npm run build:lib`
+`$ yarn run build:lib`
 
 ### Usage
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

Changes `npm` commands in the README to their `yarn` equivalents.