### PR TITLE
(chore) Fix lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # AMPATH POC Formentry
 
 Ampath forms is a forms engine that is inspired and built to work with OpenMRS and its encounter/obs model. That being said it tries not to assume that it will be used with an OpenMRS context and does not take responsibility for fetching any dynamic data from OpenMRS that responsibility should be handled by the consuming application by providing data sources to the engine
@@ -15,16 +14,12 @@ The question model is lifted from the Angular tutorial and adapted to support ou
 
 The concept of datasources is an attempt at eliminating need for the library to know about the OpenMRS backend for cases where you need to ;
 
-  
-
--   Resolve uuid to labels by hitting an OpenMRS endpoint (Mostly used for values which provide concept uuids and allows us fetch the label from a remote endpoint)
-    
--   Fetch options for a select drop down by searching via rest (Used for concepts and drugs)
-    
--   Upload documents and relate them to an encounter(Basically allows us to upload images and then set the url  as an obs value which may not be ideal)
-    
+- Resolve uuid to labels by hitting an OpenMRS endpoint (Mostly used for values which provide concept uuids and allows us fetch the label from a remote endpoint)
+- Fetch options for a select drop down by searching via rest (Used for concepts and drugs)
+- Upload documents and relate them to an encounter(Basically allows us to upload images and then set the url as an obs value which may not be ideal)
 
 The engine does not care about where the data sources get their data, only that they return observables which the engine can subscribe to for the data it needs. Which means you can provide dummy observables to the engine and it will happily consume them (That is how the example consumer app in the repository works without having an OpenMRS backend)
+
 ### Expression runner
 
 The expression run is basically that it takes in an expression , runs it and returns true or false. It is used for hiding/showing , disabling/enabling controls and in running complex validation logic.
@@ -34,11 +29,12 @@ The expression run is basically that it takes in an expression , runs it and ret
 This is an important component that allows validation and skip logic. It is done after the question model has been transformed into an angular form schema and basically just goes through each control and identifies which fields cares about subscribes to their changes.
 
 ### Validation and Skip logic
+
 We use Javascript expressions through the expression runner to achieve complex cross field validations and skip logic.
 
 ### Calculations
+
 The engine contains a suite of helpers to allow fields to calculate their values based on the values of other field this is also dependant on the expression runner.
-  
 
 ### Control Interfaces
 
@@ -50,11 +46,9 @@ CanGenerateAlert - This is used in a control to provide an implementation for ge
 
 CanCalculate - This is used in a control to provide an implementation for calculating the value of the field base on other values in the form
 
-  
-
 ### Custom Controls
 
-Angular provides various controls for handling forms FormControl - for simple fields , FormGroup - grouped fields and FormArray for repeating fields. Afe* controls are custom implementations of these fields to add some custom behaviour necessary for the form engine.
+Angular provides various controls for handling forms FormControl - for simple fields , FormGroup - grouped fields and FormArray for repeating fields. Afe\* controls are custom implementations of these fields to add some custom behaviour necessary for the form engine.
 
 AfeFormControl
 
@@ -68,28 +62,25 @@ The form engine supports using custom widgets and controls. The widgets and cont
 
 The custom widgets take recieve this inputs
 
-* `config`  which provides the the widgets configs
-* `dark` which will be used to toggle the them to match the engine when this is true the widget should have a background color of `#f4f4f4` and `#ffffff` otherwise
+- `config` which provides the the widgets configs
+- `dark` which will be used to toggle the them to match the engine when this is true the widget should have a background color of `#f4f4f4` and `#ffffff` otherwise
 
 Custom Controls will receive
 
-* `question` - Json of the question as defined in the schema
-* `value` - current value of the control
-* `disabled` - disabled state of the control
-* `config` - the config of the control
+- `question` - Json of the question as defined in the schema
+- `value` - current value of the control
+- `disabled` - disabled state of the control
+- `config` - the config of the control
 
-When developing the engine expects custom components to be served at localhost:8000 see example components at https://github.com/enyachoke/afe-ref-custom-components. Otherwise project will complain about the proxy 
+When developing the engine expects custom components to be served at localhost:8000 see example components at https://github.com/enyachoke/afe-ref-custom-components. Otherwise project will complain about the proxy
 
 `[HPM] Error occurred while trying to proxy request /lib/web-components.bundled.js?module from localhost:4200 to http://localhost:8000 (ECONNREFUSED) (https://nodejs.org/api/errors.html#errors_common_system_errors)`
 
-
 Which is should be fine if your are not working on custom components (Make sure to not include them in the schema)
-
 
 ### Developing
 
 `$ git clone https://github.com/AMPATH/ngx-openmrs-formentry`
-
 
 `$ cd ngx-openmrs-formentry `
 
@@ -104,6 +95,7 @@ Which is should be fine if your are not working on custom components (Make sure 
 ### Usage
 
 `app.component.ts`
+
 ```Javascript
 import { Component, OnInit } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
@@ -373,22 +365,22 @@ export class AppComponent implements OnInit {
 
 }
 ```
-  `app.component.html`
-  
-  ```html
-  <div *ngIf="form && form.rootNode">
 
-	<form [formGroup]="form.rootNode.control">
+`app.component.html`
 
-		<form-renderer (onAction)="actionClicked($event)" [node]="form.rootNode"></form-renderer>
-
-</form>
-
+```html
+<div *ngIf="form && form.rootNode">
+  <form [formGroup]="form.rootNode.control">
+    <ofe-form-renderer
+      (onAction)="actionClicked($event)"
+      [node]="form.rootNode"
+    ></ofe-form-renderer>
+  </form>
 </div>
-  ```
+```
 
-See ```src/app/adult-1.4.json``` for  and ```src/app/mock/obs.json``` for sample encounter payload
- 
+See `src/app/adult-1.4.json` for and `src/app/mock/obs.json` for sample encounter payload
+
 ### To publish:
 
 Update the version in both of the `package.json` files
@@ -400,6 +392,7 @@ Update the version in both of the `package.json` files
 `$ git tag <Version>`
 
 Reset branch so you don't commit the dist to the src repository
+
 ```
 
 $ git reset HEAD~1 --hard

--- a/projects/ngx-formentry/.eslintrc.json
+++ b/projects/ngx-formentry/.eslintrc.json
@@ -7,9 +7,7 @@
   ],
   "overrides": [
     {
-      "files": [
-        "*.ts"
-      ],
+      "files": ["*.ts"],
       "parserOptions": {
         "project": [
           "projects/ngx-formentry/tsconfig.lib.json",
@@ -22,7 +20,7 @@
           "warn",
           {
             "type": "attribute",
-            "prefix": "lib",
+            "prefix": "ofe",
             "style": "camelCase"
           }
         ],
@@ -30,16 +28,14 @@
           "warn",
           {
             "type": "element",
-            "prefix": "lib",
+            "prefix": "ofe",
             "style": "kebab-case"
           }
         ]
       }
     },
     {
-      "files": [
-        "*.html"
-      ],
+      "files": ["*.html"],
       "rules": {}
     }
   ]

--- a/projects/ngx-formentry/src/change-tracking/sample-form/sample-form.component.ts
+++ b/projects/ngx-formentry/src/change-tracking/sample-form/sample-form.component.ts
@@ -9,7 +9,7 @@ import {
 
 import { AfeFormControl } from '../../abstract-controls-extension/afe-form-control';
 @Component({
-  selector: 'my-sample-form',
+  selector: 'ofe-sample-form',
   templateUrl: 'sample-form.component.html'
 })
 export class SampleFormComponent implements OnInit {

--- a/projects/ngx-formentry/src/components/afe-ng-select.component.spec.ts
+++ b/projects/ngx-formentry/src/components/afe-ng-select.component.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
-/* eslint-disable no-unused-expressions, @typescript-eslint/no-unused-expressions */
-
 import { TestBed } from '@angular/core/testing';
 import { AfeNgSelectComponent } from './afe-ng-select.component';
 import { DummyDataSource } from '../form-entry/data-sources/dummy-data-source';

--- a/projects/ngx-formentry/src/components/afe-ng-select.component.ts
+++ b/projects/ngx-formentry/src/components/afe-ng-select.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, forwardRef, OnInit, OnChanges } from '@angular/core';
+import { Component, Input, forwardRef, OnInit } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { Option } from '../form-entry/question-models/select-option';
@@ -6,7 +6,7 @@ import { Option } from '../form-entry/question-models/select-option';
 import { DataSource } from '../form-entry/question-models/interfaces/data-source';
 
 @Component({
-  selector: 'afe-ng-select',
+  selector: 'ofe-ng-select',
   template: `<ng-select
     (searchInputText)="getChangingText($event)"
     (ngModelChange)="onValueChange($event)"
@@ -22,8 +22,7 @@ import { DataSource } from '../form-entry/question-models/interfaces/data-source
     }
   ]
 })
-export class AfeNgSelectComponent
-  implements ControlValueAccessor, OnInit, OnChanges {
+export class AfeNgSelectComponent implements ControlValueAccessor, OnInit {
   subject: BehaviorSubject<Option[]>;
   subjectOption: BehaviorSubject<Option>;
   @Input() dataSource: DataSource;
@@ -46,8 +45,6 @@ export class AfeNgSelectComponent
   }
 
   registerOnTouched(fn: any): void {}
-
-  ngOnChanges(changes: any) {}
 
   ngOnInit() {
     if (this.extras) {

--- a/projects/ngx-formentry/src/components/appointments-overview/appointments-overview.component.ts
+++ b/projects/ngx-formentry/src/components/appointments-overview/appointments-overview.component.ts
@@ -1,14 +1,14 @@
-import { Component, OnInit, OnChanges, Input } from '@angular/core';
+import { Component, OnChanges, Input } from '@angular/core';
 
 import { LeafNode } from '../../form-entry/form-factory/form-node';
 import moment from 'moment';
 
 @Component({
-  selector: 'appointments-overview',
+  selector: 'ofe-appointments-overview',
   templateUrl: './appointments-overview.component.html',
   styleUrls: ['./appointments-overview.component.css']
 })
-export class AppointmentsOverviewComponent implements OnInit, OnChanges {
+export class AppointmentsOverviewComponent implements OnChanges {
   @Input() node: LeafNode;
   showAppointments = false;
   loadingAppointments = false;
@@ -17,8 +17,6 @@ export class AppointmentsOverviewComponent implements OnInit, OnChanges {
   appointments: Array<any> = [];
   today = '';
   constructor() {}
-
-  ngOnInit() {}
 
   ngOnChanges() {
     this.node.control.valueChanges.subscribe((appointmentDate) => {

--- a/projects/ngx-formentry/src/components/check-box/checkbox.component.ts
+++ b/projects/ngx-formentry/src/components/check-box/checkbox.component.ts
@@ -1,16 +1,10 @@
-import {
-  Component,
-  Input,
-  forwardRef,
-  OnInit,
-  AfterViewInit
-} from '@angular/core';
+import { Component, Input, forwardRef, OnInit } from '@angular/core';
 
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import * as _ from 'lodash';
 
 @Component({
-  selector: 'checkbox',
+  selector: 'ofe-checkbox',
   templateUrl: './checkbox.component.html',
   providers: [
     {
@@ -20,7 +14,7 @@ import * as _ from 'lodash';
     }
   ]
 })
-export class CheckboxControlComponent implements OnInit, AfterViewInit {
+export class CheckboxControlComponent implements OnInit {
   @Input() public id: String;
   @Input() public options: Array<any>;
   @Input() public selected: Array<any>;
@@ -35,8 +29,6 @@ export class CheckboxControlComponent implements OnInit, AfterViewInit {
       return option;
     });
   }
-
-  public ngAfterViewInit() {}
 
   public writeValue(value: any) {
     this.value = value;

--- a/projects/ngx-formentry/src/components/custom-component-wrapper/custom-component-wrapper.component.ts
+++ b/projects/ngx-formentry/src/components/custom-component-wrapper/custom-component-wrapper.component.ts
@@ -1,14 +1,13 @@
-import { Component, forwardRef, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
-  selector: 'app-custom-component-wrapper',
+  selector: 'ofe-custom-component-wrapper',
   templateUrl: 'custom-component-wrapper.component.html'
 })
-export class CustomComponentWrapperComponent implements OnInit {
+export class CustomComponentWrapperComponent {
   @Input()
   componentConfigs: Array<{ tag: ''; url?: ''; module?: ''; detail?: any }>;
 
   @Input()
   dark = true;
-  ngOnInit(): void {}
 }

--- a/projects/ngx-formentry/src/components/custom-control-wrapper/custom-control-wrapper.component.ts
+++ b/projects/ngx-formentry/src/components/custom-control-wrapper/custom-control-wrapper.component.ts
@@ -1,16 +1,9 @@
 import { Component, forwardRef, Input, OnInit } from '@angular/core';
-import {
-  AbstractControl,
-  ControlValueAccessor,
-  NG_VALIDATORS,
-  NG_VALUE_ACCESSOR,
-  ValidationErrors,
-  Validator
-} from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { CustomControlQuestion } from '../../form-entry/question-models/custom-control-question.model';
 
 @Component({
-  selector: 'app-custom-control-wrapper',
+  selector: 'ofe-custom-control-wrapper',
   templateUrl: 'custom-control-wrapper.component.html',
   providers: [
     {
@@ -38,6 +31,7 @@ export class CustomControlWrapperComponent
   registerOnValidatorChange?(fn: () => void): void {
     throw new Error('Method not implemented.');
   }
+
   ngOnInit(): void {
     this.customControlConfig = this.question?.extras?.customControlConfig;
   }

--- a/projects/ngx-formentry/src/components/date-time-picker/date-picker/date-picker.component.html
+++ b/projects/ngx-formentry/src/components/date-time-picker/date-picker/date-picker.component.html
@@ -1,4 +1,4 @@
-<picker-modal (onOverlayClick)="cancelDatePicker()">
+<ofe-picker-modal (overlayClick)="cancelDatePicker()">
   <div class="picker-wrap">
     <div class="picker-box">
       <div class="picker-header">
@@ -84,4 +84,4 @@
       </div>
     </div>
   </div>
-</picker-modal>
+</ofe-picker-modal>

--- a/projects/ngx-formentry/src/components/date-time-picker/date-picker/date-picker.component.spec.ts
+++ b/projects/ngx-formentry/src/components/date-time-picker/date-picker/date-picker.component.spec.ts
@@ -33,9 +33,9 @@ describe('DatePickerComponent', () => {
     expect(todayBtnEl.nativeElement.textContent).toBe('Today');
   });
 
-  it('should raise onSelectDate event when "Today" button clicked', () => {
+  it('should fire a dateSelect event when "Today" button clicked', () => {
     let selectedDateValue: any;
-    comp.onSelectDate.subscribe((date: any) => (selectedDateValue = date));
+    comp.dateSelect.subscribe((date: any) => (selectedDateValue = date));
     expect(selectedDateValue).toBeUndefined();
     const todayBtnEl = fixture.debugElement.query(By.css('.action-today'));
     todayBtnEl.triggerEventHandler('click', null);
@@ -47,9 +47,9 @@ describe('DatePickerComponent', () => {
     expect(clearBtnEl.nativeElement.textContent).toBe('Clear');
   });
 
-  it('should raise onSelectDate event when "Clear" button clicked', () => {
+  it('should fire a dateSelect event when "Clear" button clicked', () => {
     let selectedDateValue: any;
-    comp.onSelectDate.subscribe((date: any) => (selectedDateValue = date));
+    comp.dateSelect.subscribe((date: any) => (selectedDateValue = date));
     const clearBtnEl = fixture.debugElement.query(By.css('.action-clear'));
     clearBtnEl.triggerEventHandler('click', null);
     expect(selectedDateValue).toBeNull();
@@ -60,9 +60,9 @@ describe('DatePickerComponent', () => {
     expect(closeBtnEl.nativeElement.textContent).toBe('Close');
   });
 
-  it('should raise onDatePickerCancel event when "Close" button clicked', () => {
+  it('should fire a datePickerCancel event when "Close" button clicked', () => {
     let pickerStatus: boolean;
-    comp.onDatePickerCancel.subscribe(
+    comp.datePickerCancel.subscribe(
       (status: boolean) => (pickerStatus = status)
     );
     const closeBtnEl = fixture.debugElement.query(By.css('.action-close'));

--- a/projects/ngx-formentry/src/components/date-time-picker/date-picker/date-picker.component.ts
+++ b/projects/ngx-formentry/src/components/date-time-picker/date-picker/date-picker.component.ts
@@ -13,7 +13,7 @@ declare let require: any;
 // webpack2_
 
 @Component({
-  selector: 'date-picker',
+  selector: 'ofe-date-picker',
   templateUrl: './date-picker.component.html',
   styleUrls: ['./date-picker.component.css']
 })
@@ -24,8 +24,8 @@ export class DatePickerComponent implements OnInit {
   @Input() public locale = 'en';
   @Input() public viewFormat = 'll';
   @Input() public returnObject = 'js';
-  @Output() public onDatePickerCancel = new EventEmitter<boolean>();
-  @Output() public onSelectDate = new EventEmitter<any>();
+  @Output() public datePickerCancel = new EventEmitter<boolean>();
+  @Output() public dateSelect = new EventEmitter<any>();
 
   public calendarDate: Moment;
   public selectedDate: Moment;
@@ -98,7 +98,7 @@ export class DatePickerComponent implements OnInit {
     );
     day = this.calendarDate.clone().add(daysDifference, 'd');
     const selectedDay = this.parseToReturnObjectType(day);
-    this.onSelectDate.emit(selectedDay);
+    this.dateSelect.emit(selectedDay);
     this.cancelDatePicker();
     return;
   }
@@ -117,19 +117,19 @@ export class DatePickerComponent implements OnInit {
 
   public selectToday(): void {
     const today = this.parseToReturnObjectType(moment());
-    this.onSelectDate.emit(today);
+    this.dateSelect.emit(today);
     this.cancelDatePicker();
     return;
   }
 
   public clearPickDate(): void {
-    this.onSelectDate.emit(null);
+    this.dateSelect.emit(null);
     this.cancelDatePicker();
     return;
   }
 
   public cancelDatePicker(): void {
-    this.onDatePickerCancel.emit(false);
+    this.datePickerCancel.emit(false);
     return;
   }
 

--- a/projects/ngx-formentry/src/components/date-time-picker/date-time-picker.component.html
+++ b/projects/ngx-formentry/src/components/date-time-picker/date-time-picker.component.html
@@ -86,17 +86,17 @@
     />
   </div>
 </div>
-<date-picker
+<ofe-date-picker
   *ngIf="showDatePicker"
   [initDate]="value"
-  (onSelectDate)="setDate($event)"
-  (onDatePickerCancel)="toggleDatePicker($event)"
-></date-picker>
+  (dateSelect)="setDate($event)"
+  (datePickerCancel)="toggleDatePicker($event)"
+></ofe-date-picker>
 
-<time-picker
+<ofe-time-picker
   *ngIf="showTimePicker"
   [initTime]="value"
   [use12Hour]="true"
-  (onSelectTime)="setTime($event)"
-  (onTimePickerCancel)="toggleTimePicker($event)"
-></time-picker>
+  (timeSelect)="setTime($event)"
+  (timePickerCancel)="toggleTimePicker($event)"
+></ofe-time-picker>

--- a/projects/ngx-formentry/src/components/date-time-picker/date-time-picker.component.ts
+++ b/projects/ngx-formentry/src/components/date-time-picker/date-time-picker.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  OnInit,
   Input,
   forwardRef,
   EventEmitter,
@@ -10,7 +9,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import moment from 'moment';
 
 @Component({
-  selector: 'date-time-picker',
+  selector: 'ofe-date-time-picker',
   templateUrl: './date-time-picker.component.html',
   styleUrls: ['./date-time-picker.component.css'],
   providers: [
@@ -21,21 +20,19 @@ import moment from 'moment';
     }
   ]
 })
-export class DateTimePickerComponent implements OnInit, ControlValueAccessor {
+export class DateTimePickerComponent implements ControlValueAccessor {
   @Input() modelValue: any;
   @Input() showDate = true;
   @Input() showTime = false;
   @Input() showWeeks = false;
   @Input() weeks: number[] = [2, 4, 6, 8, 12, 16, 24];
-  @Output() onDateChange = new EventEmitter<any>();
+  @Output() dateChange = new EventEmitter<any>();
   public showDatePicker = false;
   public showTimePicker = false;
   onChange: any = () => {};
   onTouched: any = () => {};
 
   constructor() {}
-
-  ngOnInit() {}
 
   weeksSelected(count) {
     const now = new Date();
@@ -84,7 +81,7 @@ export class DateTimePickerComponent implements OnInit, ControlValueAccessor {
 
   set value(val) {
     this.modelValue = val;
-    this.onDateChange.emit(val);
+    this.dateChange.emit(val);
     this.onChange(val);
     this.onTouched();
   }

--- a/projects/ngx-formentry/src/components/date-time-picker/picker-modal/modal.component.spec.ts
+++ b/projects/ngx-formentry/src/components/date-time-picker/picker-modal/modal.component.spec.ts
@@ -24,9 +24,9 @@ describe('ModalComponent', () => {
     overlayEl = fixture.debugElement.query(By.css('.modal-overlay'));
   });
 
-  it('should raise onOverlayClick event when the .modal-overlay element clicked', () => {
+  it('should raise an overlayClick event when the .modal-overlay element clicked', () => {
     let modalStatus: boolean;
-    comp.onOverlayClick.subscribe((status: boolean) => (modalStatus = status));
+    comp.overlayClick.subscribe((status: boolean) => (modalStatus = status));
     overlayEl.triggerEventHandler('click', null);
     expect(modalStatus).toBeFalsy();
   });

--- a/projects/ngx-formentry/src/components/date-time-picker/picker-modal/modal.component.ts
+++ b/projects/ngx-formentry/src/components/date-time-picker/picker-modal/modal.component.ts
@@ -5,7 +5,6 @@
 import {
   Component,
   Output,
-  OnInit,
   EventEmitter,
   ChangeDetectionStrategy
 } from '@angular/core';
@@ -17,20 +16,18 @@ declare let require: any;
 // webpack2_
 
 @Component({
-  selector: 'picker-modal',
+  selector: 'ofe-picker-modal',
   templateUrl: './modal.component.html',
   styleUrls: ['./modal.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: []
 })
-export class ModalComponent implements OnInit {
-  @Output() onOverlayClick = new EventEmitter<boolean>();
+export class ModalComponent {
+  @Output() overlayClick = new EventEmitter<boolean>();
 
   constructor() {}
 
-  ngOnInit() {}
-
   closeModal() {
-    this.onOverlayClick.emit(false);
+    this.overlayClick.emit(false);
   }
 }

--- a/projects/ngx-formentry/src/components/date-time-picker/time-picker/time-picker.component.html
+++ b/projects/ngx-formentry/src/components/date-time-picker/time-picker/time-picker.component.html
@@ -1,4 +1,4 @@
-<picker-modal (onOverlayClick)="cancelTimePicker()">
+<ofe-picker-modal (overlayClick)="cancelTimePicker()">
   <div class="picker-wrap">
     <div class="picker-box">
       <div class="picker-header">Time Picker</div>
@@ -42,4 +42,4 @@
       </div>
     </div>
   </div>
-</picker-modal>
+</ofe-picker-modal>

--- a/projects/ngx-formentry/src/components/date-time-picker/time-picker/time-picker.component.spec.ts
+++ b/projects/ngx-formentry/src/components/date-time-picker/time-picker/time-picker.component.spec.ts
@@ -34,9 +34,9 @@ describe('TimePickerComponent', () => {
     expect(nowBtnEl.nativeElement.textContent).toBe('Now');
   });
 
-  it('should raise onSelectTime event when "Now" button clicked', () => {
+  it('should raise a timeSelect event when "Now" button clicked', () => {
     let selectedTimeValue: string;
-    comp.onSelectTime.subscribe((time: string) => (selectedTimeValue = time));
+    comp.timeSelect.subscribe((time: string) => (selectedTimeValue = time));
     comp.returnObject = 'string';
     const nowBtnEl = fixture.debugElement.query(By.css('.action-now'));
     nowBtnEl.triggerEventHandler('click', null);
@@ -48,13 +48,13 @@ describe('TimePickerComponent', () => {
     expect(confirmBtnEl.nativeElement.textContent).toBe('Confirm');
   });
 
-  it('should raise onSelectTime event when "Confirm" button clicked', () => {
+  it('should raise timeSelect event when "Confirm" button clicked', () => {
     let selectedTimeValue: string;
     const initTimeMoment = moment().add(1, 'h');
     comp.initTime = initTimeMoment.format(comp.viewFormat);
     comp.returnObject = 'string';
     fixture.detectChanges();
-    comp.onSelectTime.subscribe((time: string) => (selectedTimeValue = time));
+    comp.timeSelect.subscribe((time: string) => (selectedTimeValue = time));
     const confirmBtnEl = fixture.debugElement.query(By.css('.action-confirm'));
     confirmBtnEl.triggerEventHandler('click', null);
     expect(selectedTimeValue).toBe(initTimeMoment.format(comp.viewFormat));
@@ -65,9 +65,9 @@ describe('TimePickerComponent', () => {
     expect(clearBtnEl.nativeElement.textContent).toBe('Clear');
   });
 
-  it('should raise onSelectTime event when "Clear" button clicked', () => {
+  it('should raise a timeSelect event when "Clear" button clicked', () => {
     let selectedTimeValue: string;
-    comp.onSelectTime.subscribe((time: string) => (selectedTimeValue = time));
+    comp.timeSelect.subscribe((time: string) => (selectedTimeValue = time));
     const clearBtnEl = fixture.debugElement.query(By.css('.action-clear'));
     clearBtnEl.triggerEventHandler('click', null);
     expect(selectedTimeValue).toBeNull();
@@ -78,9 +78,9 @@ describe('TimePickerComponent', () => {
     expect(closeBtnEl.nativeElement.textContent).toBe('Close');
   });
 
-  it('should raise onTimePickerCancel event when "Close" button clicked', () => {
+  it('should raise a timePickerCancel event when "Close" button clicked', () => {
     let timePickerStatus: boolean;
-    comp.onTimePickerCancel.subscribe(
+    comp.timePickerCancel.subscribe(
       (status: boolean) => (timePickerStatus = status)
     );
     const closeBtnEl = fixture.debugElement.query(By.css('.action-close'));

--- a/projects/ngx-formentry/src/components/date-time-picker/time-picker/time-picker.component.ts
+++ b/projects/ngx-formentry/src/components/date-time-picker/time-picker/time-picker.component.ts
@@ -12,7 +12,7 @@ declare let require: any;
 // webpack2_
 
 @Component({
-  selector: 'time-picker',
+  selector: 'ofe-time-picker',
   templateUrl: './time-picker.component.html',
   styleUrls: ['./time-picker.component.css']
 })
@@ -22,8 +22,8 @@ export class TimePickerComponent implements OnInit {
   @Input() viewFormat = 'hh:mm A';
   @Input() use12Hour = false;
   @Input() returnObject = 'js';
-  @Output() onSelectTime = new EventEmitter<any>();
-  @Output() onTimePickerCancel = new EventEmitter<boolean>();
+  @Output() timeSelect = new EventEmitter<any>();
+  @Output() timePickerCancel = new EventEmitter<boolean>();
   hourFormat = 'HH';
   public time: Moment;
 
@@ -74,26 +74,26 @@ export class TimePickerComponent implements OnInit {
 
   selectTime(): void {
     const selectTime = this.parseToReturnObjectType(this.time);
-    this.onSelectTime.emit(selectTime);
+    this.timeSelect.emit(selectTime);
     this.cancelTimePicker();
     return;
   }
 
   selectNow(): void {
     const selectTime = this.parseToReturnObjectType(moment());
-    this.onSelectTime.emit(selectTime);
+    this.timeSelect.emit(selectTime);
     this.cancelTimePicker();
     return;
   }
 
   clearTime(): void {
-    this.onSelectTime.emit(null);
+    this.timeSelect.emit(null);
     this.cancelTimePicker();
     return;
   }
 
   cancelTimePicker(): void {
-    this.onTimePickerCancel.emit(false);
+    this.timePickerCancel.emit(false);
     return;
   }
 

--- a/projects/ngx-formentry/src/components/file-upload/file-upload.component.ts
+++ b/projects/ngx-formentry/src/components/file-upload/file-upload.component.ts
@@ -2,8 +2,9 @@ import { Component, OnInit, Input, forwardRef, Renderer2 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { DataSource } from '../../form-entry/question-models/interfaces/data-source';
+
 @Component({
-  selector: 'app-file-upload',
+  selector: 'ofe-file-upload',
   templateUrl: 'file-upload.component.html',
   providers: [
     {
@@ -28,7 +29,7 @@ export class FileUploadComponent implements OnInit, ControlValueAccessor {
   pdfUploaded = false;
   formEntryMode = true;
   pdfUrl: string;
-  private _dataSource: DataSource;
+
   @Input()
   public get dataSource(): DataSource {
     return this._dataSource;
@@ -37,6 +38,8 @@ export class FileUploadComponent implements OnInit, ControlValueAccessor {
     this._dataSource = v;
   }
 
+  private _dataSource: DataSource;
+
   constructor(private renderer: Renderer2) {}
 
   ngOnInit() {
@@ -44,11 +47,13 @@ export class FileUploadComponent implements OnInit, ControlValueAccessor {
       this.checkFileType();
     }
   }
+
   public onFileChange(fileList) {
     for (const file of fileList) {
       this.upload(file);
     }
   }
+
   upload(data) {
     if (this.dataSource) {
       this.uploading = true;

--- a/projects/ngx-formentry/src/components/file-upload/secure.pipe.ts
+++ b/projects/ngx-formentry/src/components/file-upload/secure.pipe.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @angular-eslint/component-class-suffix */
 import {
   Pipe,
   PipeTransform,
@@ -11,7 +10,6 @@ import { Subscription, Observable, BehaviorSubject } from 'rxjs';
 import { DomSanitizer } from '@angular/platform-browser';
 
 // Using similarity from AsyncPipe to avoid having to pipe |secure|async in HTML.
-// eslint-disable-next-line @angular-eslint/use-pipe-transform-interface
 @Pipe({
   name: 'secure',
   pure: false

--- a/projects/ngx-formentry/src/components/input/input.directive.ts
+++ b/projects/ngx-formentry/src/components/input/input.directive.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @angular-eslint/component-class-suffix, @angular-eslint/directive-class-suffix */
 import { Directive, HostBinding, Input } from '@angular/core';
 
 /**
@@ -7,15 +6,15 @@ import { Directive, HostBinding, Input } from '@angular/core';
  * Example:
  *
  * ```html
- * <input ibmText/>
+ * <input ofeTextInput/>
  * ```
  *
  * See the [vanilla carbon docs](http://www.carbondesignsystem.com/components/text-input/code) for more detail.
  */
 @Directive({
-  selector: '[ibmText]'
+  selector: '[ofeTextInput]'
 })
-export class TextInput {
+export class TextInputDirective {
   /**
    * `light` or `dark` input theme
    */
@@ -27,17 +26,24 @@ export class TextInput {
   @Input() size: 'sm' | 'md' | 'xl' = 'md';
 
   @HostBinding('class.cds--text-input') inputClass = true;
+
   @HostBinding('class.cds--text-input--xl') get isSizeXl() {
     return this.size === 'xl';
   }
   @HostBinding('class.cds--text-input--sm') get isSizeSm() {
     return this.size === 'sm';
   }
-  @HostBinding('class.cds--text-input--invalid') @Input() invalid = false;
+
+  @HostBinding('class.cds--text-input--invalid')
+  @Input()
+  invalid = false;
+
   @HostBinding('class.cds--text-input__field-wrapper--warning')
   @Input()
   warn = false;
+
   @HostBinding('class.cds--skeleton') @Input() skeleton = false;
+
   @HostBinding('class.cds--text-input--light') get isLightTheme() {
     return this.theme === 'light';
   }

--- a/projects/ngx-formentry/src/components/input/input.module.ts
+++ b/projects/ngx-formentry/src/components/input/input.module.ts
@@ -4,13 +4,13 @@ import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 
 // imports
-import { Label } from './label.component';
-import { TextInput } from './input.directive';
-import { TextArea } from './text-area.directive';
+import { LabelComponent } from './label.component';
+import { TextInputDirective } from './input.directive';
+import { TextAreaDirective } from './text-area.directive';
 
 @NgModule({
-  declarations: [Label, TextInput, TextArea],
-  exports: [Label, TextInput, TextArea],
+  declarations: [LabelComponent, TextInputDirective, TextAreaDirective],
+  exports: [LabelComponent, TextInputDirective, TextAreaDirective],
   imports: [CommonModule, FormsModule]
 })
 export class InputModule {}

--- a/projects/ngx-formentry/src/components/input/label.component.spec.ts
+++ b/projects/ngx-formentry/src/components/input/label.component.spec.ts
@@ -2,22 +2,22 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
-import { Label } from './label.component';
+import { LabelComponent } from './label.component';
 
-describe('Label', () => {
-  let component: Label;
-  let fixture: ComponentFixture<Label>;
+describe('LabelComponent', () => {
+  let component: LabelComponent;
+  let fixture: ComponentFixture<LabelComponent>;
   let de: DebugElement;
   let el: HTMLElement;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [Label],
+      declarations: [LabelComponent],
       imports: [],
       providers: []
     });
 
-    fixture = TestBed.createComponent(Label);
+    fixture = TestBed.createComponent(LabelComponent);
     component = fixture.componentInstance;
     de = fixture.debugElement.query(By.css('label'));
     el = de.nativeElement;
@@ -25,7 +25,7 @@ describe('Label', () => {
   });
 
   it('should work', () => {
-    expect(component instanceof Label).toBe(true);
+    expect(component instanceof LabelComponent).toBe(true);
   });
 
   // This functionality isn't replicated in the Carbon UI

--- a/projects/ngx-formentry/src/components/input/label.component.ts
+++ b/projects/ngx-formentry/src/components/input/label.component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @angular-eslint/component-class-suffix */
 import {
   Component,
   Input,
@@ -11,32 +10,32 @@ import {
   AfterContentInit
 } from '@angular/core';
 
-import { TextArea } from './text-area.directive';
+import { TextAreaDirective } from './text-area.directive';
 
 /**
  * [See demo](../../?path=/story/input--label)
  *
  * ```html
- * <ibm-label labelState="success">
+ * <ofe-label labelState="success">
  *     <label label>Field with success</label>
  *     <input type="text" class="input-field">
- * </ibm-label>
+ * </ofe-label>
  *
- * <ibm-label labelState="warning">
+ * <ofe-label labelState="warning">
  *     <label label>Field with warning</label>
  *     <input type="text" class="input-field">
- * </ibm-label>
+ * </ofe-label>
  *
- * <ibm-label labelState="error">
+ * <ofe-label labelState="error">
  *     <label label>Field with error</label>
  *     <input type="text" class="input-field">
- * </ibm-label>
+ * </ofe-label>
  * ```
  *
  * <example-url>../../iframe.html?id=input--label</example-url>
  */
 @Component({
-  selector: 'ibm-label',
+  selector: 'ofe-label',
   template: `
     <label
       [for]="labelInputID"
@@ -109,7 +108,7 @@ import { TextArea } from './text-area.directive';
     </div>
   `
 })
-export class Label implements AfterContentInit, AfterViewInit {
+export class LabelComponent implements AfterContentInit, AfterViewInit {
   /**
    * Used to build the id of the input item associated with the `Label`.
    */
@@ -122,7 +121,7 @@ export class Label implements AfterContentInit, AfterViewInit {
    * The id of the input item associated with the `Label`. This value is also used to associate the `Label` with
    * its input counterpart through the 'for' attribute.
    */
-  @Input() labelInputID = 'ibm-label-' + Label.labelCounter;
+  @Input() labelInputID = 'ofe-label-' + LabelComponent.labelCounter;
 
   /**
    * State of the `Label` will determine the styles applied.
@@ -161,15 +160,16 @@ export class Label implements AfterContentInit, AfterViewInit {
   @ViewChild('wrapper', { static: false }) wrapper: ElementRef<HTMLDivElement>;
 
   // @ts-ignore
-  @ContentChild(TextArea, { static: false }) textArea: TextArea;
+  @ContentChild(TextAreaDirective, { static: false })
+  textArea: TextAreaDirective;
 
   @HostBinding('class.cds--form-item') labelClass = true;
 
   /**
-   * Creates an instance of Label.
+   * Creates an instance of LabelComponent.
    */
   constructor() {
-    Label.labelCounter++;
+    LabelComponent.labelCounter++;
   }
 
   /**

--- a/projects/ngx-formentry/src/components/input/text-area.directive.ts
+++ b/projects/ngx-formentry/src/components/input/text-area.directive.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @angular-eslint/component-class-suffix, @angular-eslint/directive-class-suffix */
 import { Directive, HostBinding, Input } from '@angular/core';
 
 /**
@@ -7,15 +6,15 @@ import { Directive, HostBinding, Input } from '@angular/core';
  * Example:
  *
  * ```html
- * <textarea ibmTextArea></textarea>
+ * <textarea ofeTextAreaInput></textarea>
  * ```
  *
  * See the [vanilla carbon docs](http://www.carbondesignsystem.com/components/text-input/code) for more detail.
  */
 @Directive({
-  selector: '[ibmTextArea]'
+  selector: '[ofeTextAreaInput]'
 })
-export class TextArea {
+export class TextAreaDirective {
   /**
    * `light` or `dark` input theme
    */

--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.component.ts
@@ -1,8 +1,9 @@
 import { Component, forwardRef, Input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import moment from 'moment';
+
 @Component({
-  selector: 'ngx-datetimepicker',
+  selector: 'ofe-ngx-date-time-picker',
   templateUrl: './ngx-datetime-picker.html',
   styleUrls: ['./ngx-datetime-picker.css'],
   providers: [

--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
@@ -17,12 +17,12 @@
           [id]="id"
           [value]="value"
           [owlDateTime]="dt1"
-          [owlDateTimeTrigger]="dt1"
+          [ofeOwlDateTimeTrigger]="dt1"
           placeholder="mm/dd/yyyy"
           data-date-picker-input
         />
         <svg
-          [owlDateTimeTrigger]="dt1"
+          [ofeOwlDateTimeTrigger]="dt1"
           focusable="false"
           preserveAspectRatio="xMidYMid meet"
           style="will-change: transform"
@@ -86,8 +86,8 @@
     </div>
   </div>
 </div>
-<owl-date-time
-  [pickerType]="datePickerFormat ? datePickerFormat :'calendar'"
+<ofe-owl-date-time
+  [pickerType]="datePickerFormat ? datePickerFormat : 'calendar'"
   [disabled]="isDisabled"
   #dt1
-></owl-date-time>
+></ofe-owl-date-time>

--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.module.ts
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.module.ts
@@ -2,7 +2,7 @@
  * date-time-picker.module
  */
 
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgxDatetimeComponent } from './ngx-datetime-picker.component';
@@ -10,7 +10,6 @@ import { OwlDateTimeModule } from '../ngx-pick-datetime/lib/date-time/date-time.
 import { OwlNativeDateTimeModule } from '../ngx-pick-datetime/lib/date-time/adapter/native-date-time.module';
 
 @NgModule({
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
   imports: [
     CommonModule,
     FormsModule,

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-body.component.spec.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-body.component.spec.ts
@@ -92,13 +92,13 @@ describe('OwlCalendarBodyComponent', () => {
 
 @Component({
   template: ` <table
-    owl-date-time-calendar-body
+    ofe-owl-date-time-calendar-body
     [rows]="rows"
     [todayValue]="todayValue"
     [selectedValues]="selectedValues"
     [selectMode]="'single'"
     [activeCell]="activeCell"
-    (select)="handleSelect()"
+    (cellSelected)="handleSelect()"
   ></table>`
 })
 class StandardCalendarBodyComponent {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-body.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-body.component.ts
@@ -1,20 +1,15 @@
-/* eslint-disable @angular-eslint/component-class-suffix, @angular-eslint/no-host-metadata-property */
-/**
- * calendar-body.component
- */
-
 import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
+  HostBinding,
   Input,
   NgZone,
-  OnInit,
   Output
 } from '@angular/core';
-import { SelectMode } from './date-time.class';
 import { take } from 'rxjs/operators';
+import { SelectMode } from './date-time.class';
 
 export class CalendarCell {
   constructor(
@@ -28,17 +23,16 @@ export class CalendarCell {
 }
 
 @Component({
-  selector: '[owl-date-time-calendar-body]',
+  /* eslint-disable-next-line @angular-eslint/component-selector */
+  selector: '[ofe-owl-date-time-calendar-body]',
   exportAs: 'owlDateTimeCalendarBody',
   templateUrl: './calendar-body.component.html',
   styleUrls: ['./calendar-body.component.scss'],
-  host: {
-    '[class.owl-dt-calendar-body]': 'owlDTCalendarBodyClass'
-  },
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class OwlCalendarBodyComponent implements OnInit {
+export class OwlCalendarBodyComponent {
+  @HostBinding('class.owl-dt-calendar-body') owlDTCalendarBodyClass = true;
+
   /**
    * The cell number of the active cell in the table.
    */
@@ -85,11 +79,7 @@ export class OwlCalendarBodyComponent implements OnInit {
    * Emit when a calendar cell is selected
    * */
   @Output()
-  public readonly select = new EventEmitter<CalendarCell>();
-
-  get owlDTCalendarBodyClass(): boolean {
-    return true;
-  }
+  public readonly cellSelected = new EventEmitter<CalendarCell>();
 
   get isInSingleMode(): boolean {
     return this.selectMode === 'single';
@@ -105,10 +95,8 @@ export class OwlCalendarBodyComponent implements OnInit {
 
   constructor(private elmRef: ElementRef, private ngZone: NgZone) {}
 
-  public ngOnInit() {}
-
   public selectCell(cell: CalendarCell): void {
-    this.select.emit(cell);
+    this.cellSelected.emit(cell);
   }
 
   public isActiveCell(rowIndex: number, colIndex: number): boolean {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-month-view.component.html
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-month-view.component.html
@@ -22,7 +22,7 @@
     </tr>
   </thead>
   <tbody
-    owl-date-time-calendar-body
+    ofe-owl-date-time-calendar-body
     role="grid"
     [rows]="days"
     [todayValue]="todayDate"
@@ -30,6 +30,6 @@
     [selectMode]="selectMode"
     [activeCell]="activeCell"
     (keydown)="handleCalendarKeydown($event)"
-    (select)="selectCalendarCell($event)"
+    (cellSelected)="selectCalendarCell($event)"
   ></tbody>
 </table>

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-month-view.component.spec.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-month-view.component.spec.ts
@@ -293,10 +293,10 @@ describe('OwlMonthViewComponent', () => {
 
 @Component({
   template: `
-    <owl-date-time-month-view
+    <ofe-owl-date-time-month-view
       [(selected)]="selected"
       [(pickerMoment)]="pickerMoment"
-    ></owl-date-time-month-view>
+    ></ofe-owl-date-time-month-view>
   `
 })
 class StandardMonthViewComponent {
@@ -306,10 +306,10 @@ class StandardMonthViewComponent {
 
 @Component({
   template: `
-    <owl-date-time-month-view
+    <ofe-owl-date-time-month-view
       [(pickerMoment)]="pickerMoment"
       [dateFilter]="dateFilter"
-    ></owl-date-time-month-view>
+    ></ofe-owl-date-time-month-view>
   `
 })
 class MonthViewWithDateFilterComponent {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-month-view.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-month-view.component.ts
@@ -1,14 +1,10 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * calendar-month-view.component
- */
-
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  HostBinding,
   Inject,
   Input,
   OnDestroy,
@@ -45,18 +41,18 @@ const DAYS_PER_WEEK = 7;
 const WEEKS_PER_VIEW = 6;
 
 @Component({
-  selector: 'owl-date-time-month-view',
+  selector: 'ofe-owl-date-time-month-view',
   exportAs: 'owlYearView',
   templateUrl: './calendar-month-view.component.html',
   styleUrls: ['./calendar-month-view.component.scss'],
-  host: {
-    '[class.owl-dt-calendar-view]': 'owlDTCalendarView'
-  },
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OwlMonthViewComponent<T>
   implements OnInit, AfterContentInit, OnDestroy {
+  @HostBinding('class.owl-dt-calendar-view') get owlDTCalendarView() {
+    return true;
+  }
+
   /**
    * Whether to hide dates in other months at the start or end of the current month.
    * */
@@ -279,10 +275,6 @@ export class OwlMonthViewComponent<T>
   /** The body of calendar table */
   @ViewChild(OwlCalendarBodyComponent, { static: true })
   calendarBodyElm: OwlCalendarBodyComponent;
-
-  get owlDTCalendarView(): boolean {
-    return true;
-  }
 
   constructor(
     private cdRef: ChangeDetectorRef,

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-multi-year-view.component.html
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-multi-year-view.component.html
@@ -35,7 +35,7 @@
     </tr>
   </thead>
   <tbody
-    owl-date-time-calendar-body
+    ofe-owl-date-time-calendar-body
     role="grid"
     [rows]="years"
     [numCols]="3"
@@ -45,7 +45,7 @@
     [selectedValues]="selectedYears"
     [selectMode]="selectMode"
     (keydown)="handleCalendarKeydown($event)"
-    (select)="selectCalendarCell($event)"
+    (cellSelected)="selectCalendarCell($event)"
   ></tbody>
 </table>
 <button

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-multi-year-view.component.spec.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-multi-year-view.component.spec.ts
@@ -299,11 +299,11 @@ describe('OwlMultiYearViewComponent', () => {
 
 @Component({
   template: `
-    <owl-date-time-multi-year-view
+    <ofe-owl-date-time-multi-year-view
       [selected]="selected"
       [(pickerMoment)]="pickerMoment"
-      (change)="handleChange($event)"
-    ></owl-date-time-multi-year-view>
+      (monthChange)="handleChange($event)"
+    ></ofe-owl-date-time-multi-year-view>
   `
 })
 class StandardMultiYearViewComponent {
@@ -317,10 +317,10 @@ class StandardMultiYearViewComponent {
 
 @Component({
   template: `
-    <owl-date-time-multi-year-view
+    <ofe-owl-date-time-multi-year-view
       [(pickerMoment)]="pickerMoment"
       [dateFilter]="dateFilter"
-    ></owl-date-time-multi-year-view>
+    ></ofe-owl-date-time-multi-year-view>
   `
 })
 class MultiYearViewWithDateFilterComponent {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-multi-year-view.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-multi-year-view.component.ts
@@ -1,16 +1,11 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * calendar-multi-year-view.component
- */
-
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  HostBinding,
   Input,
-  OnInit,
   Optional,
   Output,
   ViewChild
@@ -38,17 +33,21 @@ export const YEARS_PER_ROW = 3;
 export const YEAR_ROWS = 7;
 
 @Component({
-  selector: 'owl-date-time-multi-year-view',
+  selector: 'ofe-owl-date-time-multi-year-view',
   templateUrl: './calendar-multi-year-view.component.html',
   styleUrls: ['./calendar-multi-year-view.component.scss'],
-  host: {
-    '[class.owl-dt-calendar-view]': 'owlDTCalendarView',
-    '[class.owl-dt-calendar-multi-year-view]': 'owlDTCalendarMultiYearView'
-  },
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class OwlMultiYearViewComponent<T> implements OnInit, AfterContentInit {
+export class OwlMultiYearViewComponent<T> implements AfterContentInit {
+  @HostBinding('class.owl-dt-calendar-view') get owlDTCalendarView() {
+    return true;
+  }
+
+  @HostBinding('class.owl-dt-calendar-multi-year-view')
+  get owlDTCalendarMultiYearView() {
+    return true;
+  }
+
   /**
    * The select mode of the picker;
    * */
@@ -84,6 +83,7 @@ export class OwlMultiYearViewComponent<T> implements OnInit, AfterContentInit {
   }
 
   private _selecteds: T[] = [];
+
   @Input()
   get selecteds(): T[] {
     return this._selecteds;
@@ -220,7 +220,7 @@ export class OwlMultiYearViewComponent<T> implements OnInit, AfterContentInit {
   /**
    * Callback to invoke when a new month is selected
    * */
-  @Output() readonly change = new EventEmitter<T>();
+  @Output() readonly monthChange = new EventEmitter<T>();
 
   /**
    * Emits the selected year. This doesn't imply a change on the selected date
@@ -239,21 +239,11 @@ export class OwlMultiYearViewComponent<T> implements OnInit, AfterContentInit {
   @ViewChild(OwlCalendarBodyComponent, { static: true })
   calendarBodyElm: OwlCalendarBodyComponent;
 
-  get owlDTCalendarView(): boolean {
-    return true;
-  }
-
-  get owlDTCalendarMultiYearView(): boolean {
-    return true;
-  }
-
   constructor(
     private cdRef: ChangeDetectorRef,
     private pickerIntl: OwlDateTimeIntl,
     @Optional() private dateTimeAdapter: DateTimeAdapter<T>
   ) {}
-
-  public ngOnInit() {}
 
   public ngAfterContentInit(): void {
     this._todayYear = this.dateTimeAdapter.getYear(this.dateTimeAdapter.now());
@@ -287,7 +277,7 @@ export class OwlMultiYearViewComponent<T> implements OnInit, AfterContentInit {
       this.dateTimeAdapter.getSeconds(this.pickerMoment)
     );
 
-    this.change.emit(selected);
+    this.monthChange.emit(selected);
   }
 
   /**

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-year-view.component.html
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-year-view.component.html
@@ -9,7 +9,7 @@
     </tr>
   </thead>
   <tbody
-    owl-date-time-calendar-body
+    ofe-owl-date-time-calendar-body
     role="grid"
     [rows]="months"
     [numCols]="3"
@@ -19,6 +19,6 @@
     [selectedValues]="selectedMonths"
     [selectMode]="selectMode"
     (keydown)="handleCalendarKeydown($event)"
-    (select)="selectCalendarCell($event)"
+    (cellSelected)="selectCalendarCell($event)"
   ></tbody>
 </table>

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-year-view.component.spec.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-year-view.component.spec.ts
@@ -1,7 +1,3 @@
-/**
- * calendar-year-view.component.spec
- */
-
 import {
   async,
   ComponentFixture,
@@ -315,11 +311,11 @@ describe('OwlYearViewComponent', () => {
 
 @Component({
   template: `
-    <owl-date-time-year-view
+    <ofe-owl-date-time-year-view
       [selected]="selected"
       [(pickerMoment)]="pickerMoment"
-      (change)="handleChange($event)"
-    ></owl-date-time-year-view>
+      (monthChange)="handleChange($event)"
+    ></ofe-owl-date-time-year-view>
   `
 })
 class StandardYearViewComponent {
@@ -333,10 +329,10 @@ class StandardYearViewComponent {
 
 @Component({
   template: `
-    <owl-date-time-year-view
+    <ofe-owl-date-time-year-view
       [(pickerMoment)]="pickerMoment"
       [dateFilter]="dateFilter"
-    ></owl-date-time-year-view>
+    ></ofe-owl-date-time-year-view>
   `
 })
 class YearViewWithDateFilterComponent {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-year-view.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar-year-view.component.ts
@@ -1,14 +1,10 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * calendar-year-view.component
- */
-
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  HostBinding,
   Inject,
   Input,
   OnDestroy,
@@ -44,18 +40,18 @@ const MONTHS_PER_YEAR = 12;
 const MONTHS_PER_ROW = 3;
 
 @Component({
-  selector: 'owl-date-time-year-view',
+  selector: 'ofe-owl-date-time-year-view',
   exportAs: 'owlMonthView',
   templateUrl: './calendar-year-view.component.html',
   styleUrls: ['./calendar-year-view.component.scss'],
-  host: {
-    '[class.owl-dt-calendar-view]': 'owlDTCalendarView'
-  },
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OwlYearViewComponent<T>
   implements OnInit, AfterContentInit, OnDestroy {
+  @HostBinding('class.owl-dt-calendar-view') get owlDTCalendarView() {
+    return true;
+  }
+
   /**
    * The select mode of the picker;
    * */
@@ -205,7 +201,7 @@ export class OwlYearViewComponent<T>
    * Callback to invoke when a new month is selected
    * */
   @Output()
-  readonly change = new EventEmitter<T>();
+  readonly monthChange = new EventEmitter<T>();
 
   /**
    * Emits the selected year. This doesn't imply a change on the selected date
@@ -224,10 +220,6 @@ export class OwlYearViewComponent<T>
   /** The body of calendar table */
   @ViewChild(OwlCalendarBodyComponent, { static: true })
   calendarBodyElm: OwlCalendarBodyComponent;
-
-  get owlDTCalendarView(): boolean {
-    return true;
-  }
 
   constructor(
     private cdRef: ChangeDetectorRef,
@@ -286,7 +278,7 @@ export class OwlYearViewComponent<T>
       this.dateTimeAdapter.getSeconds(this.pickerMoment)
     );
 
-    this.change.emit(result);
+    this.monthChange.emit(result);
   }
 
   /**

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar.component.html
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar.component.html
@@ -120,7 +120,7 @@
   [ngSwitch]="currentView"
   tabindex="-1"
 >
-  <owl-date-time-month-view
+  <ofe-owl-date-time-month-view
     *ngSwitchCase="'month'"
     [pickerMoment]="pickerMoment"
     [firstDayOfWeek]="firstDayOfWeek"
@@ -134,9 +134,9 @@
     (pickerMomentChange)="handlePickerMomentChange($event)"
     (selectedChange)="dateSelected($event)"
     (userSelection)="userSelected()"
-  ></owl-date-time-month-view>
+  ></ofe-owl-date-time-month-view>
 
-  <owl-date-time-year-view
+  <ofe-owl-date-time-year-view
     *ngSwitchCase="'year'"
     [pickerMoment]="pickerMoment"
     [selected]="selected"
@@ -148,10 +148,10 @@
     (keyboardEnter)="focusActiveCell()"
     (pickerMomentChange)="handlePickerMomentChange($event)"
     (monthSelected)="selectMonthInYearView($event)"
-    (change)="goToDateInView($event, 'month')"
-  ></owl-date-time-year-view>
+    (monthChange)="goToDateInView($event, 'month')"
+  ></ofe-owl-date-time-year-view>
 
-  <owl-date-time-multi-year-view
+  <ofe-owl-date-time-multi-year-view
     *ngSwitchCase="'multi-years'"
     [pickerMoment]="pickerMoment"
     [selected]="selected"
@@ -163,6 +163,6 @@
     (keyboardEnter)="focusActiveCell()"
     (pickerMomentChange)="handlePickerMomentChange($event)"
     (yearSelected)="selectYearInMultiYearView($event)"
-    (change)="goToDateInView($event, 'year')"
-  ></owl-date-time-multi-year-view>
+    (monthChange)="goToDateInView($event, 'year')"
+  ></ofe-owl-date-time-multi-year-view>
 </div>

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar.component.spec.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar.component.spec.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @angular-eslint/component-class-suffix */
-/**
- * calendar.component.spec
- */
-
 import {
   waitForAsync,
   ComponentFixture,
@@ -453,13 +448,13 @@ describe('OwlCalendarComponent', () => {
 
 @Component({
   template: `
-    <owl-date-time-calendar
+    <ofe-owl-date-time-calendar
       [(selected)]="selected"
       [selectMode]="selectMode"
       [pickerMoment]="pickerMoment"
       (monthSelected)="selectedMonth = $event"
       (yearSelected)="selectedYear = $event"
-    ></owl-date-time-calendar>
+    ></ofe-owl-date-time-calendar>
   `
 })
 class StandardCalendar {
@@ -472,12 +467,12 @@ class StandardCalendar {
 
 @Component({
   template: `
-    <owl-date-time-calendar
+    <ofe-owl-date-time-calendar
       [selectMode]="selectMode"
       [pickerMoment]="pickerMoment"
       [minDate]="minDate"
       [maxDate]="maxDate"
-    ></owl-date-time-calendar>
+    ></ofe-owl-date-time-calendar>
   `
 })
 class CalendarWithMinMax {
@@ -490,12 +485,12 @@ class CalendarWithMinMax {
 
 @Component({
   template: `
-    <owl-date-time-calendar
+    <ofe-owl-date-time-calendar
       [(selected)]="selected"
       [selectMode]="selectMode"
       [pickerMoment]="pickerMoment"
       [dateFilter]="dateFilter"
-    ></owl-date-time-calendar>
+    ></ofe-owl-date-time-calendar>
   `
 })
 class CalendarWithDateFilter {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/calendar.component.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * calendar.component
- */
-
 import {
   AfterContentInit,
   AfterViewChecked,
@@ -11,14 +6,17 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  HostBinding,
   Inject,
   Input,
   NgZone,
   OnDestroy,
-  OnInit,
   Optional,
   Output
 } from '@angular/core';
+import { take } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
+
 import { OwlDateTimeIntl } from './date-time-picker-intl.service';
 import { DateTimeAdapter } from './adapter/date-time-adapter.class';
 import {
@@ -26,22 +24,21 @@ import {
   OwlDateTimeFormats
 } from './adapter/date-time-format.class';
 import { SelectMode } from './date-time.class';
-import { take } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
 
 @Component({
-  selector: 'owl-date-time-calendar',
+  selector: 'ofe-owl-date-time-calendar',
   exportAs: 'owlDateTimeCalendar',
   templateUrl: './calendar.component.html',
   styleUrls: ['./calendar.component.scss'],
-  host: {
-    '[class.owl-dt-calendar]': 'owlDTCalendarClass'
-  },
-  preserveWhitespaces: false,
+
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OwlCalendarComponent<T>
-  implements OnInit, AfterContentInit, AfterViewChecked, OnDestroy {
+  implements AfterContentInit, AfterViewChecked, OnDestroy {
+  @HostBinding('class.owl-dt-calendar') get owlDTCalendarClass() {
+    return true;
+  }
+
   @Input()
   get minDate(): T | null {
     return this._minDate;
@@ -169,13 +166,6 @@ export class OwlCalendarComponent<T>
     return this._currentView === 'month';
   }
 
-  /**
-   * Bind class 'owl-dt-calendar' to host
-   * */
-  get owlDTCalendarClass(): boolean {
-    return true;
-  }
-
   constructor(
     private elmRef: ElementRef,
     private pickerIntl: OwlDateTimeIntl,
@@ -278,8 +268,6 @@ export class OwlCalendarComponent<T>
       (!this.maxDate || this.dateTimeAdapter.compare(date, this.maxDate) <= 0)
     );
   };
-
-  public ngOnInit() {}
 
   public ngAfterContentInit(): void {
     this._currentView = this.startView;

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-inline.component.html
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-inline.component.html
@@ -1,1 +1,1 @@
-<owl-date-time-container></owl-date-time-container>
+<ofe-owl-date-time-container></ofe-owl-date-time-container>

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-inline.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-inline.component.ts
@@ -1,14 +1,10 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * date-time-inline.component
- */
-
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
   forwardRef,
+  HostBinding,
   Inject,
   Input,
   OnInit,
@@ -38,19 +34,19 @@ export const OWL_DATETIME_VALUE_ACCESSOR: any = {
 };
 
 @Component({
-  selector: 'owl-date-time-inline',
+  selector: 'ofe-owl-date-time-inline',
   templateUrl: './date-time-inline.component.html',
   styleUrls: ['./date-time-inline.component.scss'],
-  host: {
-    '[class.owl-dt-inline]': 'owlDTInlineClass'
-  },
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   providers: [OWL_DATETIME_VALUE_ACCESSOR]
 })
 export class OwlDateTimeInlineComponent<T>
   extends OwlDateTime<T>
   implements OnInit, ControlValueAccessor {
+  @HostBinding('class.owl-dt-inline') get owlDTInlineClass() {
+    return true;
+  }
+
   @ViewChild(OwlDateTimeContainerComponent, { static: true })
   container: OwlDateTimeContainerComponent<T>;
 
@@ -125,8 +121,9 @@ export class OwlDateTimeInlineComponent<T>
   }
 
   private _dateTimeFilter: (date: T | null) => boolean;
-  @Input('owlDateTimeFilter')
-  get dateTimeFilter() {
+
+  @Input()
+  get owlDateTimeFilter() {
     return this._dateTimeFilter;
   }
 
@@ -141,7 +138,7 @@ export class OwlDateTimeInlineComponent<T>
     return this._min || null;
   }
 
-  @Input('min')
+  @Input() min: Date;
   set minDateTime(value: T | null) {
     this._min = this.getValidDate(this.dateTimeAdapter.deserialize(value));
     this.changeDetector.markForCheck();
@@ -154,7 +151,7 @@ export class OwlDateTimeInlineComponent<T>
     return this._max || null;
   }
 
-  @Input('max')
+  @Input() max: Date;
   set maxDateTime(value: T | null) {
     this._max = this.getValidDate(this.dateTimeAdapter.deserialize(value));
     this.changeDetector.markForCheck();
@@ -246,10 +243,6 @@ export class OwlDateTimeInlineComponent<T>
       this._selectMode === 'rangeFrom' ||
       this._selectMode === 'rangeTo'
     );
-  }
-
-  get owlDTInlineClass(): boolean {
-    return true;
   }
 
   private onModelChange: Function = () => {};

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker-container.component.html
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker-container.component.html
@@ -3,7 +3,7 @@
   [@fadeInPicker]="picker.pickerMode === 'inline' ? '' : 'enter'"
   class="owl-dt-container-inner"
 >
-  <owl-date-time-calendar
+  <ofe-owl-date-time-calendar
     *ngIf="pickerType === 'both' || pickerType === 'calendar'"
     class="owl-dt-container-row"
     [firstDayOfWeek]="picker.firstDayOfWeek"
@@ -19,9 +19,8 @@
     (yearSelected)="picker.selectYear($event)"
     (monthSelected)="picker.selectMonth($event)"
     (selectedChange)="dateSelected($event)"
-  ></owl-date-time-calendar>
-
-  <owl-date-time-timer
+  ></ofe-owl-date-time-calendar>
+  <ofe-owl-date-time-timer
     *ngIf="pickerType === 'both' || pickerType === 'timer'"
     class="owl-dt-container-row"
     [pickerMoment]="pickerMoment"
@@ -33,8 +32,7 @@
     [stepMinute]="picker.stepMinute"
     [stepSecond]="picker.stepSecond"
     (selectedChange)="timeSelected($event)"
-  ></owl-date-time-timer>
-
+  ></ofe-owl-date-time-timer>
   <div
     *ngIf="picker.isInRangeMode"
     role="radiogroup"

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker-container.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker-container.component.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * date-time-picker-container.component
- */
-
 import {
   AfterContentInit,
   AfterViewInit,
@@ -10,18 +5,12 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  OnInit,
+  HostBinding,
+  HostListener,
   Optional,
   ViewChild
 } from '@angular/core';
 import { AnimationEvent } from '@angular/animations';
-import { OwlDateTimeIntl } from './date-time-picker-intl.service';
-import { OwlCalendarComponent } from './calendar.component';
-import { OwlTimerComponent } from './timer.component';
-import { DateTimeAdapter } from './adapter/date-time-adapter.class';
-import { OwlDateTime, PickerType } from './date-time.class';
-import { Observable, Subject } from 'rxjs';
-import { owlDateTimePickerAnimations } from './date-time-picker.animations';
 import {
   DOWN_ARROW,
   LEFT_ARROW,
@@ -29,35 +18,72 @@ import {
   SPACE,
   UP_ARROW
 } from '@angular/cdk/keycodes';
+import { Observable, Subject } from 'rxjs';
+
+import { DateTimeAdapter } from './adapter/date-time-adapter.class';
+import { OwlCalendarComponent } from './calendar.component';
+import { OwlDateTime, PickerType } from './date-time.class';
+import { OwlDateTimeIntl } from './date-time-picker-intl.service';
+import { owlDateTimePickerAnimations } from './date-time-picker.animations';
+import { OwlTimerComponent } from './timer.component';
 
 @Component({
   exportAs: 'owlDateTimeContainer',
-  selector: 'owl-date-time-container',
+  selector: 'ofe-owl-date-time-container',
   templateUrl: './date-time-picker-container.component.html',
   styleUrls: ['./date-time-picker-container.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   animations: [
     owlDateTimePickerAnimations.transformPicker,
     owlDateTimePickerAnimations.fadeInPicker
-  ],
-  host: {
-    '(@transformPicker.done)': 'handleContainerAnimationDone($event)',
-    '[class.owl-dt-container]': 'owlDTContainerClass',
-    '[class.owl-dt-popup-container]': 'owlDTPopupContainerClass',
-    '[class.owl-dt-dialog-container]': 'owlDTDialogContainerClass',
-    '[class.owl-dt-inline-container]': 'owlDTInlineContainerClass',
-    '[class.owl-dt-container-disabled]': 'owlDTContainerDisabledClass',
-    '[attr.id]': 'owlDTContainerId',
-    '[@transformPicker]': 'owlDTContainerAnimation'
-  }
+  ]
 })
 export class OwlDateTimeContainerComponent<T>
-  implements OnInit, AfterContentInit, AfterViewInit {
+  implements AfterContentInit, AfterViewInit {
   @ViewChild(OwlCalendarComponent, { static: false })
   calendar: OwlCalendarComponent<T>;
+
   @ViewChild(OwlTimerComponent, { static: false })
   timer: OwlTimerComponent<T>;
+
+  @HostBinding('class.owl-dt-container') get owlDTContainerClass() {
+    return true;
+  }
+
+  @HostBinding('class.owl-dt-popup-container') get owlDTPopupContainerClass() {
+    return this.picker.pickerMode === 'popup';
+  }
+
+  @HostBinding('class.owl-dt-dialog-container')
+  get owlDTDialogContainerClass() {
+    return this.picker.pickerMode === 'dialog';
+  }
+
+  @HostBinding('class.owl-dt-inline-container')
+  get owlDTInlineContainerClass() {
+    return this.picker.pickerMode === 'inline';
+  }
+
+  @HostBinding('class.owl-dt-container-disabled')
+  get owlDTContainerDisabledClass() {
+    return this.picker.disabled;
+  }
+
+  @HostBinding('attr.id') get owlDTContainerId() {
+    return this.picker.id;
+  }
+
+  @HostBinding('@transformPicker') get owlDTContainerAnimation() {
+    return this.picker.pickerMode === 'inline' ? '' : 'enter';
+  }
+
+  @HostListener('@transformPicker.done', ['$event'])
+  public handleContainerAnimationDone(event: AnimationEvent): void {
+    const toState = event.toState;
+    if (toState === 'enter') {
+      this.pickerOpened$.next();
+    }
+  }
 
   public picker: OwlDateTime<T>;
   public activeSelectedIndex = 0; // The current active SelectedIndex in range select mode (0: 'from', 1: 'to')
@@ -170,34 +196,6 @@ export class OwlDateTimeContainerComponent<T>
     return this.elmRef.nativeElement;
   }
 
-  get owlDTContainerClass(): boolean {
-    return true;
-  }
-
-  get owlDTPopupContainerClass(): boolean {
-    return this.picker.pickerMode === 'popup';
-  }
-
-  get owlDTDialogContainerClass(): boolean {
-    return this.picker.pickerMode === 'dialog';
-  }
-
-  get owlDTInlineContainerClass(): boolean {
-    return this.picker.pickerMode === 'inline';
-  }
-
-  get owlDTContainerDisabledClass(): boolean {
-    return this.picker.disabled;
-  }
-
-  get owlDTContainerId(): string {
-    return this.picker.id;
-  }
-
-  get owlDTContainerAnimation(): any {
-    return this.picker.pickerMode === 'inline' ? '' : 'enter';
-  }
-
   constructor(
     private cdRef: ChangeDetectorRef,
     private elmRef: ElementRef,
@@ -205,21 +203,12 @@ export class OwlDateTimeContainerComponent<T>
     @Optional() private dateTimeAdapter: DateTimeAdapter<T>
   ) {}
 
-  public ngOnInit() {}
-
   public ngAfterContentInit(): void {
     this.initPicker();
   }
 
   public ngAfterViewInit(): void {
     this.focusPicker();
-  }
-
-  public handleContainerAnimationDone(event: AnimationEvent): void {
-    const toState = event.toState;
-    if (toState === 'enter') {
-      this.pickerOpened$.next();
-    }
   }
 
   public dateSelected(date: T): void {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker-trigger.directive.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker-trigger.directive.ts
@@ -1,31 +1,36 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * date-time-picker-trigger.directive
- */
-
 import {
   AfterContentInit,
   ChangeDetectorRef,
   Directive,
+  HostBinding,
+  HostListener,
   Input,
   OnChanges,
   OnDestroy,
-  OnInit,
   SimpleChanges
 } from '@angular/core';
 import { OwlDateTimeComponent } from './date-time-picker.component';
 import { merge, of as observableOf, Subscription } from 'rxjs';
 
 @Directive({
-  selector: '[owlDateTimeTrigger]',
-  host: {
-    '(click)': 'handleClickOnHost($event)',
-    '[class.owl-dt-trigger-disabled]': 'owlDTTriggerDisabledClass'
-  }
+  selector: '[ofeOwlDateTimeTrigger]'
 })
 export class OwlDateTimeTriggerDirective<T>
-  implements OnInit, OnChanges, AfterContentInit, OnDestroy {
-  @Input('owlDateTimeTrigger') dtPicker: OwlDateTimeComponent<T>;
+  implements OnChanges, AfterContentInit, OnDestroy {
+  @Input('ofeOwlDateTimeTrigger') dtPicker: OwlDateTimeComponent<T>;
+
+  @HostBinding('class.owl-dt-trigger-disabled')
+  get owlDTTriggerDisabledClass(): boolean {
+    return this.disabled;
+  }
+
+  @HostListener('click', ['$event'])
+  handleClickOnHost($event: Event): void {
+    if (this.dtPicker) {
+      this.dtPicker.open();
+      $event.stopPropagation();
+    }
+  }
 
   private _disabled: boolean;
   @Input()
@@ -39,15 +44,9 @@ export class OwlDateTimeTriggerDirective<T>
     this._disabled = value;
   }
 
-  get owlDTTriggerDisabledClass(): boolean {
-    return this.disabled;
-  }
-
   private stateChanges = Subscription.EMPTY;
 
   constructor(protected changeDetector: ChangeDetectorRef) {}
-
-  public ngOnInit(): void {}
 
   public ngOnChanges(changes: SimpleChanges) {
     if (changes.datepicker) {
@@ -61,13 +60,6 @@ export class OwlDateTimeTriggerDirective<T>
 
   public ngOnDestroy(): void {
     this.stateChanges.unsubscribe();
-  }
-
-  public handleClickOnHost(event: Event): void {
-    if (this.dtPicker) {
-      this.dtPicker.open();
-      event.stopPropagation();
-    }
   }
 
   private watchStateChanges(): void {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker.component.spec.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker.component.spec.ts
@@ -1,9 +1,3 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property, @angular-eslint/component-class-suffix */
-/**
- * date-time-picker.component.spec
- */
-
-import { OwlDateTimeComponent } from './date-time-picker.component';
 import {
   ComponentFixture,
   fakeAsync,
@@ -18,12 +12,16 @@ import {
   ValueProvider,
   ViewChild
 } from '@angular/core';
-import { OwlDateTimeInputDirective } from './date-time-picker-input.directive';
+import { By } from '@angular/platform-browser';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
-import { OwlDateTimeModule } from './date-time.module';
+import { ENTER, ESCAPE, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
+
+import { OwlDateTimeComponent } from './date-time-picker.component';
+import { OwlDateTimeInputDirective } from './date-time-picker-input.directive';
+import { OwlDateTimeModule } from './date-time.module';
 import { OwlNativeDateTimeModule } from './adapter/native-date-time.module';
 import {
   dispatchKeyboardEvent,
@@ -32,8 +30,7 @@ import {
   dispatchEvent,
   dispatchFakeEvent
 } from '../../test-helpers';
-import { ENTER, ESCAPE, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
-import { By } from '@angular/platform-browser';
+
 import { OwlDateTimeContainerComponent } from './date-time-picker-container.component';
 import { OwlDateTimeTriggerDirective } from './date-time-picker-trigger.directive';
 import { OWL_DATE_TIME_FORMATS } from './adapter/date-time-format.class';
@@ -132,14 +129,14 @@ describe('OwlDateTimeComponent', () => {
         fixture.detectChanges();
 
         expect(
-          document.querySelector('.owl-dt-dialog owl-dialog-container')
+          document.querySelector('.owl-dt-dialog ofe-owl-dialog-container')
         ).toBeNull();
 
         testComponent.dateTimePicker.open();
         fixture.detectChanges();
 
         expect(
-          document.querySelector('.owl-dt-dialog owl-dialog-container')
+          document.querySelector('.owl-dt-dialog ofe-owl-dialog-container')
         ).not.toBeNull();
       });
 
@@ -232,13 +229,15 @@ describe('OwlDateTimeComponent', () => {
         fixture.detectChanges();
         flush();
 
-        expect(document.querySelector('owl-dialog-container')).not.toBeNull();
+        expect(
+          document.querySelector('ofe-owl-dialog-container')
+        ).not.toBeNull();
 
         testComponent.dateTimePicker.close();
         fixture.detectChanges();
         flush();
 
-        expect(document.querySelector('owl-dialog-container')).toBeNull();
+        expect(document.querySelector('ofe-owl-dialog-container')).toBeNull();
       }));
 
       it('should close popup panel when cancel button clicked', fakeAsync(() => {
@@ -382,7 +381,7 @@ describe('OwlDateTimeComponent', () => {
         );
       });
 
-      it('input should aria-owns owl-date-time-container after opened in popup mode', fakeAsync(() => {
+      it('input should aria-owns ofe-owl-date-time-container after opened in popup mode', fakeAsync(() => {
         const inputEl = fixture.debugElement.query(By.css('input'))
           .nativeElement;
         expect(inputEl.getAttribute('aria-owns')).toBeNull();
@@ -398,11 +397,11 @@ describe('OwlDateTimeComponent', () => {
         const ownedElement = document.getElementById(ownedElementId);
         expect(ownedElement).not.toBeNull();
         expect((ownedElement as Element).tagName.toLowerCase()).toBe(
-          'owl-date-time-container'
+          'ofe-owl-date-time-container'
         );
       }));
 
-      it('input should aria-owns owl-date-time-container after opened in dialog mode', fakeAsync(() => {
+      it('input should aria-owns ofe-owl-date-time-container after opened in dialog mode', fakeAsync(() => {
         testComponent.pickerMode = 'dialog';
         fixture.detectChanges();
 
@@ -421,7 +420,7 @@ describe('OwlDateTimeComponent', () => {
         const ownedElement = document.getElementById(ownedElementId);
         expect(ownedElement).not.toBeNull();
         expect((ownedElement as Element).tagName.toLowerCase()).toBe(
-          'owl-date-time-container'
+          'ofe-owl-date-time-container'
         );
       }));
 
@@ -1528,7 +1527,7 @@ describe('OwlDateTimeComponent', () => {
       });
     });
 
-    describe('DateTimePicker with owlDateTimeTrigger', () => {
+    describe('DateTimePicker with dtPicker', () => {
       let fixture: ComponentFixture<DateTimePickerWithTrigger>;
       let testComponent: DateTimePickerWithTrigger;
 
@@ -1548,14 +1547,16 @@ describe('OwlDateTimeComponent', () => {
       }));
 
       it('should open the picker when trigger clicked', () => {
-        expect(document.querySelector('owl-date-time-container')).toBeNull();
+        expect(
+          document.querySelector('ofe-owl-date-time-container')
+        ).toBeNull();
 
         const toggle = fixture.debugElement.query(By.css('button'));
         dispatchMouseEvent(toggle.nativeElement, 'click');
         fixture.detectChanges();
 
         expect(
-          document.querySelector('owl-date-time-container')
+          document.querySelector('ofe-owl-date-time-container')
         ).not.toBeNull();
       });
 
@@ -1566,12 +1567,16 @@ describe('OwlDateTimeComponent', () => {
           .nativeElement;
 
         expect(toggle.classList).toContain('owl-dt-trigger-disabled');
-        expect(document.querySelector('owl-date-time-container')).toBeNull();
+        expect(
+          document.querySelector('ofe-owl-date-time-container')
+        ).toBeNull();
 
         dispatchMouseEvent(toggle, 'click');
         fixture.detectChanges();
 
-        expect(document.querySelector('owl-date-time-container')).toBeNull();
+        expect(
+          document.querySelector('ofe-owl-date-time-container')
+        ).toBeNull();
       });
 
       it('should not open the picker when trigger clicked if input is disabled', () => {
@@ -1583,12 +1588,16 @@ describe('OwlDateTimeComponent', () => {
           .nativeElement;
 
         expect(toggle.classList).toContain('owl-dt-trigger-disabled');
-        expect(document.querySelector('owl-date-time-container')).toBeNull();
+        expect(
+          document.querySelector('ofe-owl-date-time-container')
+        ).toBeNull();
 
         dispatchMouseEvent(toggle, 'click');
         fixture.detectChanges();
 
-        expect(document.querySelector('owl-date-time-container')).toBeNull();
+        expect(
+          document.querySelector('ofe-owl-date-time-container')
+        ).toBeNull();
       });
     });
 
@@ -1789,7 +1798,7 @@ describe('OwlDateTimeComponent', () => {
         fixture.detectChanges();
 
         expect(
-          document.querySelector('owl-date-time-container')
+          document.querySelector('ofe-owl-date-time-container')
         ).not.toBeNull();
 
         const cellOne = document.querySelector(
@@ -1872,7 +1881,7 @@ describe('OwlDateTimeComponent', () => {
         fixture.detectChanges();
 
         expect(
-          document.querySelector('owl-date-time-container')
+          document.querySelector('ofe-owl-date-time-container')
         ).not.toBeNull();
 
         const cells = document.querySelectorAll('.owl-dt-calendar-cell');
@@ -1900,7 +1909,7 @@ describe('OwlDateTimeComponent', () => {
         fixture.detectChanges();
 
         expect(
-          document.querySelector('owl-date-time-container')
+          document.querySelector('ofe-owl-date-time-container')
         ).not.toBeNull();
 
         const increaseHourBtn = document.querySelector(
@@ -1944,7 +1953,7 @@ describe('OwlDateTimeComponent', () => {
         fixture.detectChanges();
 
         expect(
-          document.querySelector('owl-date-time-container')
+          document.querySelector('ofe-owl-date-time-container')
         ).not.toBeNull();
 
         const increaseMinuteBtn = document.querySelector(
@@ -1988,7 +1997,7 @@ describe('OwlDateTimeComponent', () => {
         fixture.detectChanges();
 
         expect(
-          document.querySelector('owl-date-time-container')
+          document.querySelector('ofe-owl-date-time-container')
         ).not.toBeNull();
 
         const increaseSecondBtn = document.querySelector(
@@ -2127,13 +2136,13 @@ describe('OwlDateTimeComponent', () => {
 @Component({
   template: `
     <input [owlDateTime]="dt" [value]="date" />
-    <owl-date-time
+    <ofe-owl-date-time
       [opened]="opened"
       [disabled]="disabled"
       [pickerType]="pickerType"
       [pickerMode]="pickerMode"
       #dt
-    ></owl-date-time>
+    ></ofe-owl-date-time>
   `
 })
 class StandardDateTimePicker {
@@ -2151,11 +2160,11 @@ class StandardDateTimePicker {
 @Component({
   template: `
     <input [owlDateTime]="dt" [selectMode]="selectMode" [values]="dates" />
-    <owl-date-time
+    <ofe-owl-date-time
       [startAt]="startAt"
       [pickerType]="pickerType"
       #dt
-    ></owl-date-time>
+    ></ofe-owl-date-time>
   `
 })
 class RangeDateTimePicker {
@@ -2173,13 +2182,13 @@ class RangeDateTimePicker {
   template: `
     <input [owlDateTime]="dt" />
     <input [owlDateTime]="dt" />
-    <owl-date-time #dt></owl-date-time>
+    <ofe-owl-date-time #dt></ofe-owl-date-time>
   `
 })
 class MultiInputDateTimePicker {}
 
 @Component({
-  template: ` <owl-date-time #dt></owl-date-time> `
+  template: ` <ofe-owl-date-time #dt></ofe-owl-date-time> `
 })
 class NoInputDateTimePicker {
   @ViewChild('dt', { static: true })
@@ -2189,7 +2198,7 @@ class NoInputDateTimePicker {
 @Component({
   template: `
     <input [owlDateTime]="dt" [value]="date" />
-    <owl-date-time #dt [startAt]="startDate"></owl-date-time>
+    <ofe-owl-date-time #dt [startAt]="startDate"></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithStartAt {
@@ -2202,12 +2211,12 @@ class DateTimePickerWithStartAt {
 @Component({
   template: `
     <input [owlDateTime]="dt" [value]="date" />
-    <owl-date-time
+    <ofe-owl-date-time
       #dt
       [startView]="startView"
       (monthSelected)="onMonthSelection()"
       (yearSelected)="onYearSelection()"
-    ></owl-date-time>
+    ></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithStartView {
@@ -2224,7 +2233,7 @@ class DateTimePickerWithStartView {
 @Component({
   template: `
     <input [(ngModel)]="moment" [selectMode]="selectMode" [owlDateTime]="dt" />
-    <owl-date-time #dt></owl-date-time>
+    <ofe-owl-date-time #dt></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithNgModel {
@@ -2241,9 +2250,9 @@ class DateTimePickerWithNgModel {
     <input
       [formControl]="formControl"
       [owlDateTime]="dt"
-      [owlDateTimeTrigger]="dt"
+      [ofeOwlDateTimeTrigger]="dt"
     />
-    <owl-date-time #dt></owl-date-time>
+    <ofe-owl-date-time #dt></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithFormControl {
@@ -2259,8 +2268,8 @@ class DateTimePickerWithFormControl {
 @Component({
   template: `
     <input [owlDateTime]="dt" />
-    <button [owlDateTimeTrigger]="dt">Icon</button>
-    <owl-date-time #dt></owl-date-time>
+    <button [ofeOwlDateTimeTrigger]="dt">Icon</button>
+    <ofe-owl-date-time #dt></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithTrigger {
@@ -2277,9 +2286,9 @@ class DateTimePickerWithTrigger {
       [min]="min"
       [max]="max"
       [owlDateTime]="dt"
-      [owlDateTimeTrigger]="dt"
+      [ofeOwlDateTimeTrigger]="dt"
     />
-    <owl-date-time [showSecondsTimer]="true" #dt></owl-date-time>
+    <ofe-owl-date-time [showSecondsTimer]="true" #dt></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithMinAndMaxValidation {
@@ -2301,9 +2310,9 @@ class DateTimePickerWithMinAndMaxValidation {
       [(ngModel)]="date"
       [owlDateTimeFilter]="filter"
       [owlDateTime]="dt"
-      [owlDateTimeTrigger]="dt"
+      [ofeOwlDateTimeTrigger]="dt"
     />
-    <owl-date-time [showSecondsTimer]="true" #dt></owl-date-time>
+    <ofe-owl-date-time [showSecondsTimer]="true" #dt></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithFilterValidation {
@@ -2321,13 +2330,13 @@ class DateTimePickerWithFilterValidation {
   template: `
     <input
       [owlDateTime]="dt"
-      [owlDateTimeTrigger]="dt"
+      [ofeOwlDateTimeTrigger]="dt"
       (change)="handleChange()"
       (input)="handleInput()"
       (dateTimeChange)="handleDateTimeChange()"
       (dateTimeInput)="handleDateTimeInput()"
     />
-    <owl-date-time [showSecondsTimer]="true" #dt></owl-date-time>
+    <ofe-owl-date-time [showSecondsTimer]="true" #dt></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithChangeAndInputEvents {
@@ -2350,7 +2359,7 @@ class DateTimePickerWithChangeAndInputEvents {
 @Component({
   template: `
     <input [owlDateTime]="dt" [(ngModel)]="value" [min]="min" [max]="max" />
-    <owl-date-time #dt [startAt]="startAt"></owl-date-time>
+    <ofe-owl-date-time #dt [startAt]="startAt"></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithISOStrings {
@@ -2367,11 +2376,11 @@ class DateTimePickerWithISOStrings {
 @Component({
   template: `
     <input [(ngModel)]="selected" [owlDateTime]="dt" />
-    <owl-date-time
+    <ofe-owl-date-time
       (afterPickerOpen)="openedSpy()"
       (afterPickerClosed)="closedSpy()"
       #dt
-    ></owl-date-time>
+    ></ofe-owl-date-time>
   `
 })
 class DateTimePickerWithEvents {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/date-time-picker.component.ts
@@ -1,7 +1,3 @@
-/**
- * date-time-picker.component
- */
-
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -13,7 +9,6 @@ import {
   Input,
   NgZone,
   OnDestroy,
-  OnInit,
   Optional,
   Output,
   ViewContainerRef
@@ -30,6 +25,9 @@ import {
 } from '@angular/cdk/overlay';
 import { ESCAPE, UP_ARROW } from '@angular/cdk/keycodes';
 import { coerceArray, coerceBooleanProperty } from '@angular/cdk/coercion';
+import { merge, Subscription } from 'rxjs';
+import { filter, take } from 'rxjs/operators';
+
 import { OwlDateTimeContainerComponent } from './date-time-picker-container.component';
 import { OwlDateTimeInputDirective } from './date-time-picker-input.directive';
 import { DateTimeAdapter } from './adapter/date-time-adapter.class';
@@ -45,8 +43,6 @@ import {
 } from './date-time.class';
 import { OwlDialogRef } from '../dialog/dialog-ref.class';
 import { OwlDialogService } from '../dialog/dialog.service';
-import { merge, Subscription } from 'rxjs';
-import { filter, take } from 'rxjs/operators';
 
 /** Injection token that determines the scroll handling while the dtPicker is open. */
 export const OWL_DTPICKER_SCROLL_STRATEGY = new InjectionToken<
@@ -69,16 +65,15 @@ export const OWL_DTPICKER_SCROLL_STRATEGY_PROVIDER = {
 };
 
 @Component({
-  selector: 'owl-date-time',
+  selector: 'ofe-owl-date-time',
   exportAs: 'owlDateTime',
   templateUrl: './date-time-picker.component.html',
   styleUrls: ['./date-time-picker.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OwlDateTimeComponent<T>
   extends OwlDateTime<T>
-  implements OnInit, OnDestroy {
+  implements OnDestroy {
   /** Custom class for the picker backdrop. */
   @Input()
   public backdropClass: string | string[] = [];
@@ -89,6 +84,7 @@ export class OwlDateTimeComponent<T>
 
   /** The date to open the calendar to initially. */
   private _startAt: T | null;
+
   @Input()
   get startAt(): T | null {
     // If an explicit startAt is set we start there, otherwise we start at whatever the currently
@@ -311,8 +307,6 @@ export class OwlDateTimeComponent<T>
     super(dateTimeAdapter, dateTimeFormats);
     this.defaultScrollStrategy = defaultScrollStrategy;
   }
-
-  public ngOnInit() {}
 
   public ngOnDestroy(): void {
     this.close();

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/timer-box.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/timer-box.component.ts
@@ -1,12 +1,8 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * timer-box.component
- */
-
 import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
+  HostBinding,
   Input,
   OnDestroy,
   OnInit,
@@ -18,16 +14,17 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 @Component({
   exportAs: 'owlDateTimeTimerBox',
-  selector: 'owl-date-time-timer-box',
+  selector: 'ofe-owl-date-time-timer-box',
   templateUrl: './timer-box.component.html',
   styleUrls: ['./timer-box.component.scss'],
-  preserveWhitespaces: false,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {
-    '[class.owl-dt-timer-box]': 'owlDTTimerBoxClass'
-  }
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OwlTimerBoxComponent implements OnInit, OnDestroy {
+  @HostBinding('class.owl-dt-timer-box')
+  get owlDTTimerBoxClass() {
+    return true;
+  }
+
   @Input() showDivider = false;
 
   @Input() upBtnAriaLabel: string;
@@ -64,10 +61,6 @@ export class OwlTimerBoxComponent implements OnInit, OnDestroy {
 
   get displayValue(): number {
     return this.boxValue || this.value;
-  }
-
-  get owlDTTimerBoxClass(): boolean {
-    return true;
   }
 
   constructor() {}

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/timer.component.html
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/timer.component.html
@@ -1,4 +1,4 @@
-<owl-date-time-timer-box
+<ofe-owl-date-time-timer-box
   [upBtnAriaLabel]="upHourButtonLabel"
   [downBtnAriaLabel]="downHourButtonLabel"
   [upBtnDisabled]="!upHourEnabled()"
@@ -11,8 +11,8 @@
   [inputLabel]="'Hour'"
   (inputChange)="setHourValueViaInput($event)"
   (valueChange)="setHourValue($event)"
-></owl-date-time-timer-box>
-<owl-date-time-timer-box
+></ofe-owl-date-time-timer-box>
+<ofe-owl-date-time-timer-box
   [showDivider]="true"
   [upBtnAriaLabel]="upMinuteButtonLabel"
   [downBtnAriaLabel]="downMinuteButtonLabel"
@@ -25,8 +25,8 @@
   [inputLabel]="'Minute'"
   (inputChange)="setMinuteValue($event)"
   (valueChange)="setMinuteValue($event)"
-></owl-date-time-timer-box>
-<owl-date-time-timer-box
+></ofe-owl-date-time-timer-box>
+<ofe-owl-date-time-timer-box
   *ngIf="showSecondsTimer"
   [showDivider]="true"
   [upBtnAriaLabel]="upSecondButtonLabel"
@@ -40,7 +40,7 @@
   [inputLabel]="'Second'"
   (inputChange)="setSecondValue($event)"
   (valueChange)="setSecondValue($event)"
-></owl-date-time-timer-box>
+></ofe-owl-date-time-timer-box>
 
 <div *ngIf="hour12Timer" class="owl-dt-timer-hour12">
   <button

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/timer.component.spec.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/timer.component.spec.ts
@@ -1,15 +1,10 @@
-/* eslint-disable @angular-eslint/component-class-suffix */
-/**
- * timer.component.spec
- */
-
 import { EventEmitter } from '@angular/core';
 import {
-  async,
   ComponentFixture,
   fakeAsync,
   flush,
-  TestBed
+  TestBed,
+  waitForAsync
 } from '@angular/core/testing';
 import { OwlDateTimeIntl } from './date-time-picker-intl.service';
 import { Component, DebugElement, NgZone } from '@angular/core';
@@ -50,18 +45,20 @@ class MockNgZone extends NgZone {
 describe('OwlTimerComponent', () => {
   let zone: MockNgZone;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [OwlNativeDateTimeModule, OwlDateTimeModule],
-      declarations: [StandardTimer],
-      providers: [
-        OwlDateTimeIntl,
-        { provide: NgZone, useFactory: () => (zone = new MockNgZone()) }
-      ]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [OwlNativeDateTimeModule, OwlDateTimeModule],
+        declarations: [StandardTimer],
+        providers: [
+          OwlDateTimeIntl,
+          { provide: NgZone, useFactory: () => (zone = new MockNgZone()) }
+        ]
+      }).compileComponents();
+    })
+  );
 
-  describe('standard timer', () => {
+  describe('Standard timer', () => {
     let fixture: ComponentFixture<StandardTimer>;
     let testComponent: StandardTimer;
     let timerDebugElement: DebugElement;
@@ -82,7 +79,7 @@ describe('OwlTimerComponent', () => {
 
     it('should have two timer boxes if showSecondsTimer set to false', () => {
       const timerBoxes = timerElement.querySelectorAll(
-        'owl-date-time-timer-box'
+        'ofe-owl-date-time-timer-box'
       );
       expect(timerInstance.showSecondsTimer).toBeFalsy();
       expect(timerBoxes.length).toBe(2);
@@ -93,7 +90,7 @@ describe('OwlTimerComponent', () => {
       fixture.detectChanges();
 
       const timerBoxes = timerElement.querySelectorAll(
-        'owl-date-time-timer-box'
+        'ofe-owl-date-time-timer-box'
       );
       expect(timerInstance.showSecondsTimer).toBeTruthy();
       expect(timerBoxes.length).toBe(3);
@@ -349,7 +346,7 @@ describe('OwlTimerComponent', () => {
 
 @Component({
   template: `
-    <owl-date-time-timer
+    <ofe-owl-date-time-timer
       [hour12Timer]="hour12Timer"
       [showSecondsTimer]="showSecondsTimer"
       [pickerMoment]="pickerMoment"
@@ -359,7 +356,7 @@ describe('OwlTimerComponent', () => {
       [minDateTime]="minDateTime"
       [maxDateTime]="maxDateTime"
       (selectedChange)="handleSelectedChange($event)"
-    ></owl-date-time-timer>
+    ></ofe-owl-date-time-timer>
   `
 })
 class StandardTimer {

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/timer.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/date-time/timer.component.ts
@@ -1,39 +1,40 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
-/**
- * timer.component
- */
-
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
+  HostBinding,
   Input,
   NgZone,
-  OnInit,
   Optional,
   Output
 } from '@angular/core';
+import { take } from 'rxjs/operators';
 import { OwlDateTimeIntl } from './date-time-picker-intl.service';
 import { DateTimeAdapter } from './adapter/date-time-adapter.class';
-import { take } from 'rxjs/operators';
 
 @Component({
   exportAs: 'owlDateTimeTimer',
-  selector: 'owl-date-time-timer',
+  selector: 'ofe-owl-date-time-timer',
   templateUrl: './timer.component.html',
   styleUrls: ['./timer.component.scss'],
-  preserveWhitespaces: false,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {
-    '[class.owl-dt-timer]': 'owlDTTimerClass',
-    '[attr.tabindex]': 'owlDTTimeTabIndex'
-  }
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class OwlTimerComponent<T> implements OnInit {
+export class OwlTimerComponent<T> {
+  @HostBinding('attr.tabindex')
+  get owlDTTimeTabIndex() {
+    return -1;
+  }
+
+  @HostBinding('class.owl-dt-timer')
+  get owlDTTimerClass() {
+    return true;
+  }
+
   /** The current picker moment */
   private _pickerMoment: T;
+
   @Input()
   get pickerMoment() {
     return this._pickerMoment;
@@ -46,6 +47,7 @@ export class OwlTimerComponent<T> implements OnInit {
 
   /** The minimum selectable date time. */
   private _minDateTime: T | null;
+
   @Input()
   get minDateTime(): T | null {
     return this._minDateTime;
@@ -58,6 +60,7 @@ export class OwlTimerComponent<T> implements OnInit {
 
   /** The maximum selectable date time. */
   private _maxDateTime: T | null;
+
   @Input()
   get maxDateTime(): T | null {
     return this._maxDateTime;
@@ -172,14 +175,6 @@ export class OwlTimerComponent<T> implements OnInit {
   @Output()
   selectedChange = new EventEmitter<T>();
 
-  get owlDTTimerClass(): boolean {
-    return true;
-  }
-
-  get owlDTTimeTabIndex(): number {
-    return -1;
-  }
-
   constructor(
     private ngZone: NgZone,
     private elmRef: ElementRef,
@@ -187,8 +182,6 @@ export class OwlTimerComponent<T> implements OnInit {
     private cdRef: ChangeDetectorRef,
     @Optional() private dateTimeAdapter: DateTimeAdapter<T>
   ) {}
-
-  public ngOnInit() {}
 
   /**
    * Focus to the host element

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -22,7 +22,7 @@ import { SelectOption } from '../../form-entry/question-models/interfaces/select
 import { DataSource } from '../../form-entry/question-models/interfaces/data-source';
 import * as _ from 'lodash';
 @Component({
-  selector: 'ngx-remote-select',
+  selector: 'ofe-remote-select',
   templateUrl: 'remote-select.component.html',
   providers: [
     {
@@ -38,15 +38,15 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
   remoteOptionsLoading = false;
   remoteOptionInput$ = new Subject<string>();
   selectedRemoteOptions: SelectOption;
-  @Input() placeholder = 'Search...';
-  @Input() componentID: string;
-  @Input() disabled = false;
-  @Input() theme = 'dark';
   items = [];
   value = [];
   loading = false;
   searchText = '';
   notFoundMsg = 'match no found';
+  @Input() placeholder = 'Search...';
+  @Input() componentID: string;
+  @Input() disabled = false;
+  @Input() theme = 'dark';
   @Output() done: EventEmitter<any> = new EventEmitter<any>();
 
   private _dataSource: DataSource;

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.html
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.html
@@ -1,7 +1,7 @@
 <div class="tab-container">
   <div class="tab">
     <button
-      hover-class="hover"
+      ofeHoverClass="hover"
       class="tablinks completed"
       *ngFor="let tab of tabs"
       (click)="selectTab(tab)"

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.ts
@@ -13,7 +13,7 @@ import type { QueryList } from '@angular/core';
 import { TabComponent } from './tab.component';
 
 @Component({
-  selector: 'ngx-tab-set',
+  selector: 'ofe-tab-set',
   styleUrls: ['ngx-tab-set.component.scss'],
   templateUrl: 'ngx-tab-set.component.html'
 })
@@ -25,7 +25,7 @@ export class TabSetComponent implements AfterContentInit, OnChanges {
   @Input() public customTabsClass: String = '';
   @Input() public selectedIndex: Number = 0;
 
-  @Output() public onSelect = new EventEmitter();
+  @Output() public tabSelect = new EventEmitter();
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.selectedIndex && !changes.selectedIndex.firstChange) {
@@ -58,7 +58,7 @@ export class TabSetComponent implements AfterContentInit, OnChanges {
 
     // activate the tab the user has clicked on.
     tabToSelect.active = true;
-    this.onSelect.emit(this.tabs.toArray().indexOf(tabToSelect));
+    this.tabSelect.emit(this.tabs.toArray().indexOf(tabToSelect));
   }
   public getStatusClasses(active, disabled) {
     if (active) {

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/tab.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, ContentChild, TemplateRef } from '@angular/core';
 
 @Component({
-  selector: 'ngx-tab',
+  selector: 'ofe-tab',
   templateUrl: 'tab.component.html',
   styleUrls: ['./tab.component.css']
 })

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/tabset.html
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/tabset.html
@@ -1,7 +1,7 @@
 <div class="tab-container">
   <div class="tab">
     <button
-      hover-class="hover"
+      ofeHoverClass="hover"
       class="tablinks completed"
       *ngFor="let tab of tabs"
       (click)="selectTab(tab)"

--- a/projects/ngx-formentry/src/components/ngx-tabset/directives/hover-class.directive.ts
+++ b/projects/ngx-formentry/src/components/ngx-tabset/directives/hover-class.directive.ts
@@ -1,11 +1,12 @@
 import { Directive, HostListener, ElementRef, Input } from '@angular/core';
 
 @Directive({
-  selector: '[hover-class]'
+  selector: '[ofeHoverClass]'
 })
 export class HoverClassDirective {
   constructor(public elementRef: ElementRef) {}
-  @Input('hover-class') hoverClass: any;
+
+  @Input() hoverClass: string;
 
   @HostListener('mouseenter') onMouseEnter() {
     this.elementRef.nativeElement.classList.add(this.hoverClass);

--- a/projects/ngx-formentry/src/components/number-input/number-input.component.ts
+++ b/projects/ngx-formentry/src/components/number-input/number-input.component.ts
@@ -24,7 +24,7 @@ export class NumberChangeEvent {
 }
 
 @Component({
-  selector: 'number-input',
+  selector: 'ofe-number-input',
   templateUrl: 'number-input.component.html',
   providers: [
     {
@@ -121,7 +121,7 @@ export class NumberInputComponent implements ControlValueAccessor {
   /**
    * Emits event notifying other classes when a change in state occurs in the input.
    */
-  @Output() change = new EventEmitter<NumberChangeEvent>();
+  @Output() numberChange = new EventEmitter<NumberChangeEvent>();
   /**
    * Sets the decrement label text
    */
@@ -222,7 +222,7 @@ export class NumberInputComponent implements ControlValueAccessor {
     const event = new NumberChangeEvent();
     event.source = this;
     event.value = this.value;
-    this.change.emit(event);
+    this.numberChange.emit(event);
     this.propagateChange(this.value);
   }
 

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.ts
@@ -1,16 +1,10 @@
-import {
-  Component,
-  Input,
-  forwardRef,
-  OnInit,
-  AfterViewInit
-} from '@angular/core';
+import { Component, Input, forwardRef, OnInit } from '@angular/core';
 
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import * as _ from 'lodash';
 
 @Component({
-  selector: 'radio',
+  selector: 'ofe-radio-button',
   templateUrl: './radio.component.html',
   providers: [
     {
@@ -20,7 +14,7 @@ import * as _ from 'lodash';
     }
   ]
 })
-export class RadioButtonControlComponent implements OnInit, AfterViewInit {
+export class RadioButtonControlComponent implements OnInit {
   @Input() public id: String;
   @Input() public selected: any;
   @Input() public options: Array<any>;
@@ -35,8 +29,6 @@ export class RadioButtonControlComponent implements OnInit, AfterViewInit {
       return option;
     });
   }
-
-  public ngAfterViewInit() {}
 
   public writeValue(value: any) {}
 

--- a/projects/ngx-formentry/src/components/select/optgroup.directive.ts
+++ b/projects/ngx-formentry/src/components/select/optgroup.directive.ts
@@ -1,10 +1,8 @@
-/* eslint-disable @angular-eslint/component-class-suffix, @angular-eslint/directive-class-suffix */
 import { Directive, HostBinding } from '@angular/core';
 
 @Directive({
-  // eslint-disable-next-line
-  selector: 'optgroup'
+  selector: '[ofeOptgroup]'
 })
-export class OptGroup {
+export class OptGroupDirective {
   @HostBinding('class') inputClass = 'cds--select-optgroup';
 }

--- a/projects/ngx-formentry/src/components/select/option.directive.ts
+++ b/projects/ngx-formentry/src/components/select/option.directive.ts
@@ -1,10 +1,8 @@
-/* eslint-disable @angular-eslint/component-class-suffix, @angular-eslint/directive-class-suffix */
 import { Directive, HostBinding } from '@angular/core';
 
 @Directive({
-  // eslint-disable-next-line
-  selector: 'option'
+  selector: '[ofeOption]'
 })
-export class Option {
+export class OptionDirective {
   @HostBinding('class') inputClass = 'cds--select-option';
 }

--- a/projects/ngx-formentry/src/components/select/select.component.html
+++ b/projects/ngx-formentry/src/components/select/select.component.html
@@ -1,0 +1,119 @@
+<div class="cds--form-item">
+  <ng-template [ngIf]="skeleton">
+    <div *ngIf="label" class="cds--label cds--skeleton"></div>
+    <div class="cds--select cds--skeleton"></div>
+  </ng-template>
+  <div
+    *ngIf="!skeleton"
+    class="cds--select"
+    [ngClass]="{
+      'cds--select--inline': display === 'inline',
+      'cds--select--light': theme === 'light',
+      'cds--select--invalid': invalid,
+      'cds--select--warning': warn,
+      'cds--select--disabled': disabled
+    }"
+  >
+    <label *ngIf="label" [for]="id" class="cds--label">
+      <ng-container *ngIf="!isTemplate(label)">{{ label }}</ng-container>
+      <ng-template
+        *ngIf="isTemplate(label)"
+        [ngTemplateOutlet]="label"
+      ></ng-template>
+    </label>
+    <div *ngIf="helperText" class="cds--form__helper-text">
+      <ng-container *ngIf="!isTemplate(helperText)">{{
+        helperText
+      }}</ng-container>
+      <ng-template
+        *ngIf="isTemplate(helperText)"
+        [ngTemplateOutlet]="helperText"
+      ></ng-template>
+    </div>
+    <div
+      *ngIf="display === 'inline'; else noInline"
+      class="cds--select-input--inline__wrapper"
+    >
+      <ng-container *ngTemplateOutlet="noInline"></ng-container>
+    </div>
+  </div>
+</div>
+
+<!-- select element: dynamically projected based on 'display' variant -->
+<ng-template #noInline>
+  <div
+    class="cds--select-input__wrapper extend"
+    [attr.data-invalid]="invalid ? true : null"
+  >
+    <select
+      #select
+      [attr.id]="id"
+      [attr.aria-label]="ariaLabel"
+      [disabled]="disabled"
+      (change)="onChange($event)"
+      [attr.aria-invalid]="invalid ? 'true' : null"
+      class="cds--select-input"
+      [ngClass]="{
+        'cds--select-input--xl': size === 'xl',
+        'cds--select-input--sm': size === 'sm'
+      }"
+    >
+      <ng-content></ng-content>
+    </select>
+    <svg
+      focusable="false"
+      preserveAspectRatio="xMidYMid meet"
+      style="will-change: transform"
+      xmlns="http://www.w3.org/2000/svg"
+      class="cds--select__arrow"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+    >
+      <path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
+    </svg>
+    <svg
+      *ngIf="invalid"
+      focusable="false"
+      preserveAspectRatio="xMidYMid meet"
+      style="will-change: transform"
+      xmlns="http://www.w3.org/2000/svg"
+      class="cds--text-input__invalid-icon"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+    >
+      <path
+        d="M8,1C4.2,1,1,4.2,1,8s3.2,7,7,7s7-3.1,7-7S11.9,1,8,1z M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2    c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z"
+      ></path>
+      <path
+        d="M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8    c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z"
+        data-icon-path="inner-path"
+        opacity="0"
+      ></path>
+    </svg>
+  </div>
+  <div
+    *ngIf="invalid && invalidText && !warn"
+    role="alert"
+    class="cds--form-requirement"
+    aria-live="polite"
+  >
+    <ng-container *ngIf="!isTemplate(invalidText)">{{
+      invalidText
+    }}</ng-container>
+    <ng-template
+      *ngIf="isTemplate(invalidText)"
+      [ngTemplateOutlet]="invalidText"
+    ></ng-template>
+  </div>
+  <div *ngIf="!invalid && warn" class="cds--form-requirement">
+    <ng-container *ngIf="!isTemplate(warnText)">{{ warnText }}</ng-container>
+    <ng-template
+      *ngIf="isTemplate(warnText)"
+      [ngTemplateOutlet]="warnText"
+    ></ng-template>
+  </div>
+</ng-template>

--- a/projects/ngx-formentry/src/components/select/select.component.scss
+++ b/projects/ngx-formentry/src/components/select/select.component.scss
@@ -1,0 +1,11 @@
+.cds--select--inline .cds--form__helper-text {
+  order: 4;
+}
+
+.cds--select--inline:not(.cds--select--invalid) .cds--form__helper-text {
+  margin-top: 0;
+}
+
+.cds--select-input__wrapper {
+  min-width: 16rem;
+}

--- a/projects/ngx-formentry/src/components/select/select.component.spec.ts
+++ b/projects/ngx-formentry/src/components/select/select.component.spec.ts
@@ -1,41 +1,42 @@
-/* eslint-disable @angular-eslint/component-class-suffix */
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
-import { Component } from '@angular/core';
-import { Select } from './select.component';
+
+import { SelectComponent } from './select.component';
 
 @Component({
   template: `
-    <ibm-select (valueChange)="onChange($event)" [(ngModel)]="model">
+    <ofe-select (valueChange)="onChange($event)" [(ngModel)]="model">
       <option value="option1">Option 1</option>
-    </ibm-select>
+    </ofe-select>
   `
 })
-class SelectTest {
+class SelectComponentTest {
   model = null;
   value = null;
+
   onChange(event) {
     this.value = event;
   }
 }
 
-describe('Select', () => {
+describe('SelectComponent', () => {
   let fixture, wrapper, element;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [Select, SelectTest],
+      declarations: [SelectComponent, SelectComponentTest],
       imports: [FormsModule]
     });
   });
 
   it('should work', () => {
-    fixture = TestBed.createComponent(Select);
-    expect(fixture.componentInstance instanceof Select).toBe(true);
+    fixture = TestBed.createComponent(SelectComponent);
+    expect(fixture.componentInstance instanceof SelectComponent).toBe(true);
   });
 
   it('should call onChange on change select and propagate the change back to the form', () => {
-    fixture = TestBed.createComponent(SelectTest);
+    fixture = TestBed.createComponent(SelectComponentTest);
     wrapper = fixture.componentInstance;
     fixture.detectChanges();
     const de = fixture.debugElement.query(By.css('.cds--select-input'));
@@ -49,62 +50,62 @@ describe('Select', () => {
   });
 
   it('should set label to test', () => {
-    fixture = TestBed.overrideComponent(SelectTest, {
+    fixture = TestBed.overrideComponent(SelectComponentTest, {
       set: {
-        template: `<ibm-select label="test"></ibm-select>`
+        template: `<ofe-select label="test"></ofe-select>`
       }
-    }).createComponent(SelectTest);
+    }).createComponent(SelectComponentTest);
     fixture.detectChanges();
-    element = fixture.debugElement.query(By.css('ibm-select')).nativeElement;
+    element = fixture.debugElement.query(By.css('ofe-select')).nativeElement;
     expect(element.querySelector('.cds--label').textContent).toEqual('test');
   });
 
   it('should set helperText to test', () => {
-    fixture = TestBed.overrideComponent(SelectTest, {
+    fixture = TestBed.overrideComponent(SelectComponentTest, {
       set: {
-        template: `<ibm-select helperText="test"></ibm-select>`
+        template: `<ofe-select helperText="test"></ofe-select>`
       }
-    }).createComponent(SelectTest);
+    }).createComponent(SelectComponentTest);
     fixture.detectChanges();
-    element = fixture.debugElement.query(By.css('ibm-select')).nativeElement;
+    element = fixture.debugElement.query(By.css('ofe-select')).nativeElement;
     expect(
       element.querySelector('.cds--form__helper-text').textContent
     ).toEqual('test');
   });
 
   it('should set display to inline', () => {
-    fixture = TestBed.overrideComponent(SelectTest, {
+    fixture = TestBed.overrideComponent(SelectComponentTest, {
       set: {
-        template: `<ibm-select display="inline"></ibm-select>`
+        template: `<ofe-select display="inline"></ofe-select>`
       }
-    }).createComponent(SelectTest);
+    }).createComponent(SelectComponentTest);
     fixture.detectChanges();
-    element = fixture.debugElement.query(By.css('ibm-select')).nativeElement;
+    element = fixture.debugElement.query(By.css('ofe-select')).nativeElement;
     expect(element.querySelector('.cds--select--inline')).toBeTruthy();
   });
 
   it('should set option to disabled', () => {
-    fixture = TestBed.overrideComponent(SelectTest, {
+    fixture = TestBed.overrideComponent(SelectComponentTest, {
       set: {
         template: `
-                <ibm-select>
+                <ofe-select>
                     <option value="option1" disabled> Option 1 </option>
-                </ibm-select>`
+                </ofe-select>`
       }
-    }).createComponent(SelectTest);
+    }).createComponent(SelectComponentTest);
     fixture.detectChanges();
-    element = fixture.debugElement.query(By.css('ibm-select')).nativeElement;
+    element = fixture.debugElement.query(By.css('ofe-select')).nativeElement;
     expect(element.querySelector('option').disabled).toBe(true);
   });
 
   it('should display ibm-icon-warning-filled16 and display invalid text', () => {
-    fixture = TestBed.overrideComponent(SelectTest, {
+    fixture = TestBed.overrideComponent(SelectComponentTest, {
       set: {
-        template: `<ibm-select [invalid]=true invalidText="test"></ibm-select>`
+        template: `<ofe-select [invalid]=true invalidText="test"></ofe-select>`
       }
-    }).createComponent(SelectTest);
+    }).createComponent(SelectComponentTest);
     fixture.detectChanges();
-    element = fixture.debugElement.query(By.css('ibm-select')).nativeElement;
+    element = fixture.debugElement.query(By.css('ofe-select')).nativeElement;
     expect(
       element.querySelector('.cds--text-input__invalid-icon')
     ).toBeTruthy();
@@ -114,13 +115,13 @@ describe('Select', () => {
   });
 
   it('should set class cds--skeleton', () => {
-    fixture = TestBed.overrideComponent(SelectTest, {
+    fixture = TestBed.overrideComponent(SelectComponentTest, {
       set: {
-        template: `<ibm-select [skeleton]=true></ibm-select>`
+        template: `<ofe-select [skeleton]=true></ofe-select>`
       }
-    }).createComponent(SelectTest);
+    }).createComponent(SelectComponentTest);
     fixture.detectChanges();
-    element = fixture.debugElement.query(By.css('ibm-select')).nativeElement;
+    element = fixture.debugElement.query(By.css('ofe-select')).nativeElement;
     expect(element.querySelector('.cds--skeleton')).toBeTruthy();
   });
 });

--- a/projects/ngx-formentry/src/components/select/select.component.ts
+++ b/projects/ngx-formentry/src/components/select/select.component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @angular-eslint/component-class-suffix */
 import {
   AfterViewInit,
   Component,
@@ -13,171 +12,36 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 /**
- * `ibm-select` provides a styled `select` component.
+ * `ofe-select` provides a styled `select` component.
  *
  * [See demo](../../?path=/story/select--basic)
  *
  * Example:
  *
  * ```
- * <ibm-select [(ngModel)]="model">
+ * <ofe-select [(ngModel)]="model">
  *     <option value="default" disabled selected hidden>Choose an option</option>
  *     <option value="option1">Option 1</option>
  *    <option value="option2">Option 2</option>
  *     <option value="option3">Option 3</option>
- * </ibm-select>
+ * </ofe-select>
  *    ```
  *
  * <example-url>../../iframe.html?id=select--basic</example-url>
  */
 @Component({
-  selector: 'ibm-select',
-  template: `
-    <div class="cds--form-item">
-      <ng-template [ngIf]="skeleton">
-        <div *ngIf="label" class="cds--label cds--skeleton"></div>
-        <div class="cds--select cds--skeleton"></div>
-      </ng-template>
-      <div
-        *ngIf="!skeleton"
-        class="cds--select"
-        [ngClass]="{
-          'cds--select--inline': display === 'inline',
-          'cds--select--light': theme === 'light',
-          'cds--select--invalid': invalid,
-          'cds--select--warning': warn,
-          'cds--select--disabled': disabled
-        }"
-      >
-        <label *ngIf="label" [for]="id" class="cds--label">
-          <ng-container *ngIf="!isTemplate(label)">{{ label }}</ng-container>
-          <ng-template
-            *ngIf="isTemplate(label)"
-            [ngTemplateOutlet]="label"
-          ></ng-template>
-        </label>
-        <div *ngIf="helperText" class="cds--form__helper-text">
-          <ng-container *ngIf="!isTemplate(helperText)">{{
-            helperText
-          }}</ng-container>
-          <ng-template
-            *ngIf="isTemplate(helperText)"
-            [ngTemplateOutlet]="helperText"
-          ></ng-template>
-        </div>
-        <div
-          *ngIf="display === 'inline'; else noInline"
-          class="cds--select-input--inline__wrapper"
-        >
-          <ng-container *ngTemplateOutlet="noInline"></ng-container>
-        </div>
-      </div>
-    </div>
-
-    <!-- select element: dynamically projected based on 'display' variant -->
-    <ng-template #noInline>
-      <div
-        class="cds--select-input__wrapper extend"
-        [attr.data-invalid]="invalid ? true : null"
-      >
-        <select
-          #select
-          [attr.id]="id"
-          [attr.aria-label]="ariaLabel"
-          [disabled]="disabled"
-          (change)="onChange($event)"
-          [attr.aria-invalid]="invalid ? 'true' : null"
-          class="cds--select-input"
-          [ngClass]="{
-            'cds--select-input--xl': size === 'xl',
-            'cds--select-input--sm': size === 'sm'
-          }"
-        >
-          <ng-content></ng-content>
-        </select>
-        <svg
-          focusable="false"
-          preserveAspectRatio="xMidYMid meet"
-          style="will-change: transform;"
-          xmlns="http://www.w3.org/2000/svg"
-          class="cds--select__arrow"
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          aria-hidden="true"
-        >
-          <path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
-        </svg>
-        <svg
-          *ngIf="invalid"
-          focusable="false"
-          preserveAspectRatio="xMidYMid meet"
-          style="will-change: transform;"
-          xmlns="http://www.w3.org/2000/svg"
-          class="cds--text-input__invalid-icon"
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          aria-hidden="true"
-        >
-          <path
-            d="M8,1C4.2,1,1,4.2,1,8s3.2,7,7,7s7-3.1,7-7S11.9,1,8,1z M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2    c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z"
-          ></path>
-          <path
-            d="M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8    c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z"
-            data-icon-path="inner-path"
-            opacity="0"
-          ></path>
-        </svg>
-      </div>
-      <div
-        *ngIf="invalid && invalidText && !warn"
-        role="alert"
-        class="cds--form-requirement"
-        aria-live="polite"
-      >
-        <ng-container *ngIf="!isTemplate(invalidText)">{{
-          invalidText
-        }}</ng-container>
-        <ng-template
-          *ngIf="isTemplate(invalidText)"
-          [ngTemplateOutlet]="invalidText"
-        ></ng-template>
-      </div>
-      <div *ngIf="!invalid && warn" class="cds--form-requirement">
-        <ng-container *ngIf="!isTemplate(warnText)">{{
-          warnText
-        }}</ng-container>
-        <ng-template
-          *ngIf="isTemplate(warnText)"
-          [ngTemplateOutlet]="warnText"
-        ></ng-template>
-      </div>
-    </ng-template>
-  `,
-  styles: [
-    `
-      .cds--select--inline .cds--form__helper-text {
-        order: 4;
-      }
-
-      .cds--select--inline:not(.cds--select--invalid) .cds--form__helper-text {
-        margin-top: 0;
-      }
-      .cds--select-input__wrapper {
-        min-width: 16rem;
-      }
-    `
-  ],
+  selector: 'ofe-select',
+  templateUrl: 'select.component.html',
+  styleUrls: ['./select.component.scss'],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: Select,
+      useExisting: SelectComponent,
       multi: true
     }
   ]
 })
-export class Select implements ControlValueAccessor, AfterViewInit {
+export class SelectComponent implements ControlValueAccessor, AfterViewInit {
   /**
    * Tracks the total number of selects instantiated. Used to generate unique IDs
    */
@@ -210,7 +74,7 @@ export class Select implements ControlValueAccessor, AfterViewInit {
   /**
    * Sets the unique ID. Defaults to `select-${total count of selects instantiated}`
    */
-  @Input() id = `select-${Select.selectCount++}`;
+  @Input() id = `select-${SelectComponent.selectCount++}`;
   /**
    * Number input field render size
    */
@@ -236,7 +100,6 @@ export class Select implements ControlValueAccessor, AfterViewInit {
 
   @Output() valueChange = new EventEmitter();
 
-  // @ts-ignore
   @ViewChild('select', { static: false }) select: ElementRef;
 
   @Input() set value(v) {

--- a/projects/ngx-formentry/src/components/select/select.module.ts
+++ b/projects/ngx-formentry/src/components/select/select.module.ts
@@ -4,13 +4,13 @@ import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 
 // imports
-import { Select } from './select.component';
-import { Option } from './option.directive';
-import { OptGroup } from './optgroup.directive';
+import { SelectComponent } from './select.component';
+import { OptionDirective } from './option.directive';
+import { OptGroupDirective } from './optgroup.directive';
 
 @NgModule({
-  declarations: [Select, Option, OptGroup],
-  exports: [Select, Option, OptGroup],
+  declarations: [SelectComponent, OptionDirective, OptGroupDirective],
+  exports: [SelectComponent, OptionDirective, OptGroupDirective],
   imports: [CommonModule, FormsModule]
 })
 export class SelectModule {}

--- a/projects/ngx-formentry/src/form-entry/data-sources/data-sources.ts
+++ b/projects/ngx-formentry/src/form-entry/data-sources/data-sources.ts
@@ -11,9 +11,7 @@ export class DataSources {
 
   registerDataSource(key: string, dataSource: any, unWrap = false) {
     if (unWrap) {
-      // eslint-disable-next-line guard-for-in
       for (const o in dataSource) {
-        
         this.registerDataSource(o, dataSource[o], false);
       }
     }

--- a/projects/ngx-formentry/src/form-entry/directives/collapse.directive.ts
+++ b/projects/ngx-formentry/src/form-entry/directives/collapse.directive.ts
@@ -1,10 +1,8 @@
-/* eslint-disable @angular-eslint/no-host-metadata-property */
 import {
   AnimationBuilder,
   AnimationFactory,
   AnimationPlayer
 } from '@angular/animations';
-
 import {
   AfterViewChecked,
   Directive,
@@ -19,14 +17,11 @@ import {
 import { collapseAnimation, expandAnimation } from './collapse-animations';
 
 @Directive({
-  selector: '[collapse]',
-  exportAs: 'bs-collapse',
-  // eslint-disable-next-line @angular-eslint/no-host-metadata-property
-  host: {
-    '[class.collapse]': 'true'
-  }
+  selector: '[ofeCollapse]',
+  exportAs: 'bs-collapse'
 })
 export class CollapseDirective implements AfterViewChecked {
+  // @HostBinding('class.collapse')
   /** This event fires as soon as content collapses */
   @Output() collapsed: EventEmitter<CollapseDirective> = new EventEmitter();
   /** This event fires when collapsing is started */

--- a/projects/ngx-formentry/src/form-entry/directives/historical-value.directive.ts
+++ b/projects/ngx-formentry/src/form-entry/directives/historical-value.directive.ts
@@ -11,7 +11,7 @@ import * as _ from 'lodash';
 import { NodeBase } from '../form-factory/form-node';
 
 @Directive({
-  selector: `[node]`
+  selector: `[ofeNode]`
 })
 export class HistoricalValueDirective {
   @Input() _node: NodeBase;

--- a/projects/ngx-formentry/src/form-entry/error-renderer/error-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/error-renderer/error-renderer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import * as _ from 'lodash';
 
 import { Form } from '../form-factory/form';
@@ -8,19 +8,17 @@ import { QuestionGroup } from '../question-models/group-question';
 import { FormErrorsService } from '../services/form-errors.service';
 
 @Component({
-  selector: 'error-renderer',
+  selector: 'ofe-error-renderer',
   templateUrl: 'error-renderer.component.html',
   styleUrls: ['./error-renderer.component.css']
 })
-export class ErrorRendererComponent implements OnInit {
+export class ErrorRendererComponent {
   @Input() form: Form;
 
   constructor(
     private validationFactory: ValidationFactory,
     private formErrorsService: FormErrorsService
   ) {}
-
-  ngOnInit() {}
 
   showErrors() {
     return !this.form.valid && this.form.showErrors;

--- a/projects/ngx-formentry/src/form-entry/expression-runner/expression-runner.ts
+++ b/projects/ngx-formentry/src/form-entry/expression-runner/expression-runner.ts
@@ -21,7 +21,6 @@ export class ExpressionRunner {
     const runner = this;
     const runnable: Runnable = {
       run: () => {
-        /* eslint-disable */
         let scope: any = {};
         if (control.uuid) {
           scope[control.uuid] = control.value;

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -11,7 +11,7 @@ import { FormControlService } from './form-factory/form-control.service';
 import { ValidationFactory } from './form-factory/validation.factory';
 import { FormRendererComponent } from './form-renderer/form-renderer.component';
 import { ErrorRendererComponent } from './error-renderer/error-renderer.component';
-import { HistoricalValueDirective } from './directives/historical-value-directive';
+import { HistoricalValueDirective } from './directives/historical-value.directive';
 import { CollapseDirective } from './directives/collapse.directive';
 import { HistoricalFieldHelperService } from './helpers/historical-field-helper-service';
 import { NumberInputModule } from '../components/number-input/number-input.module';

--- a/projects/ngx-formentry/src/form-entry/form-factory/form.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/form.ts
@@ -83,7 +83,7 @@ export class Form {
   ) {
     if (rootNode instanceof GroupNode) {
       const nodeAsGroup = rootNode as GroupNode;
-      // eslint-disable-next-line guard-for-in
+
       for (const o in nodeAsGroup.children) {
         this.searchNodeByQuestionType(
           nodeAsGroup.children[o],
@@ -125,7 +125,7 @@ export class Form {
 
     if (rootNode instanceof GroupNode) {
       const nodeAsGroup = rootNode as GroupNode;
-      // eslint-disable-next-line guard-for-in
+
       for (const o in nodeAsGroup.children) {
         this.findNodesByQuestionId(
           nodeAsGroup.children[o],
@@ -217,7 +217,7 @@ export class Form {
 
     if (rootNode instanceof GroupNode) {
       const nodeAsGroup = rootNode as GroupNode;
-      // eslint-disable-next-line guard-for-in
+
       for (const o in nodeAsGroup.children) {
         this._updateAlertsForAllControls(nodeAsGroup.children[o]);
       }
@@ -244,7 +244,7 @@ export class Form {
 
     if (rootNode instanceof GroupNode) {
       const nodeAsGroup = rootNode as GroupNode;
-      // eslint-disable-next-line guard-for-in
+
       for (const o in nodeAsGroup.children) {
         this._updateHiddenDisabledStateForAllControls(nodeAsGroup.children[o]);
       }

--- a/projects/ngx-formentry/src/form-entry/form-factory/hiders-disablers.factory.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/hiders-disablers.factory.spec.ts
@@ -33,13 +33,11 @@ describe('Hiders Disablers Factory:', () => {
       HidersDisablersFactory
     );
 
-    /* eslint-disable */
     let model: QuestionBase = new QuestionBase({
       type: 'date',
       key: 'control1',
       disable: "control2 === 10 && arrayContains(control3, 'six')"
     });
-    /* eslint-enable */
 
     const control: AfeFormControl = new AfeFormControl();
 
@@ -69,13 +67,11 @@ describe('Hiders Disablers Factory:', () => {
       HidersDisablersFactory
     );
 
-    /* eslint-disable */
     let model: QuestionBase = new QuestionBase({
       type: 'date',
       key: 'control1',
       hide: "control2 === 10 && arrayContains(control3, 'six')"
     });
-    /* eslint-enable */
 
     const control: AfeFormControl = new AfeFormControl();
 

--- a/projects/ngx-formentry/src/form-entry/form-factory/show-messages.factory.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/show-messages.factory.spec.ts
@@ -25,7 +25,6 @@ describe('Show Messages Factory:', () => {
   it('should return a message when the alertWhenExpression returns true', () => {
     const factory: AlertsFactory = TestBed.inject(AlertsFactory);
 
-    /* eslint-disable */
     let model: QuestionBase = new QuestionBase({
       type: 'testOrder',
       key: 'control1',
@@ -34,7 +33,6 @@ describe('Show Messages Factory:', () => {
         message: 'Vl required'
       }
     });
-    /* eslint-enable */
     const control2: AfeFormControl = new AfeFormControl();
     control2.uuid = 'control2';
     control2.setValue('hello');
@@ -51,7 +49,6 @@ describe('Show Messages Factory:', () => {
   it('should return an empty message when the alertWhenExpression returns false', () => {
     const factory: AlertsFactory = TestBed.inject(AlertsFactory);
 
-    /* eslint-disable */
     let model: QuestionBase = new QuestionBase({
       type: 'testOrder',
       key: 'control1',
@@ -60,7 +57,6 @@ describe('Show Messages Factory:', () => {
         message: 'Vl required'
       }
     });
-    /* eslint-enable */
     const control2: AfeFormControl = new AfeFormControl();
     control2.uuid = 'control2';
     control2.setValue('');

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -1,19 +1,18 @@
 <!--CONTAINERS-->
 <div *ngIf="node.question.renderingType === 'form'">
-  <ngx-tab-set (onSelect)="tabSelected($event)" [selectedIndex]="activeTab">
-    <ngx-tab
+  <ofe-tab-set (tabSelect)="tabSelected($event)" [selectedIndex]="activeTab">
+    <ofe-tab
       [tabTitle]="question.label"
       *ngFor="let question of node.question.questions; let i = index"
     >
-      <form-renderer
+      <ofe-form-renderer
         [node]="node.children[question.key]"
         [parentComponent]="this"
         [parentGroup]="node.control"
         [labelMap]="labelMap"
       >
-      </form-renderer>
-    </ngx-tab>
-
+      </ofe-form-renderer>
+    </ofe-tab>
     <div *ngIf="showErrors()" class="container">
       <div
         data-notification
@@ -61,22 +60,22 @@
         </svg>
       </div>
     </div>
-  </ngx-tab-set>
+  </ofe-tab-set>
 </div>
 <div *ngIf="node.question.renderingType === 'page'">
   <!--Page Components-->
-  <app-custom-component-wrapper
+  <ofe-custom-component-wrapper
     [dark]="theme === 'light'"
     [componentConfigs]="node.question.componentConfigs"
   >
-  </app-custom-component-wrapper>
-  <form-renderer
+  </ofe-custom-component-wrapper>
+  <ofe-form-renderer
     *ngFor="let question of node.question.questions"
     [parentComponent]="this"
     [node]="node.children[question.key]"
     [parentGroup]="parentGroup"
     [labelMap]="labelMap"
-  ></form-renderer>
+  ></ofe-form-renderer>
 </div>
 <div *ngIf="node.question.renderingType === 'section' && checkSection(node)">
   <div
@@ -108,26 +107,26 @@
         {{ node.question.label }}
       </p>
     </button>
-    <div [collapse]="isCollapsed">
+    <div ofeCollapse="isCollapsed">
       <!--Section Components-->
-      <app-custom-component-wrapper
+      <ofe-custom-component-wrapper
         [dark]="theme === 'light'"
         [componentConfigs]="node.question.componentConfigs"
       >
-      </app-custom-component-wrapper>
+      </ofe-custom-component-wrapper>
       <div
         class="cds--accordion__content accordion-content-override"
         [ngClass]="{
           'accordion-content-dark': theme === 'light'
         }"
       >
-        <form-renderer
+        <ofe-form-renderer
           *ngFor="let question of node.question.questions"
           [parentComponent]="this"
           [node]="node.children[question.key]"
           [parentGroup]="parentGroup"
           [labelMap]="labelMap"
-        ></form-renderer>
+        ></ofe-form-renderer>
       </div>
     </div>
   </div>
@@ -149,11 +148,11 @@
   [hidden]="node.control.hidden"
   [ngClass]="{ disabled: node.control.disabled }"
 >
-  <app-custom-component-wrapper
+  <ofe-custom-component-wrapper
     [dark]="!(theme === 'light')"
     [componentConfigs]="node.question.componentConfigs"
   >
-  </app-custom-component-wrapper>
+  </ofe-custom-component-wrapper>
   <div class="cds--form-item">
     <!--LEAF CONTROL-->
     <div class="question-area">
@@ -188,17 +187,17 @@
           else nativeControls
         "
       >
-        <app-custom-control-wrapper
+        <ofe-custom-control-wrapper
           [formControlName]="node.question.key"
           [id]="node.question.key + 'id'"
           [question]="node.question"
         >
-        </app-custom-control-wrapper>
+        </ofe-custom-control-wrapper>
       </div>
 
       <ng-template #nativeControls>
         <div class="afe-control" [ngSwitch]="node.question.renderingType">
-          <ibm-select
+          <ofe-select
             [theme]="theme"
             *ngSwitchCase="'select'"
             [formControlName]="node.question.key"
@@ -207,21 +206,21 @@
             <option *ngFor="let o of node.question.options" [value]="o.value">
               {{ o.label }}
             </option>
-          </ibm-select>
+          </ofe-select>
 
           <div *ngSwitchCase="'file'">
-            <app-file-upload
+            <ofe-file-upload
               [dataSource]="dataSource"
               [formControlName]="node.question.key"
               [id]="node.question.key + 'id'"
               (fileChanged)="upload($event)"
             >
-            </app-file-upload>
+            </ofe-file-upload>
           </div>
 
           <textarea
             [theme]="theme"
-            ibmTextArea
+            ofeTextAreaInput
             [ngClass]="{
               'cds--text-area--light': theme === 'light',
               'cds--text-area--invalid': !node.control.valid
@@ -236,7 +235,7 @@
           >
           </textarea>
 
-          <ngx-remote-select
+          <ofe-remote-select
             [theme]="theme"
             *ngSwitchCase="'remote-select'"
             [placeholder]="node.question.placeholder"
@@ -245,9 +244,9 @@
             [componentID]="node.question.key + 'id'"
             [formControlName]="node.question.key"
             [id]="node.question.key + 'id'"
-          ></ngx-remote-select>
+          ></ofe-remote-select>
 
-          <ngx-datetimepicker
+          <ofe-ngx-date-time-picker
             [weeks]="node.question.extras.questionOptions.weeksList"
             [showWeeks]="node.question.showWeeksAdder"
             [theme]="theme"
@@ -256,7 +255,7 @@
             *ngSwitchCase="'date'"
             [datePickerFormat]="node.question.datePickerFormat"
           >
-          </ngx-datetimepicker>
+          </ofe-ngx-date-time-picker>
           <ng-select
             [ngClass]="{ 'afe-custom': theme === 'light' }"
             [id]="node.question.key + 'id'"
@@ -284,7 +283,7 @@
           >
           </ng-select>
 
-          <number-input
+          <ofe-number-input
             [theme]="theme"
             *ngSwitchCase="'number'"
             [id]="node.question.key + 'id'"
@@ -293,12 +292,12 @@
             [formControlName]="node.question.key"
             [attr.placeholder]="node.question.placeholder"
           >
-          </number-input>
+          </ofe-number-input>
 
           <input
             [theme]="theme"
             class="cds--text-input"
-            ibmText
+            ofeTextInput
             *ngSwitchDefault
             [formControlName]="node.question.key"
             [attr.placeholder]="node.question.placeholder"
@@ -308,17 +307,22 @@
           />
 
           <div *ngSwitchCase="'radio'">
-            <radio [id]="node.question.key + 'id'" [formControlName]="node.question.key"
-                   [options]="node.question.options" [selected]="node.control.value" [allowRadioUnselect]="node.question.allowRadioUnselect"></radio>
+            <ofe-radio-button
+              [id]="node.question.key + 'id'"
+              [formControlName]="node.question.key"
+              [options]="node.question.options"
+              [selected]="node.control.value"
+              [allowRadioUnselect]="node.question.allowRadioUnselect"
+            ></ofe-radio-button>
           </div>
 
           <div *ngSwitchCase="'checkbox'">
-            <checkbox
+            <ofe-checkbox
               [id]="node.question.key + 'id' + controlId"
               [formControlName]="node.question.key"
               [options]="node.question.options"
               [selected]="node.control.value"
-            ></checkbox>
+            ></ofe-checkbox>
           </div>
 
           <div
@@ -353,7 +357,7 @@
                 </div>
                 <button
                   type="button"
-                  [node]="node"
+                  ofeNode="node"
                   [name]="'historyValue'"
                   class="cds--btn cds--btn--primary cds--btn--sm col-xs-3"
                 >
@@ -362,7 +366,7 @@
               </div>
             </div>
           </div>
-          <appointments-overview [node]="node"></appointments-overview>
+          <ofe-appointments-overview [node]="node"></ofe-appointments-overview>
           <div *ngIf="hasErrors()">
             <div *ngFor="let e of errors()">
               <span class="text-danger">{{ e }}</span>
@@ -407,13 +411,13 @@
       <div [ngSwitch]="node.question.extras.type">
         <div *ngSwitchCase="'testOrder'">
           <div *ngFor="let child of node.children; let i = index">
-            <form-renderer
+            <ofe-form-renderer
               *ngFor="let question of child.question.questions"
               [parentComponent]="this"
               [node]="child.children[question.key]"
               [parentGroup]="child.control"
               [labelMap]="labelMap"
-            ></form-renderer>
+            ></ofe-form-renderer>
             <div>{{ child.orderNumber }}</div>
             <button
               type="button "
@@ -437,14 +441,14 @@
 
         <div *ngSwitchCase="'obsGroup'" style="margin-bottom: 20px">
           <div *ngFor="let child of node.children; let i = index">
-            <form-renderer
+            <ofe-form-renderer
               *ngFor="let question of child.question.questions"
               [parentComponent]="this"
               [node]="child.children[question.key]"
               [parentGroup]="child.control"
               [labelMap]="labelMap"
               [controlId]="i"
-            ></form-renderer>
+            ></ofe-form-renderer>
             <button
               type="button"
               style="width: 100px"
@@ -484,25 +488,25 @@
   <!--GROUP-->
   <div [ngSwitch]="node.question.renderingType">
     <div *ngSwitchCase="'group'">
-      <form-renderer
+      <ofe-form-renderer
         *ngFor="let question of node.question.questions"
         [parentComponent]="this"
         [node]="node.children[question.key]"
         [parentGroup]="node.control"
         [labelMap]="labelMap"
-      ></form-renderer>
+      ></ofe-form-renderer>
     </div>
     <div
       *ngSwitchCase="'field-set'"
       style="border: 1px solid #eeeeee; padding: 2px; margin: 2px"
     >
-      <form-renderer
+      <ofe-form-renderer
         *ngFor="let question of node.question.questions"
         [parentComponent]="this"
         [node]="node.children[question.key]"
         [parentGroup]="node.control"
         [labelMap]="labelMap"
-      ></form-renderer>
+      ></ofe-form-renderer>
     </div>
   </div>
 </div>

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -19,7 +19,7 @@ import { QuestionGroup } from '../question-models/group-question';
 import { ValidationErrors } from '@angular/forms';
 
 @Component({
-  selector: 'form-renderer',
+  selector: 'ofe-form-renderer',
   templateUrl: 'form-renderer.component.html',
   styleUrls: ['../../style/app.css', './form-renderer.component.css']
 })

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/date-question-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/date-question-options.ts
@@ -1,4 +1,3 @@
 import { BaseOptions } from '../interfaces/base-options';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DateQuestionOptions extends BaseOptions {}

--- a/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
@@ -38,7 +38,6 @@ export class EncounterAdapter implements ValueAdapter {
       switch (node.question.extras.type) {
         case 'encounterDatetime':
           if (payload['encounterDatetime']) {
-            
             node.control.setValue(
               moment(payload['encounterDatetime']).toDate()
             );
@@ -185,7 +184,7 @@ export class EncounterAdapter implements ValueAdapter {
 
     if (rootNode instanceof GroupNode) {
       const node = rootNode as GroupNode;
-      // eslint-disable-next-line guard-for-in
+
       for (const o in node.children) {
         if (node.children[o] instanceof NodeBase) {
           this._getEncounterNodes(node.children[o], array);

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -142,7 +142,7 @@ export class ObsAdapterHelper {
       let dateField: LeafNode; // other member to be manipulated by user
 
       const nodeAsGroup = node as GroupNode;
-      // eslint-disable-next-line guard-for-in
+
       for (const o in nodeAsGroup.children) {
         if (
           (nodeAsGroup.children[o] as LeafNode).question.extras.questionOptions
@@ -176,7 +176,7 @@ export class ObsAdapterHelper {
     if (node && obs.length > 0) {
       const groupNode = node as GroupNode;
       groupNode.initialValue = obs[0];
-      // eslint-disable-next-line guard-for-in
+
       for (const o in groupNode.children) {
         this.setNodeValue(groupNode.children[o], obs[0].groupMembers);
       }
@@ -207,7 +207,7 @@ export class ObsAdapterHelper {
       case 'unknown':
         if (node instanceof GroupNode) {
           const groupNode = node as GroupNode;
-          // eslint-disable-next-line guard-for-in
+
           for (const o in groupNode.children) {
             this.setNodeValue(groupNode.children[o], obs);
           }
@@ -374,7 +374,6 @@ export class ObsAdapterHelper {
     let dateField: LeafNode; // other member to be manipulated by user
 
     const nodeAsGroup = node as GroupNode;
-    // eslint-disable-next-line guard-for-in
     for (const o in nodeAsGroup.children) {
       if (
         (nodeAsGroup.children[o] as LeafNode).question.extras.questionOptions
@@ -532,7 +531,7 @@ export class ObsAdapterHelper {
       case 'unknown':
         if (node instanceof GroupNode) {
           const groupNode = node as GroupNode;
-          // eslint-disable-next-line guard-for-in
+
           for (const o in groupNode.children) {
             const groupNodePayoad = this.getObsNodePayload(
               groupNode.children[o]

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs.adapter.ts
@@ -131,7 +131,6 @@ export class ObsValueAdapter implements ValueAdapter {
     let valueField: any;
     let dateField: any;
 
-    // eslint-disable-next-line guard-for-in
     for (const o in node.children) {
       if (
         (node.children[o] as LeafNode).question.extras.questionOptions
@@ -355,14 +354,12 @@ export class ObsValueAdapter implements ValueAdapter {
     const newPayload = [];
     for (const obs of payload) {
       const groupPayload = [];
-      /* eslint-disable */
       for (let key in obs.value) {
         let concept = key.split(':')[0];
         let value = key.split(':')[1];
         groupPayload.push({ concept: concept, value: value });
       }
       newPayload.push({ concept: groupConcept, groupMembers: groupPayload });
-      /* eslint-enable */
     }
     return newPayload;
   }
@@ -433,7 +430,6 @@ export class ObsValueAdapter implements ValueAdapter {
     let valueField: any;
     let dateField: any;
 
-    // eslint-disable-next-line guard-for-in
     for (const o in node.children) {
       if (
         (node.children[o] as LeafNode).question.extras.questionOptions

--- a/projects/ngx-formentry/src/form-entry/value-adapters/order.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/order.adapter.ts
@@ -185,7 +185,6 @@ export class OrderValueAdapter implements ValueAdapter {
                 break;
               case 'repeating':
                 if (formNode.children) {
-                  // eslint-disable-next-line guard-for-in
                   for (const node in formNode.children) {
                     const question = formNode.children[node].question;
                     if (

--- a/projects/ngx-formentry/src/form-entry/value-adapters/person-attribute.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/person-attribute.adapter.ts
@@ -86,7 +86,6 @@ export class PersonAttribuAdapter implements ValueAdapter {
 
     if (rootNode instanceof GroupNode) {
       const node = rootNode as GroupNode;
-      // eslint-disable-next-line guard-for-in
       for (const o in node.children) {
         if (node.children[o] instanceof NodeBase) {
           this._getPersonAttributesNodes(node.children[o], array);

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,9 @@
 <div *ngIf="form && form.rootNode">
   <form [formGroup]="form.rootNode.control">
-    <form-renderer [node]="form.rootNode" [labelMap]="labelMap"></form-renderer>
+    <ofe-form-renderer
+      [node]="form.rootNode"
+      [labelMap]="labelMap"
+    ></ofe-form-renderer>
   </form>
 
   <div class="cds--offset-md-2">


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

Fixes a whole host of lint warnings in this repository and cleans up the code to match the Angular [styleguide](https://angular.io/guide/styleguide). These changes involve:

- Setting a [custom prefix](https://angular.io/guide/styleguide#component-custom-prefix) for component and directive selectors - `ofe-` (short for `openmrs form entry`) in this case.
- Amending component and directive selectors to adopt the prefix.
- Removing [prefixes](https://angular.io/guide/styleguide) from output properties.
- Replacing component [host metadata](https://angular.io/guide/styleguide) properties with HostBinding and HostListener decorators.
- Remove `/* eslint-disable */` comments.

## Screenshots

> Before

<img width="904" alt="Screenshot 2022-10-24 at 23 48 50" src="https://user-images.githubusercontent.com/8509731/197626655-1ae0a1a0-c32a-4ddd-8402-d3439c4de85a.png">

> After

<img width="894" alt="Screenshot 2022-10-24 at 23 49 12" src="https://user-images.githubusercontent.com/8509731/197626679-4d9e2c3a-0a4f-4e50-b441-ccec38e3efa5.png">
