### PR TITLE
(feat): Add ability to hide form navigation if the form has only one page

### DIFF
--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.html
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.html
@@ -1,5 +1,5 @@
 <div class="tab-container">
-  <div class="tab">
+  <div class="tab" *ngIf="tabs.length > 1">
     <button
       ofeHoverClass="hover"
       class="tablinks completed"
@@ -10,7 +10,13 @@
       <span>{{ tab.tabTitle }}</span>
     </button>
   </div>
-  <div id="tab" class="tab-content">
+  <div
+    id="tab"
+    [ngClass]="{
+      'tab-content': tabs.length > 1,
+      'tab-content-no-margin': tabs.length === 1
+    }"
+  >
     <ng-content></ng-content>
   </div>
 </div>

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.scss
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.scss
@@ -123,3 +123,7 @@
   width: 100%;
   margin-left: 10rem;
 }
+
+.tab-content-no-margin {
+  width: 100%;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

- Add ability to hide the form-engine navigation column if only one page exists as shown in the GIF below.


## Screenshots
![Kapture 2023-01-25 at 11 42 38](https://user-images.githubusercontent.com/28008754/214519735-5f5dc0ba-e5d2-4ce2-8398-9a9d7f070597.gif)




## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
