### PR TITLE
Fix extractObsValue helper and remove console.log in radio button

### DIFF
--- a/projects/ngx-formentry/src/components/radio-button/radio.component.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.ts
@@ -53,7 +53,6 @@ export class RadioButtonControlComponent implements ControlValueAccessor, OnInit
   }
 
   public handleClick(option) {
-    console.log("handleClick", option);
     if (this.allowUnselect && option.checked) {
       option.checked = false;
       // doesn't fire by itself, so we create a synthetic change event
@@ -64,7 +63,6 @@ export class RadioButtonControlComponent implements ControlValueAccessor, OnInit
   }
 
   public handleChange(option) {
-    console.log("handleChange", option);
     if (!option.checked) {
       this.value = undefined;
     } else {

--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -272,7 +272,7 @@ export class JsExpressionHelper {
       obs?.some(o => result = o?.concept?.uuid === uuid ? o : findObs(o.children || [], uuid));
       return result;
     }
-    return findObs(rawEncounter.obs, uuid).value || alternateControl;
+    return findObs(rawEncounter.obs, uuid)?.value || alternateControl;
   }
 
   get helperFunctions() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -112,7 +112,7 @@ export class AppComponent implements OnInit {
     this.dataSources.registerDataSource('rawPrevEnc', obs.getObs());
     this.dataSources.registerDataSource('rawPrevObs', obs.getObs());
 
-    this.dataSources.registerDataSource('patient', { sex: 'M' }, true);
+    this.dataSources.registerDataSource('patient', { sex: 'M', age: 50 }, true);
 
     this.dataSources.registerDataSource('patientInfo', {
       name: 'Test Patient',
@@ -241,7 +241,7 @@ export class AppComponent implements OnInit {
   fetchMockedTranslationsData() {
     const promise = new Promise(function (resolve, reject) {
       setTimeout(function () {
-        const translationsData = mockTranslationsData.find(translation => translation.language === 'km')
+        const translationsData = mockTranslationsData.find(translation => translation.language === 'en')
         resolve(translationsData);
       }, 2000);
     });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

The PR adds a missing null check to the `extractObsValue` helper function. It also defaults the i18n to English

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
