### PR TITLE
O3-1661: mostRecentObsValueBefore data source in AMPATH forms.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -111,6 +111,13 @@ export class AppComponent implements OnInit {
     const obs = new MockObs();
     this.dataSources.registerDataSource('rawPrevEnc', obs.getObs());
 
+
+    const mostRecentObsValueBefore = (date: string, obsConcepts) => {
+      const filteredObs = obsConcepts.filter((ob) => ob.obsDatetime.split('T')[0] < date);
+      return filteredObs;
+    }
+
+    this.dataSources.registerDataSource('mostRecentObsValueBefore', mostRecentObsValueBefore('2016-06-10', obs.getObs().obs));
     this.dataSources.registerDataSource('patient', { sex: 'M' }, true);
 
     this.dataSources.registerDataSource('patientInfo', {
@@ -152,9 +159,9 @@ export class AppComponent implements OnInit {
       }
     });
 
+
     // Create form
     this.createForm();
-
     // Set encounter, obs, orders
     adultFormObs.orders = formOrdersPayload.orders;
     this.encAdapter.populateForm(this.form, adultFormObs);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary
- Adds a data source that has a function that returns all obs values before a given date.


## Screenshots
This is an example of the logs showing all obs/concepts and filtered ones based on the date supplied
<img width="1430" alt="Screenshot 2022-12-07 at 15 34 50" src="https://user-images.githubusercontent.com/30952856/206181950-80ef9aef-0350-4e16-96fa-cc92fc912b1c.png">

## Issue
[mostRecentObsValueBefore data source in AMPATH forms](https://issues.openmrs.org/browse/O3-1661)


## Other
- I used the `mock-obs`, and I wasn't sure of the date format which will be passed, so this is not yet perfect, it is based on assumptions of a date format and some hardcording.
