### PR TITLE
(chore) Fix warnings when building and running the library

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,24 +18,19 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": ["core-js", "raf"],
             "outputPath": "dist/ngx-openmrs-formentry",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.app.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
               "src/styles.scss",
               "projects/ngx-formentry/styles/ngx-formentry.css"
             ],
             "stylePreprocessorOptions": {
-              "includePaths": [
-                "projects/ngx-formentry/styles",
-                "dist"
-              ]
+              "includePaths": ["projects/ngx-formentry/styles", "dist"]
             },
             "scripts": [],
             "vendorChunk": true,
@@ -94,25 +89,15 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.spec.json",
             "karmaConfig": "src/karma.conf.js",
-            "styles": [
-              "src/styles.css"
-            ],
-            "scripts": [
-              "node_modules/systemjs/dist/system.min.js"
-            ],
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ]
+            "styles": ["src/styles.css"],
+            "scripts": ["node_modules/systemjs/dist/system.min.js"],
+            "assets": ["src/favicon.ico", "src/assets"]
           }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": [
-              "src/**/*.ts",
-              "src/**/*.html"
-            ]
+            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
           }
         }
       }
@@ -131,10 +116,7 @@
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": [
-              "e2e//**/*.ts",
-              "e2e//**/*.html"
-            ]
+            "lintFilePatterns": ["e2e//**/*.ts", "e2e//**/*.html"]
           }
         }
       }

--- a/projects/ngx-formentry/ng-package.json
+++ b/projects/ngx-formentry/ng-package.json
@@ -1,12 +1,18 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/ngx-formentry",
-  "assets": [
-    "./styles/**/*.css"
-  ],
+  "assets": ["./styles/**/*.css"],
   "deleteDestPath": false,
   "lib": {
     "entryFile": "src/public_api.ts",
-    "styleIncludePaths": ["./styles"]
+    "styleIncludePaths": ["./styles"],
+    "umdModuleIds": {
+      "@angular-extensions/elements": "@angular-extensions/elements",
+      "@ng-select/ng-select": "@ng-select/ng-select",
+      "lodash": "lodash",
+      "moment": "moment",
+      "ngx-file-uploader-openmrs": "ngx-file-uploader-openmrs",
+      "ngx-webcam": "ngx-webcam"
+    }
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

Fixes a bunch of warnings when building and running the library by:

- Adding a map of external dependencies and their corresponding UMD module IDs to the package configuration.
- Adding a couple of libraries to the `allowedCommonJsDependencies` property of the Angular CLI builder.

## Screenshots

> CommonJS dependencies warning
<img width="896" alt="Screenshot 2022-10-11 at 21 59 11" src="https://user-images.githubusercontent.com/8509731/195177761-227183ab-f292-4096-85a0-30ce1265e61f.png">

> External modules warning
<img width="1019" alt="Screenshot 2022-10-11 at 21 34 53" src="https://user-images.githubusercontent.com/8509731/195177778-82f24ec8-2ce4-4e58-95b2-96686c0371bf.png">

