### PR TITLE
(fix):CVD risk calculation should return null if some value is not passed.[KH-62]

### DIFF
--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -171,23 +171,22 @@ export class JsExpressionHelper {
   calcSouthEastAsiaNonLabCVDRisk(sex: 'M' | 'F', smoker?: boolean, age?: number, sbp?: number, bmi?: number) {
     const hasValidValues = (typeof sex === "string" && typeof smoker === "boolean" && typeof age === "number" && typeof sbp === "number" && typeof bmi === "number");
 
-    if (hasValidValues) {
-      // Bin functions
-      const getAgeBin = (age) => Math.floor((Math.min(Math.max(40, age), 74) - 40) / 5);
-      const getSbpBin = (sbp) => Math.max(0, Math.floor((Math.min(sbp, 180) - 120) / 20) + 1);
-      const getBmiBin = (bmi) => Math.max(0, Math.floor((Math.min(bmi, 35) - 20) / 5) + 1);
-
-      // Variables
-      const sexIdx = sex === 'M' ? 0 : 1;
-      const smokerIdx = smoker ? 1 : 0;
-      const ageIdx = 6 - getAgeBin(age);
-      const bmiIdx = getBmiBin(bmi);
-      const sbpIdx = 4 - getSbpBin(sbp);
-
-      return southEastAsiaCvdRiskTables[sexIdx][smokerIdx][ageIdx][sbpIdx][bmiIdx];
+    if (!hasValidValues) {
+      return null;
     }
-    return null;
+    // Bin functions
+    const getAgeBin = (age) => Math.floor((Math.min(Math.max(40, age), 74) - 40) / 5);
+    const getSbpBin = (sbp) => Math.max(0, Math.floor((Math.min(sbp, 180) - 120) / 20) + 1);
+    const getBmiBin = (bmi) => Math.max(0, Math.floor((Math.min(bmi, 35) - 20) / 5) + 1);
 
+    // Variables
+    const sexIdx = sex === 'M' ? 0 : 1;
+    const smokerIdx = smoker ? 1 : 0;
+    const ageIdx = 6 - getAgeBin(age);
+    const bmiIdx = getBmiBin(bmi);
+    const sbpIdx = 4 - getSbpBin(sbp);
+
+    return southEastAsiaCvdRiskTables[sexIdx][smokerIdx][ageIdx][sbpIdx][bmiIdx];
   }
 
   isEmpty(val) {

--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -168,29 +168,26 @@ export class JsExpressionHelper {
 
 
 
-  calcSouthEastAsiaNonLabCVDRisk(sex: 'M' | 'F', smoker: boolean, age: number, sbp: number, bmi: number) {
-    const hasMissingValue = (sex === null || typeof sex === "undefined") ||
-      (smoker === null || typeof smoker === "undefined") ||
-      (isNaN(age) || typeof age === "undefined") ||
-      (isNaN(sbp) || typeof sbp === "undefined") ||
-      (isNaN(bmi) || typeof bmi === "undefined");
+  calcSouthEastAsiaNonLabCVDRisk(sex: 'M' | 'F', smoker?: boolean, age?: number, sbp?: number, bmi?: number) {
+    const hasValidValues = (typeof sex === "string" && typeof smoker === "boolean" && typeof age === "number" && typeof sbp === "number" && typeof bmi === "number");
 
-    if (hasMissingValue) {
-      return null;
+    if (hasValidValues) {
+      // Bin functions
+      const getAgeBin = (age) => Math.floor((Math.min(Math.max(40, age), 74) - 40) / 5);
+      const getSbpBin = (sbp) => Math.max(0, Math.floor((Math.min(sbp, 180) - 120) / 20) + 1);
+      const getBmiBin = (bmi) => Math.max(0, Math.floor((Math.min(bmi, 35) - 20) / 5) + 1);
+
+      // Variables
+      const sexIdx = sex === 'M' ? 0 : 1;
+      const smokerIdx = smoker ? 1 : 0;
+      const ageIdx = 6 - getAgeBin(age);
+      const bmiIdx = getBmiBin(bmi);
+      const sbpIdx = 4 - getSbpBin(sbp);
+
+      return southEastAsiaCvdRiskTables[sexIdx][smokerIdx][ageIdx][sbpIdx][bmiIdx];
     }
-    // Bin functions
-    const getAgeBin = (age) => Math.floor((Math.min(Math.max(40, age), 74) - 40) / 5);
-    const getSbpBin = (sbp) => Math.max(0, Math.floor((Math.min(sbp, 180) - 120) / 20) + 1);
-    const getBmiBin = (bmi) => Math.max(0, Math.floor((Math.min(bmi, 35) - 20) / 5) + 1);
+    return null;
 
-    // Variables
-    const sexIdx = sex === 'M' ? 0 : 1;
-    const smokerIdx = smoker ? 1 : 0;
-    const ageIdx = 6 - getAgeBin(age);
-    const bmiIdx = getBmiBin(bmi);
-    const sbpIdx = 4 - getSbpBin(sbp);
-
-    return southEastAsiaCvdRiskTables[sexIdx][smokerIdx][ageIdx][sbpIdx][bmiIdx];
   }
 
   isEmpty(val) {

--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -181,7 +181,9 @@ export class JsExpressionHelper {
     const bmiIdx = getBmiBin(bmi);
     const sbpIdx = 4 - getSbpBin(sbp);
 
-    return southEastAsiaCvdRiskTables[sexIdx][smokerIdx][ageIdx][sbpIdx][bmiIdx];
+    const hasAllAttributes = sex && smoker && age && sbp && bmi;
+
+    return !hasAllAttributes ? null : southEastAsiaCvdRiskTables[sexIdx][smokerIdx][ageIdx][sbpIdx][bmiIdx];
   }
 
   isEmpty(val) {
@@ -266,9 +268,9 @@ export class JsExpressionHelper {
   /**
    * Takes a target control, an encounter and concept uuid. If the target control has a value it returns it
    * otherwise it tries to find it in the encounter. Finally it returns null of it can't find either of them.
-   * @param targetControl 
-   * @param rawEncounter 
-   * @param uuid 
+   * @param targetControl
+   * @param rawEncounter
+   * @param uuid
    * @returns
    */
   getObsFromControlOrEncounter(targetControl,rawEncounter,uuid): any {

--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -169,6 +169,15 @@ export class JsExpressionHelper {
 
 
   calcSouthEastAsiaNonLabCVDRisk(sex: 'M' | 'F', smoker: boolean, age: number, sbp: number, bmi: number) {
+    const hasMissingValue = (sex === null || typeof sex === "undefined") ||
+      (smoker === null || typeof smoker === "undefined") ||
+      (isNaN(age) || typeof age === "undefined") ||
+      (isNaN(sbp) || typeof sbp === "undefined") ||
+      (isNaN(bmi) || typeof bmi === "undefined");
+
+    if (hasMissingValue) {
+      return null;
+    }
     // Bin functions
     const getAgeBin = (age) => Math.floor((Math.min(Math.max(40, age), 74) - 40) / 5);
     const getSbpBin = (sbp) => Math.max(0, Math.floor((Math.min(sbp, 180) - 120) / 20) + 1);
@@ -181,9 +190,7 @@ export class JsExpressionHelper {
     const bmiIdx = getBmiBin(bmi);
     const sbpIdx = 4 - getSbpBin(sbp);
 
-    const hasAllAttributes = sex && smoker && age && sbp && bmi;
-
-    return !hasAllAttributes ? null : southEastAsiaCvdRiskTables[sexIdx][smokerIdx][ageIdx][sbpIdx][bmiIdx];
+    return southEastAsiaCvdRiskTables[sexIdx][smokerIdx][ageIdx][sbpIdx][bmiIdx];
   }
 
   isEmpty(val) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,7 @@ import {
   OrderValueAdapter,
   EncounterAdapter,
   DataSources,
-  FormErrorsService
+  FormErrorsService,
 } from '@openmrs/ngx-formentry';
 import { MockObs } from './mock/mock-obs';
 import { mockTranslationsData } from './mock/mock-translations';
@@ -49,7 +49,7 @@ export class AppComponent implements OnInit {
     private dataSources: DataSources,
     private formErrorsService: FormErrorsService,
     private http: HttpClient,
-    private translate: TranslateService
+    private translate: TranslateService,
 
   ) {
     this.schema = adultForm;
@@ -231,7 +231,7 @@ export class AppComponent implements OnInit {
 
     this.translate.currentLang = this.currentLanguage;
     this.fetchMockedTranslationsData().then((translationsData: any) => {
-      this.translate.setTranslation(translationsData.language, translationsData.translations);
+      this.translate.setTranslation(translationsData?.language, translationsData?.translations);
     });
 
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

- Checking if all 5 values to be passed to the CVD risk calculation else return null


## Screenshots
- The screenshot below shows the logs that came out of testing when all values are not passed.
- `hasValues` returns `undefined` and the `CVD function` returns `null`

<img width="212" alt="Screenshot 2023-01-25 at 03 05 59" src="https://user-images.githubusercontent.com/30952856/214511339-1063544c-4cda-4700-abf8-de0b71d0f1ec.png">


## Issue

- https://issues.openmrs.org/browse/KH-62

