### PR TITLE
(fix) Restore the ability to use historical values

### DIFF
--- a/projects/ngx-formentry/src/form-entry/directives/historical-value.directive.ts
+++ b/projects/ngx-formentry/src/form-entry/directives/historical-value.directive.ts
@@ -11,7 +11,8 @@ import * as _ from 'lodash';
 import { NodeBase } from '../form-factory/form-node';
 
 @Directive({
-  selector: `[ofeNode]`
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: `[node]`
 })
 export class HistoricalValueDirective {
   @Input() _node: NodeBase;
@@ -26,8 +27,8 @@ export class HistoricalValueDirective {
     if (e.target.name === 'historyValue') {
       if (
         this._node &&
-        (!this.compareString(this._node.question.renderingType, 'page') ||
-          !this.compareString(this._node.question.renderingType, 'section'))
+        (!this.compareStrings(this._node.question.renderingType, 'page') ||
+          !this.compareStrings(this._node.question.renderingType, 'section'))
       ) {
         this._node.control.setValue(
           this._node.question.historicalDataValue.value
@@ -41,13 +42,7 @@ export class HistoricalValueDirective {
       }
     }
   }
-  private compareString(a, b) {
-    if (a === b) {
-      return true;
-    } else {
-      return false;
-    }
-  }
+
   @Input()
   set node(node: NodeBase) {
     if (node) {
@@ -78,5 +73,9 @@ export class HistoricalValueDirective {
         }
       }
     }
+  }
+
+  private compareStrings(a: string, b: string): boolean {
+    return a === b;
   }
 }

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -177,7 +177,7 @@
         [attr.for]="node.question.key | translate"
       >
         {{ node.question.required ? '*' : '' }}
-        {{ node.question.prefix ? node.question.prefix + ' ' : ''}}
+        {{ node.question.prefix ? node.question.prefix + ' ' : '' }}
         {{ node.question.label | translate }}
       </label>
 
@@ -357,7 +357,6 @@
                 </div>
                 <button
                   type="button"
-                  ofeNode="node"
                   [name]="'historyValue'"
                   class="cds--btn cds--btn--primary cds--btn--sm col-xs-3"
                 >


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

This PR restores the ability to use historical values from previous encounters when filling out form fields.

I inadvertently broke this feature in https://github.com/openmrs/openmrs-ngx-formentry/pull/13 when I attempted to rename the `HistoricalValueDirective`'s selector to a name containing our custom prefix (`ofeNode`) which ensured the linter stayed happy. Renaming this selector to anything other than `node` (to match the `node` Input of the `FormRenderer` component) completely breaks everything.

This PR changes the directive's `selector` name back to `[node]` and disables the `eslint/directive-selector` rule check.

Thanks to @enyachoke for reporting this regression on [Slack](https://openmrs.slack.com/archives/CHP5QAE5R/p1672993341776819). Apologies.

## Screenshots

> Screenshot showing a historical value for a form field

<img width="879" alt="Screenshot 2023-01-07 at 01 04 02" src="https://user-images.githubusercontent.com/8509731/211108500-ae438820-5af9-421b-93de-ad94af1d5271.png">
