### PR TITLE
03-1325: Ability to have arbitrary translations for labels in AMPATH forms.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@angular/router": "^12.2.16",
     "@carbon/styles": "1.x",
     "@ng-select/ng-select": "^7.4.0",
+    "@ngx-translate/core": "^13.0.0",
+    "@ngx-translate/http-loader": "^6.0.0",
     "core-js": "^2.5.4",
     "font-awesome": "^4.7.0",
     "hammerjs": "^2.0.8",

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -44,6 +44,7 @@ import { InputModule } from '../components/input/input.module';
 import { CustomControlWrapperModule } from '../components/custom-control-wrapper/custom-control-wrapper..module';
 import { LazyElementsModule } from '@angular-extensions/elements';
 import { CustomComponentWrapperModule } from '../components/custom-component-wrapper/custom-component-wrapper..module';
+import { TranslateModule } from '@ngx-translate/core';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -64,7 +65,8 @@ import { CustomComponentWrapperModule } from '../components/custom-component-wra
     SharedModule,
     CustomControlWrapperModule,
     CustomComponentWrapperModule,
-    NgxTabSetModule.forRoot()
+    NgxTabSetModule.forRoot(),
+    TranslateModule.forRoot()
   ],
   declarations: [
     FormRendererComponent,
@@ -102,7 +104,8 @@ import { CustomComponentWrapperModule } from '../components/custom-component-wra
     AfeNgSelectComponent,
     ErrorRendererComponent,
     DateTimePickerModule,
-    NgxDateTimePickerModule
+    NgxDateTimePickerModule,
+    TranslateModule
   ]
 })
 export class FormEntryModule {}

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -283,7 +283,7 @@
           >
           </ng-select>
 
-          <input
+          <ofe-number-input
             [theme]="theme"
             *ngSwitchCase="'number'"
             [id]="node.question.key + 'id'"
@@ -292,9 +292,9 @@
             [formControlName]="node.question.key"
             [attr.placeholder]="node.question.placeholder | translate"
           >
-          </input>
+          </ofe-number-input>
 
-          <ofe-number-input
+          <input
             [theme]="theme"
             class="cds--text-input"
             ofeTextInput
@@ -304,8 +304,7 @@
             [type]="node.question.renderingType"
             [id]="node.question.key + 'id'"
             [readOnly]="node.question.extras.readOnly"
-          >
-          </ofe-number-input>
+          />
 
           <div *ngSwitchCase="'radio'">
             <ofe-radio-button

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -24,10 +24,10 @@
         <div class="cds--inline-notification__details">
           <div class="cds--inline-notification__text-wrapper">
             <p class="cds--inline-notification__title">
-              {{ errorNode.question.label }}
+              {{ errorNode.question.label | translate }}
             </p>
             <p class="cds--inline-notification__subtitle">
-              {{ getControlError(errorNode) }}
+              {{ getControlError(errorNode | translate) }}
             </p>
           </div>
         </div>
@@ -294,7 +294,7 @@
           >
           </input>
 
-          <input
+          <ofe-number-input
             [theme]="theme"
             class="cds--text-input"
             ofeTextInput
@@ -304,7 +304,8 @@
             [type]="node.question.renderingType"
             [id]="node.question.key + 'id'"
             [readOnly]="node.question.extras.readOnly"
-          />
+          >
+          </ofe-number-input>
 
           <div *ngSwitchCase="'radio'">
             <ofe-radio-button

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -6,7 +6,7 @@
       *ngFor="let question of node.question.questions; let i = index"
     >
       <ofe-form-renderer
-        [node]="node.children[question.key]"
+        [node]="node.children[question.key] | translate"
         [parentComponent]="this"
         [parentGroup]="node.control"
         [labelMap]="labelMap"
@@ -174,11 +174,11 @@
         *ngIf="node.question.label"
         [style.color]="hasErrors() ? 'red' : ''"
         class="cds--label"
-        [attr.for]="node.question.key"
+        [attr.for]="node.question.key | translate"
       >
         {{ node.question.required ? '*' : '' }}
-        {{ node.question.prefix ? node.question.prefix + ' ' : ''
-        }}{{ node.question.label | translate }}
+        {{ node.question.prefix ? node.question.prefix + ' ' : ''}}
+        {{ node.question.label | translate }}
       </label>
 
       <div
@@ -300,7 +300,7 @@
             ofeTextInput
             *ngSwitchDefault
             [formControlName]="node.question.key"
-            [attr.placeholder]="node.question.placeholder"
+            [attr.placeholder]="node.question.placeholder | translate"
             [type]="node.question.renderingType"
             [id]="node.question.key + 'id'"
             [readOnly]="node.question.extras.readOnly"

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -2,7 +2,7 @@
 <div *ngIf="node.question.renderingType === 'form'">
   <ofe-tab-set (tabSelect)="tabSelected($event)" [selectedIndex]="activeTab">
     <ofe-tab
-      [tabTitle]="question.label"
+      [tabTitle]="question.label | translate"
       *ngFor="let question of node.question.questions; let i = index"
     >
       <ofe-form-renderer
@@ -104,7 +104,7 @@
         <path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
       </svg>
       <p class="cds--accordion__title">
-        {{ node.question.label }}
+        {{ node.question.label | translate }}
       </p>
     </button>
     <div ofeCollapse="isCollapsed">
@@ -178,7 +178,7 @@
       >
         {{ node.question.required ? '*' : '' }}
         {{ node.question.prefix ? node.question.prefix + ' ' : ''
-        }}{{ node.question.label }}
+        }}{{ node.question.label | translate }}
       </label>
 
       <div
@@ -204,7 +204,7 @@
             [id]="node.question.key + 'id'"
           >
             <option *ngFor="let o of node.question.options" [value]="o.value">
-              {{ o.label }}
+              {{ o.label | translate }}
             </option>
           </ofe-select>
 
@@ -225,7 +225,7 @@
               'cds--text-area--light': theme === 'light',
               'cds--text-area--invalid': !node.control.valid
             }"
-            [placeholder]="node.question.placeholder"
+            [placeholder]="node.question.placeholder | translate"
             [rows]="node.question.rows"
             class="cds--text-area"
             *ngSwitchCase="'textarea'"
@@ -238,7 +238,7 @@
           <ofe-remote-select
             [theme]="theme"
             *ngSwitchCase="'remote-select'"
-            [placeholder]="node.question.placeholder"
+            [placeholder]="node.question.placeholder | translate"
             tabindex="0"
             [dataSource]="dataSource"
             [componentID]="node.question.key + 'id'"
@@ -261,7 +261,7 @@
             [id]="node.question.key + 'id'"
             *ngSwitchCase="'multi-select'"
             [items]="node.question.options"
-            bindLabel="label"
+            bindLabel="label | translate"
             bindValue="value"
             [multiple]="true"
             placeholder=""
@@ -275,7 +275,7 @@
             [id]="node.question.key + 'id'"
             *ngSwitchCase="'single-select'"
             [items]="node.question.options"
-            bindLabel="label"
+            bindLabel="label | translate"
             bindValue="value"
             placeholder=""
             clearAllText="Clear"
@@ -283,16 +283,16 @@
           >
           </ng-select>
 
-          <ofe-number-input
+          <input
             [theme]="theme"
             *ngSwitchCase="'number'"
             [id]="node.question.key + 'id'"
             [min]="node.question.extras.questionOptions.min"
             [max]="node.question.extras.questionOptions.max"
             [formControlName]="node.question.key"
-            [attr.placeholder]="node.question.placeholder"
+            [attr.placeholder]="node.question.placeholder | translate"
           >
-          </ofe-number-input>
+          </input>
 
           <input
             [theme]="theme"
@@ -385,7 +385,7 @@
           node.question.extras.questionInfo !== ' '
         "
       >
-        {{ node.question.extras.questionInfo }}
+        {{ node.question.extras.questionInfo | translate }}
       </div>
     </div>
   </div>
@@ -398,7 +398,7 @@
   <!--ARRAY CONTROL-->
   <div [ngSwitch]="node.question.renderingType">
     <div class="well" style="padding: 2px" *ngSwitchCase="'repeating'">
-      <h4 style="margin: 2px; font-weight: bold">{{ node.question.label }}</h4>
+      <h4 style="margin: 2px; font-weight: bold">{{ node.question.label | translate }}</h4>
       <div>
         <label class="cds--label" *ngIf="node.question.extras.questionOptions.min" style="margin-right: 2px">min:
           {{ node.question.extras.questionOptions.min }}</label>

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -17,6 +17,7 @@ import { DataSource } from '../question-models/interfaces/data-source';
 import { FormErrorsService } from '../services/form-errors.service';
 import { QuestionGroup } from '../question-models/group-question';
 import { ValidationErrors } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'ofe-form-renderer',
@@ -47,6 +48,7 @@ export class FormRendererComponent implements OnInit, OnChanges {
     private validationFactory: ValidationFactory,
     private dataSources: DataSources,
     private formErrorsService: FormErrorsService,
+    public translate: TranslateService,
     @Inject(DOCUMENT) private document: any
   ) {
     this.activeTab = 0;

--- a/projects/ngx-formentry/src/shared.module.ts
+++ b/projects/ngx-formentry/src/shared.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SecurePipe } from './components/file-upload/secure.pipe';
 import { DataSources } from './form-entry/data-sources/data-sources';
+import { TranslateModule } from '@ngx-translate/core';
 @NgModule({
   declarations: [SecurePipe],
   imports: [CommonModule],
-  exports: [SecurePipe],
+  exports: [SecurePipe, TranslateModule],
   providers: [DataSources]
 })
 export class SharedModule {}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { FormGroup } from '@angular/forms';
 
 import { Subscriber, Observable, Subject, of, Observer } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
 
 import {
   QuestionFactory,
@@ -45,7 +46,9 @@ export class AppComponent implements OnInit {
     private encAdapter: EncounterAdapter,
     private dataSources: DataSources,
     private formErrorsService: FormErrorsService,
-    private http: HttpClient
+    private http: HttpClient,
+    private translate: TranslateService
+
   ) {
     this.schema = adultForm;
   }
@@ -221,6 +224,28 @@ export class AppComponent implements OnInit {
         this.labelMap[concept.reqId] = concept.display;
       });
     });
+
+    this.translate.currentLang = 'fr';
+    this.fetchMockedTranslationsData().then((translationsData: any) => {
+      this.translate.setTranslation(translationsData.language, translationsData.translations);
+    });
+
+  }
+
+  fetchMockedTranslationsData() {
+    const promise = new Promise(function (resolve, reject) {
+      setTimeout(function () {
+        const translationsData = {
+          "uuid": "510bb364-6928-42ea-9458-a46bfc2eebc6",
+          "language": "fr",
+          "translations": {
+            "Encounter Details": "Détails de la rencontre",
+          }
+        };
+        resolve(translationsData);
+      }, 2000);
+    });
+    return promise;
   }
 
   fetchMockedConceptData(concepts) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,6 +16,7 @@ import {
   FormErrorsService
 } from '@openmrs/ngx-formentry';
 import { MockObs } from './mock/mock-obs';
+import { mockTranslationsData } from './mock/mock-translations';
 
 const adultForm = require('./adult-1.6.json');
 const adultFormObs = require('./mock/obs.json');
@@ -36,6 +37,7 @@ export class AppComponent implements OnInit {
   encounterObject = adultFormObs;
   showingEncounterViewer = false;
   public header = 'UMD Demo';
+  currentLanguage = 'fr';
   labelMap = {};
 
   constructor(
@@ -225,23 +227,20 @@ export class AppComponent implements OnInit {
       });
     });
 
-    this.translate.currentLang = 'fr';
+
+    this.translate.currentLang = this.currentLanguage;
     this.fetchMockedTranslationsData().then((translationsData: any) => {
       this.translate.setTranslation(translationsData.language, translationsData.translations);
     });
 
   }
 
+
+
   fetchMockedTranslationsData() {
     const promise = new Promise(function (resolve, reject) {
       setTimeout(function () {
-        const translationsData = {
-          "uuid": "510bb364-6928-42ea-9458-a46bfc2eebc6",
-          "language": "fr",
-          "translations": {
-            "Encounter Details": "Détails de la rencontre",
-          }
-        };
+        const translationsData = mockTranslationsData.find(translation => translation.language === 'fr')
         resolve(translationsData);
       }, 2000);
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,7 +37,7 @@ export class AppComponent implements OnInit {
   encounterObject = adultFormObs;
   showingEncounterViewer = false;
   public header = 'UMD Demo';
-  currentLanguage = 'fr';
+  currentLanguage = 'km';
   labelMap = {};
 
   constructor(
@@ -240,7 +240,7 @@ export class AppComponent implements OnInit {
   fetchMockedTranslationsData() {
     const promise = new Promise(function (resolve, reject) {
       setTimeout(function () {
-        const translationsData = mockTranslationsData.find(translation => translation.language === 'fr')
+        const translationsData = mockTranslationsData.find(translation => translation.language === 'km')
         resolve(translationsData);
       }, 2000);
     });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,9 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormEntryModule } from '@openmrs/ngx-formentry';
 import { AppComponent } from './app.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
 
 @NgModule({
   declarations: [AppComponent],
@@ -14,7 +17,10 @@ import { AppComponent } from './app.component';
     BrowserAnimationsModule,
     FormEntryModule,
     HttpClientModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    TranslateModule.forRoot({
+      defaultLanguage: 'en'
+    })
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,9 +5,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormEntryModule } from '@openmrs/ngx-formentry';
 import { AppComponent } from './app.component';
-import { TranslateModule } from '@ngx-translate/core';
-import { of } from 'rxjs';
-
+import { NgxTranslateModule } from './translate/translate.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -18,9 +16,7 @@ import { of } from 'rxjs';
     FormEntryModule,
     HttpClientModule,
     ReactiveFormsModule,
-    TranslateModule.forRoot({
-      defaultLanguage: 'en'
-    })
+    NgxTranslateModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/mock/mock-translations.ts
+++ b/src/app/mock/mock-translations.ts
@@ -1,0 +1,76 @@
+const frTranslations = {
+  "uuid": "510bb364-6928-42ea-9458-a46bfc2eebc6",
+  "language": "fr",
+  "translations": {
+    "Encounter Details": "Détails de la rencontre",
+    "Vitals": "signes vitaux",
+    "Test Results": "Résultats de test",
+    "Clinical History": "Histoire clinique",
+    "Pre-Clinic Review": "Examen pré-clinique",
+    "This is custom component within a page it is displayed at the top of the page":"Il s'agit d'un composant personnalisé dans une section, il est affiché en haut de la section",
+    "Custom Control Test": "Test de contrôle personnalisé",
+    "Current Symptoms": "Symptômes actuels",
+    "Assessment": "Évaluation",
+    "Medication Plan": "Régime de médicaments",
+    "Plan": "Planifier",
+    "Facility name (site/satellite clinic required)": "Nom de l'établissement (site/clinique satellite requis)",
+    "Visit date": "Date de visite",
+    "Provider": "Fournisseur"
+  }
+};
+
+const kmTranslations = {
+  "uuid": "510bb364-6928-42ea-9458-a46bfc2eebc7",
+  "language": "km",
+  "translations": {
+    "Encounter Details": "ព័ត៌មានលម្អិតនៃការជួប",
+    "Pre-Clinic Review": "ការពិនិត្យឡើងវិញមុនគ្លីនិក",
+    "Clinical History": "ប្រវត្តិគ្លីនិក",
+    "Medical History": "ប្រវត្តិវេជ្ជសាស្ត្",
+    "Vitals": "វីតាល់",
+    "Test Results": "លទ្ធផល​តេ​ស្",
+    "This is custom component within a page it is displayed at the top of the page":"នេះគឺជាសមាសភាគផ្ទាល់ខ្លួននៅក្នុងផ្នែកដែលវាត្រូវបានបង្ហាញនៅផ្នែកខាងលើនៃផ្នែក",
+    "Custom Control Test": "ការធ្វើតេស្តត្រួតពិនិត្យផ្ទាល់ខ្លួន",
+    "Current Symptoms": "រោគសញ្ញាបច្ចុប្បន្ន",
+    "Assessment": "ការវាយតម្លៃ",
+    "Medication Plan": "ផែនការថ្នាំ",
+    "Plan": "ផែនការ",
+    "Facility name (site/satellite clinic required)": "ឈ្មោះកន្លែងប្រើប្រាស់ (ទាមទារកន្លែង/គ្លីនិកផ្កាយរណប)",
+    "Visit date": "កាលបរិច្ឆេទទស្សនា",
+    "Provider": "អ្នកផ្តល់សេវា"
+  }
+};
+
+const esTranslations = {
+  "uuid": "510bb364-6928-42ea-9458-a46bfc2eebc8",
+  "language": "es",
+  "translations": {
+    "Encounter Details": "Detalles del encuentro",
+    "Test Results": "Resultados de la prueba",
+    "Vitals": "partes vitales",
+    "Clinical History": "Historial clinico",
+    "Pre-Clinic Review": "Revisión preclínica",
+    "This is custom component within a page it is displayed at the top of the page": "Este es un componente personalizado dentro de una sección que se muestra en la parte superior de la sección",
+    "Custom Control Test": "Prueba de control personalizado",
+    "Current Symptoms": "Síntomas actuales",
+    "Assessment": "Evaluación",
+    "Medication Plan": "Plan de medicamentos",
+    "Plan": "Plan",
+    "Facility name (site/satellite clinic required)": "Nombre del centro (sitio/clínica satélite requerida)",
+    "Visit date": "Fecha de visita",
+    "Provider": "Proveedor"
+  }
+};
+
+const mockTranslationsData = [
+  esTranslations,
+  kmTranslations,
+  frTranslations
+];
+
+export {
+  esTranslations,
+  kmTranslations,
+  frTranslations,
+  mockTranslationsData
+};

--- a/src/app/mock/mock-translations.ts
+++ b/src/app/mock/mock-translations.ts
@@ -26,7 +26,7 @@ const kmTranslations = {
     "Encounter Details": "ព័ត៌មានលម្អិតនៃការជួប",
     "Pre-Clinic Review": "ការពិនិត្យឡើងវិញមុនគ្លីនិក",
     "Clinical History": "ប្រវត្តិគ្លីនិក",
-    "Medical History": "ប្រវត្តិវេជ្ជសាស្ត្",
+    "Medication History": "ប្រវត្តិវេជ្ជសាស្ត្",
     "Vitals": "វីតាល់",
     "Test Results": "លទ្ធផល​តេ​ស្",
     "This is custom component within a page it is displayed at the top of the page":"នេះគឺជាសមាសភាគផ្ទាល់ខ្លួននៅក្នុងផ្នែកដែលវាត្រូវបានបង្ហាញនៅផ្នែកខាងលើនៃផ្នែក",

--- a/src/app/translate/translate.module.ts
+++ b/src/app/translate/translate.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { TranslateModule } from '@ngx-translate/core';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    HttpClientModule,
+    TranslateModule.forRoot({
+      defaultLanguage: 'en',
+    }),
+  ],
+  exports: [TranslateModule],
+})
+export class NgxTranslateModule { }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,6 +1427,20 @@
   resolved "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.2.18.tgz"
   integrity sha512-6h/QSG6oZDs2BGfrozdOKqtM5daoCu05q+0gyb3owHz1u9FtMeXXKQ3sQfyFC/GNT3dTMlH6YFxsJPvMPwuy9A==
 
+"@ngx-translate/core@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@ngx-translate/core/-/core-13.0.0.tgz#60547cb8a0845a2a0abfde6b0bf5ec6516a63fd6"
+  integrity sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==
+  dependencies:
+    tslib "^2.0.0"
+
+"@ngx-translate/http-loader@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz#041393ab5753f50ecf64262d624703046b8c7570"
+  integrity sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==
+  dependencies:
+    tslib "^2.0.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary
- Add support for i18n translation in our forms
- Apply translation support on form labels and placeholder
- Add some mock translations

## Screenshots

## Spanish
<img width="1440" alt="Screenshot 2022-11-20 at 16 20 31" src="https://user-images.githubusercontent.com/30952856/202904454-0063c054-d57f-4ac5-b939-dc1f1822927a.png">

## Kmer
<img width="1440" alt="Screenshot 2022-11-20 at 16 20 09" src="https://user-images.githubusercontent.com/30952856/202904470-efb97c00-f59e-419c-861e-eb6c55d8fb78.png">

## French
<img width="1440" alt="Screenshot 2022-11-20 at 16 19 38" src="https://user-images.githubusercontent.com/30952856/202904476-bd3de8aa-3fd0-4c5b-a14b-03bfddba7b2d.png">


## Failure
- For some reason, the labels are not getting translated, it could be because of the nesting that is involved to get labels @ibacher @FlorianRappl please advise on how to apply translations to labels like `Visit date` , `Provider` etc
## Issue
[Ability to have arbitrary translations for labels in AMPATH forms](https://issues.openmrs.org/browse/O3-1325)

## Other
- Branched off this PR to add more work https://github.com/openmrs/openmrs-ngx-formentry/pull/4
