### PR TITLE
(fix) Add null check for undefined rawPrevObs

### DIFF
--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -272,7 +272,7 @@ export class JsExpressionHelper {
       obs?.some(o => result = o?.concept?.uuid === uuid ? o : findObs(o.children || [], uuid));
       return result;
     }
-    return findObs(rawEncounter.obs, uuid)?.value || alternateControl;
+      return findObs(rawEncounter?.obs, uuid)?.value || alternateControl;    
   }
 
   get helperFunctions() {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary
This PR adds a Null check for the raw encounter since the primary use case here https://github.com/openmrs/openmrs-esm-patient-chart/blob/316fe80b69911ecee8267d2fe08a74f76e145cc2/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts#L116 could register a `undefined` data source 

## Screenshots

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/1908926/212820326-89985d43-2bfa-46ad-8956-beae0ee687cc.png">



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
