### PR TITLE
(feat) Support for an encounter of previous obs values

### DIFF
--- a/projects/ngx-formentry/src/form-entry/helpers/historical-expression-helper-service.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/historical-expression-helper-service.ts
@@ -14,19 +14,22 @@ export class HistoricalHelperService {
 
   public evaluate(
     expr: string,
-    dataSources: any,
-    additionalScopevalues: any
-  ): any {
+    dataSources: Record<string, unknown>,
+    additionalScopeValues: Record<string, unknown> | null,
+  ) {
     const HD = new HistoricalEncounterDataService();
     HD.registerEncounters('prevEnc', dataSources['rawPrevEnc']);
-    const deps: any = {
-      HD: HD
-    };
+    if (dataSources.hasOwnProperty('rawPrevObs')) {
+      HD.registerEncounters('prevObs', dataSources['rawPrevObs']);
+    }
 
-    if (additionalScopevalues) {
-      for (const o in additionalScopevalues) {
-        if (additionalScopevalues[o]) {
-          deps[o] = additionalScopevalues[o];
+    const deps = { HD };
+
+    if (additionalScopeValues) {
+      for (const o in additionalScopeValues) {
+        const value = additionalScopeValues[o];
+        if (typeof value !== 'undefined' && value !== null) {
+          deps[o] = value;
         }
       }
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

This is a companion for the PR on [patient chart](https://github.com/openmrs/openmrs-esm-patient-chart/pull/903) to allow the form engine to use values from previous observations not necessarily on the form.

This behaviour is opt-in. A question can register its concept to get the most recent value by setting the questionOption `useMostRecentValue` to `true` or `'true'`. Once that's done the most recent value for the concept associated with the question will be available in the historical data source under the pseudo-encounter "prevObs".

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
