### PR TITLE
(fix) rename the helper extractObsValue to getObsFromControlOrEncounter and change behaviour

### DIFF
--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.spec.ts
@@ -44,7 +44,7 @@ describe('JS Expression Helper Service:', () => {
 
     let obsValue;
 
-    obsValue = helper.extractObsValue({
+    obsValue = helper.getObsFromControlOrEncounter(null,{
       obs: [{
         uuid: '0bc6ef97-7727-4787-8c16-fc21460ccdydfd',
         obsDatetime: '2016-01-21T01:17:46.000+0300',

--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -263,16 +263,22 @@ export class JsExpressionHelper {
     }
   }
 
-  /*
-   TODO make it possible to bootstrap expressions without control relations to make alternateControl optional as at the moment it required
-   if no other expression on the control as a relationship to another control*/
-  extractObsValue(rawEncounter, uuid, alternateControl?) {
+  /**
+   * Takes a target control, an encounter and concept uuid. If the target control has a value it returns it
+   * otherwise it tries to find it in the encounter. Finally it returns null of it can't find either of them.
+   * @param targetControl 
+   * @param rawEncounter 
+   * @param uuid 
+   * @returns
+   */
+  getObsFromControlOrEncounter(targetControl,rawEncounter,uuid): any {
     const findObs = (obs, uuid) => {
       let result;
-      obs?.some(o => result = o?.concept?.uuid === uuid ? o : findObs(o.children || [], uuid));
+      obs?.some(o => result = o?.concept?.uuid === uuid ? o : findObs(o.groupMembers || [], uuid));
       return result;
     }
-      return findObs(rawEncounter?.obs, uuid)?.value || alternateControl;    
+    const obsValue = findObs(rawEncounter?.obs, uuid)?.value;
+    return !!targetControl ? targetControl : typeof obsValue === 'object' ? obsValue.uuid : !!obsValue ? obsValue : null
   }
 
   get helperFunctions() {
@@ -287,7 +293,7 @@ export class JsExpressionHelper {
       isEmpty: helper.isEmpty,
       arrayContains: helper.arrayContains,
       extractRepeatingGroupValues: helper.extractRepeatingGroupValues,
-      extractObsValue: helper.extractObsValue
+      getObsFromControlOrEncounter: helper.getObsFromControlOrEncounter
     };
   }
 }


### PR DESCRIPTION
…

## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

Rename and change the behaviour of the helper extractObsValue.

```
Takes a target control, an encounter and concept uuid. If the target control has a value it returns it
  otherwise it tries to find it in the encounter. Finally, it returns null of it can't find either of them.
```
## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
