### PR TITLE
Feature/reset value on disable by config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,39 +1,18 @@
 ## Requirements
 
 - [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
+- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
+- [ ] My work includes tests or is validated by existing tests.
 
 ## Summary
-
-<!--
-Required.
-Please describe what problems your PR addresses.
--->
-
+<!-- Please describe what problems your PR addresses. -->
 
 ## Screenshots
+<!-- Required if you are making UI changes. -->
 
-*None.*
-<!--
-Optional.
-If possible, please insert any screenshots/videos of your changes here.
-Don't forget to remove the *None.* above if you do fill this section.
--->
-
-
-## Issue
-
-*None.*
-<!--
-Required if applicable.
-If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
--->
-
+## Related Issue
+<!-- Paste the link to the Jira ticket here if one exists. -->
+<!-- https://issues.openmrs.org/browse/O3- -->
 
 ## Other
-
-*None.*
-<!--
-Optional.
-Anything else that isn't covered by one of the sections above.
-Don't forget to remove the *None.* above if you do fill this section.
--->
+<!-- Anything not covered above -->

--- a/angular.json
+++ b/angular.json
@@ -89,7 +89,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.spec.json",
             "karmaConfig": "src/karma.conf.js",
-            "styles": ["src/styles.css"],
+            "styles": ["src/styles.scss"],
             "scripts": ["node_modules/systemjs/dist/system.min.js"],
             "assets": ["src/favicon.ico", "src/assets"]
           }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@carbon/styles": "1.x",
     "@ng-select/ng-select": "^7.4.0",
     "@ngx-translate/core": "^13.0.0",
-    "@ngx-translate/http-loader": "^6.0.0",
     "core-js": "^2.5.4",
     "font-awesome": "^4.7.0",
     "hammerjs": "^2.0.8",

--- a/projects/ngx-formentry/package.json
+++ b/projects/ngx-formentry/package.json
@@ -9,6 +9,7 @@
     "@angular/compiler": ">=11.2.14 <=12.0.4",
     "@angular/core": ">=11.2.14 <=12.0.4",
     "@angular/forms": ">=11.2.14 <=12.0.4",
+    "@ngx-translate/core": "^13.0.0",
     "hammerjs": "^2.0.8",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",

--- a/projects/ngx-formentry/src/abstract-controls-extension/afe-form-array.ts
+++ b/projects/ngx-formentry/src/abstract-controls-extension/afe-form-array.ts
@@ -84,7 +84,10 @@ export class AfeFormArray
 
   disable(param?: { onlySelf?: boolean; emitEvent?: boolean }) {
     super.disable(param);
-    super.setValue([]);
+    if (this.disablers.length > 0)
+      if (this.disablers[0].resetValueOnDisable) {
+        super.setValue([]);
+      }
   }
 
   setHidingFn(newHider: Hider) {

--- a/projects/ngx-formentry/src/abstract-controls-extension/afe-form-control.ts
+++ b/projects/ngx-formentry/src/abstract-controls-extension/afe-form-control.ts
@@ -74,7 +74,11 @@ class AfeFormControl
 
   disable(param?: { onlySelf?: boolean; emitEvent?: boolean }) {
     super.disable(param);
-    super.setValue('');
+
+    if (this.disablers.length > 0)
+      if (this.disablers[0].resetValueOnDisable) {
+        super.setValue('');
+      }
   }
 
   hide() {

--- a/projects/ngx-formentry/src/abstract-controls-extension/afe-form-group.ts
+++ b/projects/ngx-formentry/src/abstract-controls-extension/afe-form-group.ts
@@ -68,7 +68,11 @@ export class AfeFormGroup
 
   disable(param?: { onlySelf?: boolean; emitEvent?: boolean }) {
     super.disable(param);
-    super.setValue({});
+
+    if (this.disablers.length > 0)
+      if (this.disablers[0].resetValueOnDisable) {
+        super.setValue({});
+      }
   }
 
   setHidingFn(newHider: Hider) {

--- a/projects/ngx-formentry/src/adult.json
+++ b/projects/ngx-formentry/src/adult.json
@@ -5272,6 +5272,48 @@
           ]
         }
       ]
+    },
+    {
+      "label": "Primary Diagnoses",
+      "sections": [
+        {
+          "label": "Primary Diagnoses",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Primary Diagnosis",
+              "id": "primaryDiagnosisId",
+              "type": "diagnosis",
+              "questionOptions": {
+                "rendering": "repeating",
+                "dataSource": "diagnoses",
+                "rank": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Secondary Diagnoses",
+      "sections": [
+        {
+          "label": "Secondary Diagnoses",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Secondary Diagnosis",
+              "id": "secondaryDiagnosisId",
+              "type": "diagnosis",
+              "questionOptions": {
+                "rendering": "repeating",
+                "dataSource": "diagnoses",
+                "rank": 2
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/projects/ngx-formentry/src/components/check-box/checkbox.component.ts
+++ b/projects/ngx-formentry/src/components/check-box/checkbox.component.ts
@@ -68,10 +68,9 @@ export class CheckboxControlComponent implements OnInit {
         return o !== option.value;
       });
     }
-
-    // this._value = [...this.selected];
-    this.selected = [...this._value];
-    this.onChange(this.value);
+    
+    this._value = [...this.selected];
+    this.onChange(this._value);
   }
 
   private onChange = (change: any) => {};

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.html
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.html
@@ -1,5 +1,5 @@
 <div class="tab-container">
-  <div class="tab">
+  <div class="tab" *ngIf="tabs.length > 1">
     <button
       ofeHoverClass="hover"
       class="tablinks completed"
@@ -10,7 +10,13 @@
       <span>{{ tab.tabTitle }}</span>
     </button>
   </div>
-  <div id="tab" class="tab-content">
+  <div
+    id="tab"
+    [ngClass]="{
+      'tab-content': tabs.length > 1,
+      'tab-content-no-margin': tabs.length === 1
+    }"
+  >
     <ng-content></ng-content>
   </div>
 </div>

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.scss
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.scss
@@ -123,3 +123,7 @@
   width: 100%;
   margin-left: 10rem;
 }
+
+.tab-content-no-margin {
+  width: 100%;
+}

--- a/projects/ngx-formentry/src/components/number-input/number-input.component.html
+++ b/projects/ngx-formentry/src/components/number-input/number-input.component.html
@@ -24,6 +24,8 @@
       [value]="value"
       [attr.min]="min"
       [attr.max]="max"
+      [attr.maxlength]="maxlength"
+      [attr.minlength]="minlength"
       [attr.step]="step"
       [disabled]="disabled"
       [required]="required"

--- a/projects/ngx-formentry/src/components/number-input/number-input.component.html
+++ b/projects/ngx-formentry/src/components/number-input/number-input.component.html
@@ -20,6 +20,7 @@
     <input
       type="number"
       [id]="id"
+      ofeNumberScroll
       [value]="value"
       [attr.min]="min"
       [attr.max]="max"

--- a/projects/ngx-formentry/src/components/number-input/number-input.component.ts
+++ b/projects/ngx-formentry/src/components/number-input/number-input.component.ts
@@ -93,11 +93,11 @@ export class NumberInputComponent implements ControlValueAccessor {
   /**
    * Sets the max length attribute on the `input` element.
    */
-   @Input() maxlength = null;
-   /**
+  @Input() maxlength = null;
+  /**
    * Sets the min length attribute on the `input` element.
    */
-    @Input() minlength = null;
+  @Input() minlength = null;
   /**
    * Sets the text inside the `label` tag.
    */
@@ -201,8 +201,13 @@ export class NumberInputComponent implements ControlValueAccessor {
 
     if (this.max === null || val + this.step <= this.max) {
       this.value = parseFloat((val + this.step).toPrecision(this.precision));
-    } else {
+    }
+
+    if (this.max && this.max > 0 && this.value > this.max) {
       this.value = this.max;
+    }
+    if (this.max === undefined || this.max === '') {
+      this.value = val + this.step;
     }
 
     this.emitChangeEvent();
@@ -216,8 +221,14 @@ export class NumberInputComponent implements ControlValueAccessor {
 
     if (this.min === null || val - this.step >= this.min) {
       this.value = parseFloat((val - this.step).toPrecision(this.precision));
-    } else {
+    }
+
+    if (this.min && this.min > 0 && this.value < this.min) {
       this.value = this.min;
+    }
+
+    if (this.min === undefined || this.min === '') {
+      this.value = val - this.step;
     }
 
     this.emitChangeEvent();

--- a/projects/ngx-formentry/src/components/number-input/number-input.component.ts
+++ b/projects/ngx-formentry/src/components/number-input/number-input.component.ts
@@ -91,6 +91,14 @@ export class NumberInputComponent implements ControlValueAccessor {
    */
   @Input() max = null;
   /**
+   * Sets the max length attribute on the `input` element.
+   */
+   @Input() maxlength = null;
+   /**
+   * Sets the min length attribute on the `input` element.
+   */
+    @Input() minlength = null;
+  /**
    * Sets the text inside the `label` tag.
    */
   @Input() label: string | TemplateRef<any>;

--- a/projects/ngx-formentry/src/components/number-input/number-input.module.ts
+++ b/projects/ngx-formentry/src/components/number-input/number-input.module.ts
@@ -3,11 +3,12 @@ import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 
 import { NumberInputComponent } from './number-input.component';
+import { NumberInputDirective } from './number.directive';
 
 @NgModule({
   imports: [CommonModule, FormsModule],
   exports: [NumberInputComponent],
-  declarations: [NumberInputComponent],
+  declarations: [NumberInputComponent,NumberInputDirective],
   providers: []
 })
 export class NumberInputModule {}

--- a/projects/ngx-formentry/src/components/number-input/number.directive.ts
+++ b/projects/ngx-formentry/src/components/number-input/number.directive.ts
@@ -1,0 +1,13 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+@Directive({
+  selector: '[ofeNumberScroll]'
+})
+export class NumberInputDirective {
+  constructor(private element: ElementRef) {}
+
+  @HostListener('wheel', ['$event'])
+  public onScroll(event: WheelEvent) {
+    return false;
+  }
+}

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.css
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.css
@@ -1,0 +1,4 @@
+.inline {
+  display: inline-block;
+  padding-right: 0.5rem;
+}

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.html
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.html
@@ -2,6 +2,7 @@
   <div
     *ngFor="let option of options; let i = index"
     class="cds--form-item cds--radio-wrapper"
+    [ngClass]="{'inline': orientation === 'horizontal'}"
   >
     <label class="form-control no-border">
       <input

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.ts
@@ -4,6 +4,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 @Component({
   selector: 'ofe-radio-button',
   templateUrl: './radio.component.html',
+  styleUrls: ['./radio.component.css'],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -17,12 +18,13 @@ export class RadioButtonControlComponent implements ControlValueAccessor, OnInit
   @Input() public options: Array<any>;
   @Input() public selected: any;
   @Input() public allowUnselect: boolean;
+  @Input() public orientation: string;
 
   private _value: any = undefined;
 
   public ngOnInit() {
     this.options = this.options.map((opt) => ({ ...opt, checked: false }));
-    
+
     if (Boolean(this.selected)) {
       const maybeOpt = this.options.find((opt) => opt.value === this.selected);
       if (maybeOpt) {

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.ts
@@ -36,6 +36,10 @@ export class RadioButtonControlComponent implements ControlValueAccessor, OnInit
 
   public writeValue(value: any) {
     this.value = value;
+    const newValueOpt = this.options.find((opt) => opt.value === value);
+    if (newValueOpt) {
+      Object.assign(newValueOpt, { checked: true });
+    }
   }
 
   public registerOnChange(fn: (newValue?: any, emitModelEvent?: boolean) => void) {

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, forwardRef, OnInit } from '@angular/core';
+import { Component, Input, forwardRef, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
@@ -13,7 +13,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
     }
   ]
 })
-export class RadioButtonControlComponent implements ControlValueAccessor, OnInit {
+export class RadioButtonControlComponent implements ControlValueAccessor, OnInit, OnChanges {
   @Input() public id: String;
   @Input() public options: Array<any>;
   @Input() public selected: any;
@@ -24,14 +24,7 @@ export class RadioButtonControlComponent implements ControlValueAccessor, OnInit
 
   public ngOnInit() {
     this.options = this.options.map((opt) => ({ ...opt, checked: false }));
-
-    if (Boolean(this.selected)) {
-      const maybeOpt = this.options.find((opt) => opt.value === this.selected);
-      if (maybeOpt) {
-        Object.assign(maybeOpt, { checked: true });
-        this.value = this.selected;
-      }
-    }
+    this.updateSelectedOption();
   }
 
   public writeValue(value: any) {
@@ -80,4 +73,20 @@ export class RadioButtonControlComponent implements ControlValueAccessor, OnInit
 
   public onChange = (args) => {};
   public onTouched = () => {};
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.selected) {
+      this.updateSelectedOption();
+    }
+  }
+
+  private updateSelectedOption(): void {
+    if (this.selected) {
+      const maybeOpt = this.options.find(opt => opt.value === this.selected);
+      if (maybeOpt) {
+        this.options.forEach(opt => opt.checked = opt === maybeOpt);
+        this.value = this.selected;
+      }
+    }
+  }
 }

--- a/projects/ngx-formentry/src/form-entry/control-hiders-disablers/can-disable.ts
+++ b/projects/ngx-formentry/src/form-entry/control-hiders-disablers/can-disable.ts
@@ -14,6 +14,7 @@ export interface CanDisable {
 export interface Disabler {
   toDisable: boolean;
   disableWhenExpression: string;
+  resetValueOnDisable: boolean;
   reEvaluateDisablingExpression: EvaluateExpressionFn;
 }
 

--- a/projects/ngx-formentry/src/form-entry/control-hiders-disablers/disabler-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/control-hiders-disablers/disabler-helper.spec.ts
@@ -34,6 +34,7 @@ describe('Control Disabler Helper Service:', () => {
     const disabler: Disabler = {
       toDisable: false,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {}
     };
 
@@ -63,6 +64,7 @@ describe('Control Disabler Helper Service:', () => {
     const disabler: Disabler = {
       toDisable: false,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {}
     };
 
@@ -102,6 +104,7 @@ describe('Control Disabler Helper Service:', () => {
     const hider1: Disabler = {
       toDisable: false,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {
         hider1.toDisable = true;
       }
@@ -110,6 +113,7 @@ describe('Control Disabler Helper Service:', () => {
     const hider2: Disabler = {
       toDisable: true,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {
         hider2.toDisable = false;
       }
@@ -118,6 +122,7 @@ describe('Control Disabler Helper Service:', () => {
     const hider3: Disabler = {
       toDisable: false,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {
         hider3.toDisable = true;
       }
@@ -154,6 +159,7 @@ describe('Control Disabler Helper Service:', () => {
     const hider4: Disabler = {
       toDisable: true,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {
         hider4.toDisable = false;
       }
@@ -162,6 +168,7 @@ describe('Control Disabler Helper Service:', () => {
     const hider5: Disabler = {
       toDisable: true,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {
         hider5.toDisable = false;
       }
@@ -202,6 +209,7 @@ describe('Control Disabler Helper Service:', () => {
     const hider1: Disabler = {
       toDisable: false,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {
         hider1.toDisable = true;
       }
@@ -210,6 +218,7 @@ describe('Control Disabler Helper Service:', () => {
     const hider2: Disabler = {
       toDisable: true,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {
         hider2.toDisable = false;
       }
@@ -218,6 +227,7 @@ describe('Control Disabler Helper Service:', () => {
     const hider3: Disabler = {
       toDisable: false,
       disableWhenExpression: 'true',
+      resetValueOnDisable: true,
       reEvaluateDisablingExpression: () => {
         hider3.toDisable = true;
       }

--- a/projects/ngx-formentry/src/form-entry/directives/historical-value.directive.ts
+++ b/projects/ngx-formentry/src/form-entry/directives/historical-value.directive.ts
@@ -55,7 +55,8 @@ export class HistoricalValueDirective {
         if (
           this._node.question.renderingType === 'select' ||
           this._node.question.renderingType === 'multi-select' ||
-          this._node.question.renderingType === 'single-select'
+          this._node.question.renderingType === 'single-select' ||
+          this._node.question.renderingType === 'radio' 
         ) {
           display.text = this.historicalFieldHelper.getDisplayTextFromOptions(
             this._node.question,

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -42,7 +42,6 @@ import { NgxTabSetModule } from '../components/ngx-tabset/modules/ngx-tabset.mod
 import { SelectModule as SelectModuleCarbon } from '../components/select/select.module';
 import { InputModule } from '../components/input/input.module';
 import { CustomControlWrapperModule } from '../components/custom-control-wrapper/custom-control-wrapper..module';
-import { LazyElementsModule } from '@angular-extensions/elements';
 import { CustomComponentWrapperModule } from '../components/custom-component-wrapper/custom-component-wrapper..module';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -66,7 +65,7 @@ import { TranslateModule } from '@ngx-translate/core';
     CustomControlWrapperModule,
     CustomComponentWrapperModule,
     NgxTabSetModule.forRoot(),
-    TranslateModule.forRoot()
+    TranslateModule
   ],
   declarations: [
     FormRendererComponent,

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -31,6 +31,7 @@ import { ControlRelationsFactory } from './form-factory/control-relations.factor
 import { EncounterAdapter } from './value-adapters/encounter.adapter';
 import { PersonAttribuAdapter } from './value-adapters/person-attribute.adapter';
 import { OrderValueAdapter } from './value-adapters/order.adapter';
+import { DiagnosisValueAdapter } from './value-adapters/diagnosis.adapter';
 import { ObsAdapterHelper } from './value-adapters/obs-adapter-helper';
 import { ObsValueAdapter } from './value-adapters/obs.adapter';
 import { NgxRemoteSelectModule } from '../components/ngx-remote-select/ngx-remote-select.module';
@@ -96,6 +97,7 @@ import { TranslateModule } from '@ngx-translate/core';
     EncounterAdapter,
     PersonAttribuAdapter,
     OrderValueAdapter,
+    DiagnosisValueAdapter,
     DebugModeService
   ],
   exports: [

--- a/projects/ngx-formentry/src/form-entry/form-factory/form.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/form.ts
@@ -7,11 +7,13 @@ import { NodeBase, GroupNode, LeafNode, ArrayNode } from './form-node';
 import { QuestionBase } from '../question-models/question-base';
 import { AfeFormControl } from '../../abstract-controls-extension/afe-form-control';
 import { AfeFormArray } from '../../abstract-controls-extension/afe-form-array';
+import { Diagnosis } from '../value-adapters/diagnosis.adapter';
 
 export class Form {
   public rootNode: GroupNode;
   public valueProcessingInfo: any = {};
   public existingOrders: any = {};
+  public existingDiagnoses: Array<Diagnosis> = [];
   private _dataSourcesContainer: DataSources;
   private _showErrors = false;
   constructor(

--- a/projects/ngx-formentry/src/form-entry/form-factory/hiders-disablers.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/hiders-disablers.factory.ts
@@ -41,6 +41,7 @@ export class HidersDisablersFactory {
     const disabler: Disabler = {
       toDisable: false,
       disableWhenExpression: question.disable as string,
+      resetValueOnDisable: question.resetValueOnDisable,
       reEvaluateDisablingExpression: () => {
         const result = runnable.run();
         disabler.toDisable = result;

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -27,6 +27,7 @@ import { CheckBoxQuestion } from '../question-models/models';
 import { RadioButtonQuestion } from '../question-models/models';
 import { Injectable } from '@angular/core';
 import { CustomControlQuestion } from '../question-models/custom-control-question.model';
+import { DiagnosisQuestion } from '../question-models/diagnosis-question';
 
 @Injectable()
 export class QuestionFactory {
@@ -481,6 +482,9 @@ export class QuestionFactory {
       const orders = [];
       orders.push(testOrder);
       question.questions = orders;
+    } else if (schemaQuestion.type === 'diagnosis') {
+      const diagnosisQuestion = this.toDiagnosisQuestion(schemaQuestion);
+      question.questions = [diagnosisQuestion];
     }
 
     const mappings: any = {
@@ -701,6 +705,34 @@ export class QuestionFactory {
     };
     question.componentConfigs = schemaQuestion.componentConfigs || [];
     this.copyProperties(mappings, schemaQuestion, question);
+    return question;
+  }
+
+  toDiagnosisQuestion(schemaQuestion: any): DiagnosisQuestion {
+    const question = new DiagnosisQuestion({
+      type: '',
+      key: schemaQuestion.id,
+      label: schemaQuestion.label,
+      rendering: '',
+      rank: schemaQuestion.questionOptions.rank
+    });
+    question.questionIndex = this.quetionIndex;
+    question.prefix = schemaQuestion.prefix;
+    question.renderingType = 'remote-select';
+    question.validators = this.addValidators(schemaQuestion);
+    question.extras = schemaQuestion;
+    question.dataSource = schemaQuestion.questionOptions.dataSource || 'diagnoses';
+    const mappings: any = {
+      label: 'label',
+      required: 'required',
+      id: 'key'
+    };
+    question.componentConfigs = schemaQuestion.componentConfigs || [];
+    this.copyProperties(mappings, schemaQuestion, question);
+    this.addDisableOrHideProperty(schemaQuestion, question);
+    this.addAlertProperty(schemaQuestion, question);
+    this.addHistoricalExpressions(schemaQuestion, question);
+    this.addCalculatorProperty(schemaQuestion, question);
     return question;
   }
 

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -1030,6 +1030,15 @@ export class QuestionFactory {
       question.disable = schemaQuestion.disable.disableWhenExpression;
     }
 
+    if (schemaQuestion.disable) {
+      //if resetValueOnDisable doesn't exist on the config or no value is provided the default value will be passed (true)
+      question.resetValueOnDisable =
+        !schemaQuestion.hasOwnProperty('resetValueOnDisable') ||
+        this.isEmpty(schemaQuestion.resetValueOnDisable)
+          ? true
+          : schemaQuestion.resetValueOnDisable;
+    }
+
     if (!!schemaQuestion.hide) {
       question.hide = schemaQuestion.hide;
     }
@@ -1049,5 +1058,12 @@ export class QuestionFactory {
           : String.fromCharCode(Math.floor(r * 26) + (r > 0.5 ? 97 : 65));
     }
     return '_' + s;
+  }
+
+  isEmpty(value): boolean {
+    if (value === '' || value === null || value === undefined) {
+      return true;
+    }
+    return false;
   }
 }

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -805,8 +805,6 @@ export class QuestionFactory {
         return this.toTextQuestion(schema);
       case 'textarea':
         return this.toTextAreaQuestion(schema);
-      case 'textarea':
-        return this.toTextAreaQuestion(schema);
       case 'select-concept-answers':
         return this.toConceptAnswerSelect(schema);
       case 'encounterLocation':

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -28,6 +28,9 @@ import { RadioButtonQuestion } from '../question-models/models';
 import { Injectable } from '@angular/core';
 import { CustomControlQuestion } from '../question-models/custom-control-question.model';
 import { DiagnosisQuestion } from '../question-models/diagnosis-question';
+import { MaxLengthValidationModel } from '../question-models/max-length-validation.model';
+import { MinLengthValidationModel } from '../question-models/min-length-validation.model';
+
 
 @Injectable()
 export class QuestionFactory {
@@ -947,6 +950,22 @@ export class QuestionFactory {
             new MinValidationModel({
               type: 'min',
               min: questionOptions.min
+            })
+          );
+        }
+        if (questionOptions.maxLength) {
+          validators.push(
+            new MaxLengthValidationModel({
+              type: 'maxlength',
+              maxlength: questionOptions.maxLength
+            })
+          );
+        }
+        if (questionOptions.minLength) {
+          validators.push(
+            new MinLengthValidationModel({
+              type: 'minlength',
+              minlength: questionOptions.minLength
             })
           );
         }

--- a/projects/ngx-formentry/src/form-entry/form-factory/validation.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/validation.factory.ts
@@ -162,7 +162,7 @@ export class ValidationFactory {
             break;
           case 'maxlength':
             messages.push(
-              Messages.MIN_LENGTH_MSG.replace(
+              Messages.MAX_LENGTH_MSG.replace(
                 '{maxLength}',
                 errors.maxlength.requiredLength
               )

--- a/projects/ngx-formentry/src/form-entry/form-factory/validation.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/validation.factory.ts
@@ -20,6 +20,10 @@ import { MaxValidationModel } from '../question-models/max-validation.model';
 import { MinValidationModel } from '../question-models/min-validation.model';
 import { JsExpressionValidationModel } from '../question-models/js-expression-validation.model';
 import { ConditionalValidationModel } from '../question-models/conditional-validation.model';
+import { MaxLengthValidator } from '../validators/max-length.validator';
+import { MaxLengthValidationModel } from '../question-models/max-length-validation.model';
+import { MinLengthValidationModel } from '../question-models/min-length-validation.model';
+import { MinLengthValidator } from '../validators/min-length.validator';
 
 @Injectable()
 export class ValidationFactory {
@@ -53,9 +57,19 @@ export class ValidationFactory {
               this.getMaxValueValidator((<MaxValidationModel>validator).max)
             );
             break;
+          case 'maxlength':
+            list.push(
+              this.maxLengthValidator((<MaxLengthValidationModel>validator).maxlength)
+            );
+            break;
           case 'min':
             list.push(
               this.getMinValueValidator((<MinValidationModel>validator).min)
+            );
+            break;
+          case 'minlength':
+            list.push(
+              this.minLengthValidator((<MinLengthValidationModel>validator).minlength)
             );
             break;
           case 'conditionalRequired':
@@ -117,12 +131,12 @@ export class ValidationFactory {
     return new MinDateValidator().validate;
   }
 
-  get minLengthValidator(): any {
-    return Validators.minLength;
+  public minLengthValidator(minLength: number) {
+    return new MinLengthValidator().validate(minLength);
   }
 
-  get maxLengthValidator() {
-    return Validators.maxLength;
+  public maxLengthValidator(maxLength: number) {
+    return new MaxLengthValidator().validate(maxLength);
   }
 
   public getMinValueValidator(min: number): any {

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.css
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.css
@@ -158,7 +158,7 @@ ng-select.form-control {
   margin-bottom: 3rem;
 }
 .afe-control {
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.125rem;
 }
 [hidden] {
   display: none !important;

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.css.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.css.ts
@@ -158,7 +158,7 @@ export const DEFAULT_STYLES = `a {
   margin-bottom: 3rem;
 }
 .afe-control{
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.125rem;
 }
 [hidden] {
   display: none !important;

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -295,6 +295,8 @@
             [id]="node.question.key + 'id'"
             [min]="node.question.extras.questionOptions.min"
             [max]="node.question.extras.questionOptions.max"
+            [maxlength]="node.question.extras.questionOptions.maxLength"
+            [minlength]="node.question.extras.questionOptions.minLength"
             [formControlName]="node.question.key"
             [attr.placeholder]="node.question.placeholder | translate"
           >

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -319,6 +319,7 @@
               [options]="node.question.options"
               [allowUnselect]="node.question.allowUnselect"
               [selected]="node.control.value"
+              [orientation]="node.question.orientation"
             ></ofe-radio-button>
           </div>
 

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -460,6 +460,35 @@
           </div>
         </div>
 
+        <div *ngSwitchCase="'diagnosis'">
+          <div *ngFor="let child of node.children; let i = index">
+            <ofe-form-renderer
+              *ngFor="let question of child.question.questions"
+              [parentComponent]="this"
+              [node]="child.children[question.key]"
+              [parentGroup]="child.control"
+              [labelMap]="labelMap"
+            ></ofe-form-renderer>
+            <button
+              type="button "
+              class="cds--btn cds--btn--danger cds--btn--sm"
+              (click)="node.removeAt(i)"
+            >
+              Remove
+            </button>
+            <br />
+            <hr
+              style="
+                margin-left: -2px;
+                margin-right: -2px;
+                margin-bottom: 4px;
+                margin-top: 8px;
+                border-width: 1px;
+              "
+            />
+          </div>
+        </div>
+
         <div *ngSwitchCase="'obsGroup'" style="margin-bottom: 20px">
           <div *ngFor="let child of node.children; let i = index">
             <ofe-form-renderer

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -201,7 +201,11 @@ export class FormRendererComponent implements OnInit, OnChanges {
     }
   }
   public hasErrors() {
-    return this.node.control.touched && !this.node.control.valid;
+    return (
+      this.node.control.touched &&
+      !this.node.control.valid &&
+      this.node.control.disablers.length === 0
+    );
   }
 
   public errors() {

--- a/projects/ngx-formentry/src/form-entry/question-models/diagnosis-question.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/diagnosis-question.ts
@@ -1,0 +1,17 @@
+import { QuestionBase } from './question-base';
+import { AfeControlType } from '../../abstract-controls-extension/afe-control-type';
+import { DiagnosisQuestionOptions } from './interfaces/diagnosis-question-options';
+
+export class DiagnosisQuestion extends QuestionBase {
+  rendering: string;
+  options: any[];
+  dataSource?: any;
+
+  constructor(options: DiagnosisQuestionOptions) {
+    super(options);
+    this.renderingType = 'select';
+    this.options = options.options;
+    this.controlType = AfeControlType.AfeFormControl;
+    this.dataSource = options.dataSource || '';
+  }
+}

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
@@ -13,6 +13,7 @@ export interface BaseOptions {
   questionOptions?: any;
   hide?: string | boolean;
   alert?: any;
+  resetValueOnDisable?: boolean;
   disable?: string | boolean;
   readOnly?: string | boolean;
   enableHistoricalValue?: boolean;

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/diagnosis-question-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/diagnosis-question-options.ts
@@ -1,0 +1,8 @@
+import { BaseOptions } from '../interfaces/base-options';
+import {DataSource} from "./data-source";
+export interface DiagnosisQuestionOptions extends BaseOptions {
+  dataSource?: string;
+  rendering: string;
+  rank: number;
+  options?: Array<Record<string, string>>;
+}

--- a/projects/ngx-formentry/src/form-entry/question-models/max-length-validation.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/max-length-validation.model.ts
@@ -1,0 +1,11 @@
+import { ValidationModel } from './validation.model';
+
+export class MaxLengthValidationModel extends ValidationModel {
+ maxlength: number;
+
+  constructor(validations: any) {
+    super(validations);
+    const maxlength: any = validations.maxlength;
+    this.maxlength = +maxlength;
+  }
+}

--- a/projects/ngx-formentry/src/form-entry/question-models/max-validation.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/max-validation.model.ts
@@ -6,6 +6,6 @@ export class MaxValidationModel extends ValidationModel {
   constructor(validations: any) {
     super(validations);
     const max: any = validations.max;
-    this.max = +max;
+    this.max = Number(max);
   }
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/min-length-validation.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/min-length-validation.model.ts
@@ -1,0 +1,11 @@
+import { ValidationModel } from './validation.model';
+
+export class MinLengthValidationModel extends ValidationModel {
+ minlength: number;
+
+  constructor(validations: any) {
+    super(validations);
+    const minlength: any = validations.minlength;
+    this.minlength = +minlength;
+  }
+}

--- a/projects/ngx-formentry/src/form-entry/question-models/min-validation.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/min-validation.model.ts
@@ -6,6 +6,6 @@ export class MinValidationModel extends ValidationModel {
   constructor(validations: any) {
     super(validations);
     const min: any = validations.min;
-    this.min = +min;
+    this.min = Number(min);
   }
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -36,6 +36,7 @@ export class QuestionBase implements BaseOptions {
   validators?: Array<ValidationModel>;
   required?: boolean;
   hide?: string | boolean;
+  resetValueOnDisable?: boolean;
   disable?: string | boolean;
   readOnly?: string | boolean;
   calculateExpression?: string;

--- a/projects/ngx-formentry/src/form-entry/validators/max-length.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/max-length.validator.ts
@@ -1,0 +1,20 @@
+import { AfeFormControl } from '../../abstract-controls-extension/afe-form-control';
+
+export class MaxLengthValidator {
+  validate(maxLength: number) {
+    return (control: AfeFormControl): { [key: string]: any } => {
+      if (control.hidden) {
+        return null;
+      }
+
+      if (control.value && control.value.length !== 0) {
+        const v = (control.value).toString().length;
+        return v <= maxLength
+          ? null
+          : { maxlength: { requiredLength: maxLength, actualValue: v } };
+      }
+
+      return null;
+    };
+  }
+}

--- a/projects/ngx-formentry/src/form-entry/validators/min-length.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/min-length.validator.ts
@@ -1,0 +1,20 @@
+import { AfeFormControl } from '../../abstract-controls-extension/afe-form-control';
+
+export class MinLengthValidator {
+  validate(minLength: number) {
+    return (control: AfeFormControl): { [key: string]: any } => {
+      if (control.hidden) {
+        return null;
+      }
+
+      if (control.value && control.value.length !== 0) {
+        const v = (control.value).toString().length;
+        return v >= minLength
+          ? null
+          : { minlength: { requiredLength: minLength, actualValue: v } };
+      }
+
+      return null;
+    };
+  }
+}

--- a/projects/ngx-formentry/src/form-entry/value-adapters/diagnosis.adapter.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/diagnosis.adapter.spec.ts
@@ -1,0 +1,127 @@
+import {TestBed} from '@angular/core/testing';
+
+const adultForm = require('../../adult.json');
+const adultFormDiagnoses = require('../../mock/diagnoses.json');
+import {FormFactory} from '../../form-entry/form-factory/form.factory';
+import {FormControlService} from '../../form-entry/form-factory/form-control.service';
+import {ValidationFactory} from '../../form-entry/form-factory/validation.factory';
+import {QuestionFactory} from '../../form-entry/form-factory/question.factory';
+import {OrderValueAdapter} from './order.adapter';
+import {HidersDisablersFactory} from '../../form-entry/form-factory/hiders-disablers.factory';
+import {AlertsFactory} from '../form-factory/show-messages.factory';
+import {ExpressionRunner} from '../../form-entry/expression-runner/expression-runner';
+import {JsExpressionHelper} from '../../form-entry/helpers/js-expression-helper';
+import {ControlRelationsFactory} from '../../form-entry/form-factory/control-relations.factory';
+import {DebugModeService} from './../services/debug-mode.service';
+import {Diagnosis, DiagnosisValueAdapter} from './diagnosis.adapter';
+
+describe('Diagnosis Value Adapter', () => {
+  let formFactory: FormFactory;
+  let diagnosisValueAdapter: DiagnosisValueAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [],
+      providers: [
+        FormFactory,
+        FormControlService,
+        ValidationFactory,
+        QuestionFactory,
+        OrderValueAdapter,
+        DiagnosisValueAdapter,
+        HidersDisablersFactory,
+        AlertsFactory,
+        ExpressionRunner,
+        JsExpressionHelper,
+        ControlRelationsFactory,
+        DebugModeService
+      ]
+    });
+
+    formFactory = TestBed.inject(FormFactory);
+    diagnosisValueAdapter = TestBed.inject(DiagnosisValueAdapter);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  const newDiagnoses: Array<Diagnosis> = [
+    {
+      uuid: 'diagnosis-1-uuid4',
+      display: 'Malarial Fever',
+      certainty: 'CONFIRMED',
+      rank: 1,
+      diagnosis: {
+        coded: {
+          uuid: '116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+          display: 'Malarial Fever',
+        },
+      },
+      voided: false,
+    },
+    {
+      uuid: 'diagnosis-2-uuid5',
+      display: 'Puerperal Fever',
+      certainty: 'PROVISIONAL',
+      rank: 2,
+      diagnosis: {
+        coded: {
+          uuid: '113511AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+          display: 'Puerperal Fever',
+        },
+      },
+      voided: false,
+    }
+  ];
+
+  it('should be defined', () => {
+    expect(diagnosisValueAdapter).toBeTruthy();
+  });
+
+  describe('generateFormPayload', () => {
+    it('should populate form with additional diagnoses and generate payload', () => {
+      const form = formFactory.createForm(adultForm);
+      diagnosisValueAdapter.formDiagnosisNodes = [];
+      diagnosisValueAdapter.populateForm(form, adultFormDiagnoses.diagnoses);
+
+      let index = 0;
+
+      for (const diagnosis of newDiagnoses) {
+        const node = diagnosisValueAdapter.formDiagnosisNodes[diagnosis.rank - 1];
+        node.createChildNode();
+        const value = {};
+        value[node.question.key] = diagnosis.diagnosis.coded.uuid;
+        const childNode = node.children[index];
+        childNode.control.setValue(value);
+        //index++;
+      }
+
+      // Confirm controls where populated with data;
+      expect(diagnosisValueAdapter.formDiagnosisNodes[0].control.value[0].primaryDiagnosisId).toEqual('116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+      expect(diagnosisValueAdapter.formDiagnosisNodes[1].control.value[0].secondaryDiagnosisId).toEqual('113511AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+
+      // Confirm payload was generated;
+      const payload = diagnosisValueAdapter.generateFormPayload(form);
+      expect(payload.find(p => p.diagnosis.coded == '116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')).toBeTruthy();
+      expect(payload.find(p => p.diagnosis.coded == '113511AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')).toBeTruthy();
+
+      // Confirm deleted diagnoses were added to the payload
+      expect(payload.find(p => p.diagnosis.coded == '5945AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && p.voided)).toBeTruthy();
+    });
+  });
+
+  describe('Populate Form', () => {
+    it('should populate form with diagnoses from existing payload', () => {
+      const form = formFactory.createForm(adultForm);
+      diagnosisValueAdapter.populateForm(form, adultFormDiagnoses.diagnoses);
+
+      expect(diagnosisValueAdapter.formDiagnosisNodes.filter(n => {
+          return n.control.value.find(v => {
+            return v.secondaryDiagnosisId == '5945AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && v.secondaryDiagnosisId.display == 'FEVER';
+          });
+        }
+      )).toBeTruthy();
+    });
+  });
+});

--- a/projects/ngx-formentry/src/form-entry/value-adapters/diagnosis.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/diagnosis.adapter.ts
@@ -1,0 +1,173 @@
+import {Injectable} from '@angular/core';
+import {Form} from '../form-factory/form';
+import {ValueAdapter} from './value.adapter';
+
+@Injectable()
+export class DiagnosisValueAdapter implements ValueAdapter {
+  formDiagnosisNodes = [];
+
+  generateFormPayload(form: Form) {
+    this.formDiagnosisNodes = [];
+    this._findDiagnosisQuestionNodes(form.rootNode);
+    return this._createDiagnosesPayload(this.formDiagnosisNodes, form.existingDiagnoses);
+  }
+
+  populateForm(form: Form, diagnoses:Array<Diagnosis>) {
+    form.existingDiagnoses = diagnoses?.filter(d => {
+      return !d.voided;
+    });
+    this.formDiagnosisNodes = [];
+    this._findDiagnosisQuestionNodes(form.rootNode);
+    this._setDiagnosesValues(this.formDiagnosisNodes, form.existingDiagnoses, 1);
+    this._setDiagnosesValues(this.formDiagnosisNodes, form.existingDiagnoses, 2);
+  }
+
+  private _createDiagnosesPayload(diagnosisNodes, existingDiagnoses) {
+    const payload: Array<DiagnosisPayload> = [];
+    let deletedDiagnoses: Array<DiagnosisPayload> = [];
+
+    diagnosisNodes?.forEach(node => {
+      node.control.value.filter(v => v[node.question.key]).forEach(value => {
+        // Create Payload
+        const payloadDiagnosis = this._createPayloadDiagnosis(
+          value[node.question.key],
+          node.question.extras
+        );
+        // Validate if is new value
+          payload.push(payloadDiagnosis);
+      });
+    });
+
+    this._updatedOldDiagnoses(payload, existingDiagnoses);
+    deletedDiagnoses = this._getDeletedDiagnoses(payload, existingDiagnoses);
+    return payload.concat(deletedDiagnoses);
+  }
+
+  private _createPayloadDiagnosis(codedUuid, questionExtras): DiagnosisPayload {
+    const diagnosis: DiagnosisPayload = {
+      diagnosis: {
+        coded: codedUuid,
+      },
+      certainty: 'CONFIRMED',
+      rank: questionExtras.questionOptions.rank,
+      voided: false
+    };
+
+    return diagnosis;
+  }
+
+  private _getDeletedDiagnoses(payloadDiagnoses: Array<DiagnosisPayload>, existingDiagnoses: Array<Diagnosis>): Array<DiagnosisPayload> {
+    return existingDiagnoses?.filter(e => {
+      return !payloadDiagnoses.find(p => {
+        let isSame = !e.voided && p.diagnosis.coded === e.diagnosis.coded.uuid;
+        return isSame;
+      });
+    }).map(d => {
+      let diagnosisPayload = this._convert(d);
+      diagnosisPayload.voided = true;
+      return diagnosisPayload;
+    });
+  }
+
+  private _updatedOldDiagnoses(payloadDiagnoses: Array<DiagnosisPayload>, existingDiagnoses: Array<Diagnosis>) {
+     payloadDiagnoses.forEach(p => {
+       existingDiagnoses?.forEach(e => {
+         let isSame = !e.voided && p.diagnosis.coded === e.diagnosis.coded.uuid;
+         p.uuid = isSame ? e.uuid : null;
+       });
+     });
+  }
+
+  private _setDiagnosesValues(formDiagnosisNodes, existingDiagnoses: Array<Diagnosis>, rank: number) {
+    formDiagnosisNodes?.filter(node => node.question.extras.questionOptions.rank == rank).forEach(node => {
+      node['initialValue'] = existingDiagnoses;
+      existingDiagnoses.filter(d => d.rank == rank).forEach((diagnosis, index) => {
+        node.createChildNode();
+        const value = {};
+        value[node.question.key] = diagnosis.diagnosis.coded.uuid;
+        const childNode = node.children[index];
+        childNode.control.setValue(value);
+        childNode['initialValue'] = value;
+      });
+    });
+  }
+
+  private _findDiagnosisQuestionNodes(formNode) {
+    if (formNode.children) {
+      if (formNode.children instanceof Object) {
+        for (const key in formNode.children) {
+          if (formNode.children.hasOwnProperty(key)) {
+            switch (formNode.children[key].question.renderingType) {
+              case 'page':
+                this._findDiagnosisQuestionNodes(formNode.children[key]);
+                break;
+              case 'section':
+                this._findDiagnosisQuestionNodes(formNode.children[key]);
+                break;
+              case 'group':
+                this._findDiagnosisQuestionNodes(formNode.children[key]);
+                break;
+              case 'repeating':
+                if (formNode.children) {
+                  for (const node in formNode.children) {
+                    const question = formNode.children[node].question;
+                    if (question.extras && question.extras.type === 'diagnosis') {
+                      this.formDiagnosisNodes.push(formNode.children[node]);
+                    }
+                  }
+                }
+                break;
+              default:
+                break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private _convert(diagnosis: Diagnosis): DiagnosisPayload {
+    return {
+      uuid: diagnosis.uuid,
+      encounter: diagnosis.encounter,
+      patient: diagnosis.patient,
+      diagnosis: {
+        coded: diagnosis.diagnosis.coded.uuid,
+        nonCoded: diagnosis.diagnosis.nonCoded,
+      },
+      certainty: diagnosis.certainty,
+      rank: diagnosis.rank,
+      voided: diagnosis.voided,
+    }
+  }
+}
+
+export interface Diagnosis {
+  uuid?: string;
+  display?: string;
+  encounter?: string;
+  patient?: string;
+  diagnosis: {
+    coded?: {
+      uuid: string;
+      display?: string;
+    };
+    nonCoded?: string;
+  };
+  certainty: 'CONFIRMED' | 'PROVISIONAL';
+  rank: number;
+  voided?: boolean;
+}
+
+export interface DiagnosisPayload {
+  uuid?: string;
+  encounter?: string;
+  patient?: string;
+  diagnosis: {
+    coded?: string;
+    nonCoded?: string;
+  };
+  certainty: 'CONFIRMED' | 'PROVISIONAL';
+  rank: number;
+  voided?: boolean;
+}

--- a/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
@@ -6,6 +6,7 @@ import { Form } from '../form-factory/form';
 import { ValueAdapter } from './value.adapter';
 import { ObsValueAdapter } from './obs.adapter';
 import { OrderValueAdapter } from './order.adapter';
+import { DiagnosisValueAdapter } from './diagnosis.adapter';
 
 import moment from 'moment';
 
@@ -13,6 +14,7 @@ import moment from 'moment';
 export class EncounterAdapter implements ValueAdapter {
   constructor(
     public ordersAdapter: OrderValueAdapter,
+    public diagnosesAdapter: DiagnosisValueAdapter,
     public obsAdapter: ObsValueAdapter
   ) {}
 
@@ -21,6 +23,9 @@ export class EncounterAdapter implements ValueAdapter {
 
     if (Array.isArray(payload.orders)) {
       this.ordersAdapter.populateForm(form, payload);
+    }
+    if (Array.isArray(payload.diagnoses)) {
+      this.diagnosesAdapter.populateForm(form, payload.diagnoses);
     }
     if (Array.isArray(payload.obs)) {
       this.obsAdapter.populateForm(form, payload.obs);
@@ -80,6 +85,8 @@ export class EncounterAdapter implements ValueAdapter {
     payload['obs'] = this.obsAdapter.generateFormPayload(form) || [];
 
     payload['orders'] = this.ordersAdapter.generateFormPayload(form) || [];
+
+    payload['diagnoses'] = this.diagnosesAdapter.generateFormPayload(form) || [];
 
     return payload;
   }

--- a/projects/ngx-formentry/src/mock/diagnoses.json
+++ b/projects/ngx-formentry/src/mock/diagnoses.json
@@ -1,0 +1,121 @@
+{
+  "uuid": "3e9f1808-34dd-4407-b474-c334a2653a10",
+  "display": "ADULTRETURN 16/11/2016",
+  "encounterDatetime": "2016-11-16T11:46:37.000+0300",
+  "patient": {
+    "uuid": "b4ddd369-bec5-446e-b8f8-47fd5567b295",
+    "display": "234750205-2 - Robai Test Robai",
+    "links": [
+      {
+        "rel": "self",
+        "uri": "https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/patient/b4ddd369-bec5-446e-b8f8-47fd5567b295"
+      }
+    ]
+  },
+  "form": {
+    "uuid": "81f92a8a-ff5c-415d-a34c-b5bdca2406be",
+    "display": "AMPATH POC Adult Return Visit Form v1.0",
+    "name": "AMPATH POC Adult Return Visit Form v1.0",
+    "description": "AMPATH POC Adult Return Visit Form v1.0",
+    "encounterType": {
+      "uuid": "8d5b2be0-c2cc-11de-8d13-0010c6dffd0f",
+      "display": "ADULTRETURN",
+      "links": [
+        {
+          "rel": "self",
+          "uri": "https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/encountertype/8d5b2be0-c2cc-11de-8d13-0010c6dffd0f"
+        }
+      ]
+    },
+    "version": "1.0",
+    "build": null,
+    "published": true,
+    "formFields": [],
+    "retired": false,
+    "resources": [
+      {
+        "uuid": "991e36d7-98df-45a9-b77b-37dba0dfcb67",
+        "display": "json schema",
+        "links": [
+          {
+            "rel": "value",
+            "uri": "https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/form/81f92a8a-ff5c-415d-a34c-b5bdca2406be/resource/991e36d7-98df-45a9-b77b-37dba0dfcb67/value"
+          },
+          {
+            "rel": "self",
+            "uri": "https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/form/81f92a8a-ff5c-415d-a34c-b5bdca2406be/resource/991e36d7-98df-45a9-b77b-37dba0dfcb67"
+          }
+        ]
+      }
+    ],
+    "links": [
+      {
+        "rel": "self",
+        "uri": "https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/form/81f92a8a-ff5c-415d-a34c-b5bdca2406be"
+      },
+      {
+        "rel": "full",
+        "uri": "https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/form/81f92a8a-ff5c-415d-a34c-b5bdca2406be?v=full"
+      }
+    ],
+    "resourceVersion": "1.9"
+  },
+  "encounterType": {
+    "uuid": "8d5b2be0-c2cc-11de-8d13-0010c6dffd0f",
+    "display": "ADULTRETURN",
+    "name": "ADULTRETURN",
+    "description": "Outpatient Adult Return Visit",
+    "retired": false,
+    "links": [
+      {
+        "rel": "self",
+        "uri": "https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/encountertype/8d5b2be0-c2cc-11de-8d13-0010c6dffd0f"
+      },
+      {
+        "rel": "full",
+        "uri": "https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/encountertype/8d5b2be0-c2cc-11de-8d13-0010c6dffd0f?v=full"
+      }
+    ],
+    "resourceVersion": "1.8"
+  },
+  "diagnoses": [
+    {
+      "uuid": "636bf840-a244-4e83-815f-3ba2b6ce35bd",
+      "diagnosis": {
+        "specificName": {
+          "uuid": "16599BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "display": "Malarial Fever"
+        },
+        "coded": {
+          "uuid": "116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "display": "Malarial Fever"
+        }
+      },
+      "condition": null,
+      "certainty": "CONFIRMED",
+      "rank": 1,
+      "voided": true,
+      "display": "FEVER",
+      "resourceVersion": "1.8"
+    },
+    {
+      "uuid": "636bf840-a244-4e83-815f-3ba2b6ce35be",
+      "diagnosis": {
+        "specificName": {
+          "uuid": "3085BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "display": "FEVER"
+        },
+        "coded": {
+          "uuid": "5945AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "display": "FEVER"
+        }
+      },
+      "condition": null,
+      "certainty": "CONFIRMED",
+      "rank": 2,
+      "voided": false,
+      "display": "FEVER",
+      "resourceVersion": "1.8"
+    }
+  ]
+}

--- a/projects/ngx-formentry/styles/ngx-formentry.css
+++ b/projects/ngx-formentry/styles/ngx-formentry.css
@@ -78,7 +78,6 @@
 
 .ng-select .ng-select-container .ng-value-container {
   align-items: stretch;
-  padding: 0.4375em 0;
   border-top: 0.84375em solid transparent;
 }
 
@@ -97,14 +96,12 @@
 }
 
 .ng-select.ng-select-single .ng-select-container .ng-arrow-wrapper {
-  align-self: flex-end;
+  align-self: center;
   right: 4px;
-  top: -5px;
 }
 
 .ng-select.ng-select-single .ng-select-container .ng-clear-wrapper {
-  align-self: flex-end;
-  bottom: 7px;
+  align-self: center;
 }
 
 .ng-select.ng-select-multiple.ng-select-disabled

--- a/src/app/adult-1.6.json
+++ b/src/app/adult-1.6.json
@@ -1,8035 +1,8043 @@
 {
-	"name": "ampath_poc_adult_return_visit_form_v1.6",
-	"uuid": "xxxx",
-	"processor": "EncounterFormProcessor",
-	"referencedForms": [
-		{
-			"formName": "component_hospitalization",
-			"alias": "hosp",
-			"ref": {
-				"uuid": "77d6652f-4653-4434-af6b-6dab84117044",
-				"display": "Hospitalization Component"
-			}
-		},
-		{
-			"formName": "component_immunization-v1.0",
-			"alias": "immn1",
-			"ref": {
-				"uuid": "11b15110-e325-4d0d-bd54-5f55b21301f5",
-				"display": "Immunization v1.0 Component"
-			}
-		},
-		{
-			"formName": "component_art-v1.2",
-			"alias": "art12",
-			"ref": {
-				"uuid": "49eb4af7-7e05-4b3f-aeb0-d1931e27909b",
-				"display": "Art v1.2 Component"
-			}
-		},
-		{
-			"formName": "component_art-v1.4",
-			"alias": "art14",
-			"ref": {
-				"uuid": "fe2cc2aa-ea65-42a1-a1fc-560fff8d5480",
-				"display": "Art v1.4 DTG Component"
-			}
-		},
-		{
-			"formName": "component_pcp-prophy-v1.2",
-			"alias": "pcp12",
-			"ref": {
-				"uuid": "6493a2dd-d3c3-4ff5-9b2d-02ac6c30fe39",
-				"display": "Pcp v1.2 Prophy Component"
-			}
-		},
-		{
-			"formName": "component_tb-prophy-v1.2",
-			"alias": "tbp12",
-			"ref": {
-				"uuid": "f48291ac-40c5-466b-83ee-62758e804b32",
-				"display": "Tb Prophy Component"
-			}
-		},
-		{
-			"formName": "component_tb-treatment-v1.3",
-			"alias": "tbt13",
-			"ref": {
-				"uuid": "e04b6b46-1682-4804-aa3c-895347c8f402",
-				"display": "Tb Treatment Component"
-			}
-		},
-		{
-			"formName": "component_other-medication",
-			"alias": "omed",
-			"ref": {
-				"uuid": "46205439-ccbf-4f60-80e1-d765861f6257",
-				"display": "Other Medication Component"
-			}
-		},
-		{
-			"formName": "component_side-effect-v1.1",
-			"alias": "se11",
-			"ref": {
-				"uuid": "c45f02b4-12bb-4611-9920-aa2df3b6bd3d",
-				"display": "Side Effect v 1.1 Component"
-			}
-		},
-		{
-			"formName": "component_nutrition",
-			"alias": "nut",
-			"ref": {
-				"uuid": "e421b750-e7fc-4194-b55e-6f2c978e1af5",
-				"display": "Nutrition Component"
-			}
-		},
-		{
-			"formName": "component_vitals",
-			"alias": "vt",
-			"ref": {
-				"uuid": "7f5e06a4-92d1-4fc9-9e05-03b414457d69",
-				"display": "Vitals Component"
-			}
-		},
-		{
-			"formName": "component_hpi",
-			"alias": "hpi",
-			"ref": {
-				"uuid": "b91aef27-cd94-4934-94ac-c168ce539cb3",
-				"display": "Hpi Component"
-			}
-		},
-		{
-			"formName": "component_who-staging",
-			"alias": "who",
-			"ref": {
-				"uuid": "fdf950e0-ff0a-4d7d-a52b-33a8d5b98fb7",
-				"display": "Who Staging Component"
-			}
-		},
-		{
-			"formName": "component_assessment",
-			"alias": "ass",
-			"ref": {
-				"uuid": "98e061d2-4a16-4665-b0dc-fc0266ee689c",
-				"display": "Assessment Component"
-			}
-		},
-		{
-			"formName": "component_sti-v1.0",
-			"alias": "sti1",
-			"ref": {
-				"uuid": "6515b019-5264-4a61-a7fd-e891ea03b5f4",
-				"display": "STI v1.0 Component"
-			}
-		},
-		{
-			"formName": "component_lab-orders-v1.0",
-			"alias": "to",
-			"ref": {
-				"uuid": "61a262b6-3238-4187-9740-dea29ea4f7e4",
-				"display": "Lab Orders v1.0 Component"
-			}
-		},
-		{
-			"formName": "component_referral",
-			"alias": "ref",
-			"ref": {
-				"uuid": "f18a6b65-f55b-4d53-afe2-b929bbb66a70",
-				"display": "Referral Component"
-			}
-		},
-		{
-			"formName": "component_positive-health-dignity-&-prevention-services-v1.0",
-			"alias": "phdp",
-			"ref": {
-				"uuid": "4da1548d-e098-4658-a847-8d42f45059f4",
-				"display": "PHDP Component"
-			}
-		},
-		{
-			"formName": "component_vl-justification",
-			"alias": "vljust",
-			"ref": {
-				"uuid": "c47dd152-9996-4ec9-94bb-434f85a6a2b5",
-				"display": "VL Justification Component"
-			}
-		},
-		{
-			"formName": "component_family-planning-v1.0",
-			"alias": "fp1",
-			"ref": {
-				"uuid": "68363308-0a91-4541-9934-c3e770416d51",
-				"display": "Family Planning v1.0 Component"
-			}
-		},
-		{
-			"ref": {
-				"uuid": "a472864e-ddb4-4741-be6f-20d1b2a9be2b",
-				"display": "component_morisky-adherence-score-v1.0"
-			},
-			"formName": "component_morisky-adherence-score-v1.0",
-			"alias": "mmas1"
-		},
-		{
-			"ref": {
-				"uuid": "10fb1c84-84d8-43b3-8683-2fbe2bc9962a",
-				"display": "Feeding v1.1 Compent"
-			},
-			"formName": "component_feeding-v1.1",
-			"alias": "feed11"
-		},
-		{
-			"ref": {
-				"uuid": "df2529c9-3679-4dc1-b747-d753cdb8b774",
-				"display": "Vitals v1.3 Component"
-			},
-			"formName": "component_vitals-v1.3",
-			"alias": "vt13"
-		},
-		{
-			"ref": {
-				"uuid": "4491d2dc-abc7-45f5-b724-ef534f00d144",
-				"display": "Preclinic v1.4"
-			},
-			"formName": "component_preclinic-review-v1.4",
-			"alias": "pcr14"
-		},
-		{
-			"ref": {
-				"uuid": "68cb1748-94ea-48b2-bfd0-cda5c1a7b7d1",
-				"display": "Reproductive history v1.5"
-			},
-			"formName": "component_reproductive-history-v1.5",
-			"alias": "repro15"
-		},
-		{
-			"ref": {
-				"uuid": "64d07d7c-b82b-4245-ae0a-9e4af907eab7",
-				"display": "Crypto v1.1"
-			},
-			"formName": "component_crypto-v1.1",
-			"alias": "crypto11"
-		},
-		{
-			"ref": {
-				"uuid": "b9e18c55-6547-49ed-8025-f18bacb22e7c",
-				"display": "Lab Results v1.5"
-			},
-			"formName": "component_lab-results-v1.5",
-			"alias": "lr5"
-		},
-		{
-			"ref": {
-				"uuid": "4caf221a-1451-4331-8256-50d37f0d02c6",
-				"display": "OB-History v1.5"
-			},
-			"formName": "component_ob-history-1.5",
-			"alias": "obgynhist15"
-		},
-		{
-			"ref": {
-				"uuid": "c297210f-a151-49a5-bf51-d2d726fe459d",
-				"display": "Enhanced Adherence 1.0"
-			},
-			"formName": "component_enhanced-adherence-v1.0",
-			"alias": "enhadhere1"
-		},
-		{
-			"ref": {
-				"uuid": "83eaa418-9d70-4a27-b5cd-f7eed9e11f6f",
-				"display": "DC Plan"
-			},
-			"formName": "component_dc-plan",
-			"alias": "dcPlan"
-		},
-		{
-			"ref": {
-				"uuid": "ad50a94d-4edb-463d-b6e6-ac83eecffa7c",
-				"display": "component_gender-based-violence"
-			},
-			"formName": "component_gender-based-violence-v1.0",
-			"alias": "gbv10"
-		},
-		{
-			"ref": {
-				"uuid": "1d265294-3a62-4ab4-bc64-038cbd4a8a14",
-				"display": "component_positive-health-dignity-&-prevention-services-v12"
-			},
-			"formName": "component_positive-health-dignity-&-prevention-services-v1.2",
-			"alias": "phdp12"
-		},
-		{
-			"ref": {
-				"uuid": "3b56db77-167f-49ee-b52f-7511ac71294f",
-				"display": "component_referral-v1.4"
-			},
-			"formName": "component_referral-v1.4",
-			"alias": "ref14"
-		}
-	],
-	"pages": [
-		{
-			"label": "Encounter Details",
-			"componentConfigs": [
-				{
-					"tag": "afe-content-display",
-					"url": "http://localhost:4200/lib/web-components.bundled.js?module",
-					"module": "true",
-					"detail": "This is custom component within a page it is displayed at the top of the page"
-				}
-			],
-			"sections": [
-				{
-					"label": "Encounter Details",
-					"componentConfigs": [
-						{
-							"tag": "afe-content-display",
-							"url": "http://localhost:4200/lib/web-components.bundled.js?module",
-							"module": "true",
-							"detail": "This is custom component within a section it is displayed at the top of the section"
-						}
-					],
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Visit date:",
-							"type": "encounterDatetime",
-							"datePickerFormat": "both",
-							"required": "true",
-							"default": "",
-							"id": "encDate",
-							"questionOptions": {
-								"rendering": "date"
-							},
-							"validators": [
-								{
-									"type": "date"
-								}
-							]
-						},
-						{
-							"type": "encounterProvider",
-							"label": "Provider:",
-							"id": "provider",
-							"required": "true",
-							"default": "",
-							"questionOptions": {
-								"rendering": "ui-select-extended"
-							}
-						},
-						{
-							"type": "encounterLocation",
-							"label": "Facility name (site/satellite clinic required):",
-							"id": "location",
-							"required": "true",
-							"questionOptions": {
-								"rendering": "ui-select-extended"
-							}
-						},
-						{
-							"type": "obs",
-							"label": "Custom Control Test:",
-							"id": "customCon",
-							"default": "",
-							"questionOptions": {
-								"rendering": "select",
-								"customControl": true,
-								"answers": [
-									{
-										"concept": "8b715fed-97f6-4e38-8f6a-c167a42f8923",
-										"label": "yes"
-									},
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								]
-							},
-							"customControlConfig": {
-								"tag": "afe-content-switcher",
-								"url": "http://localhost:4200/lib/web-components.bundled.js?module",
-								"module": "true"
-							}
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Pre-Clinic Review",
-			"sections": [
-				{
-					"label": "Pre-clinic Review",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"id": "scheduledVisit",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "a89ff9a6-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a89b6440-1350-11df-a1f1-0026b9348838"
-									},
-									{
-										"concept": "a89ff816-1350-11df-a1f1-0026b9348838"
-									},
-									{
-										"concept": "a89ff8de-1350-11df-a1f1-0026b9348838"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "If unscheduled, actual scheduled date",
-							"id": "actualDate",
-							"type": "obs",
-							"required": {
-								"type": "conditionalRequired",
-								"message": "Patient visit marked as unscheduled. Please provide the scheduled date.",
-								"referenceQuestionId": "scheduledVisit",
-								"referenceQuestionAnswers": [
-									"a89ff816-1350-11df-a1f1-0026b9348838",
-									"a89ff8de-1350-11df-a1f1-0026b9348838"
-								]
-							},
-							"questionOptions": {
-								"rendering": "date",
-								"concept": "dc1942b2-5e50-4adc-949d-ad6c905f054e"
-							},
-							"validators": [
-								{
-									"type": "date",
-									"allowFutureDates": "true"
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(scheduledVisit) && arrayContains(['a89ff816-1350-11df-a1f1-0026b9348838','a89ff8de-1350-11df-a1f1-0026b9348838'], scheduledVisit) && isEmpty(myValue)",
-									"message": "Patient visit marked as unscheduled. Please provide the scheduled date."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "!arrayContains(['a89ff816-1350-11df-a1f1-0026b9348838','a89ff8de-1350-11df-a1f1-0026b9348838'], scheduledVisit)"
-							}
-						},
-						{
-							"label": "Patient covered by NHIF:",
-							"id": "nhif",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('0b49e3e6-55df-4096-93ca-59edadb74b3f')) ? undefined : HD.getObject('prevEnc').getValue('0b49e3e6-55df-4096-93ca-59edadb74b3f')",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "0b49e3e6-55df-4096-93ca-59edadb74b3f",
-								"answers": [
-									{
-										"concept": "8b715fed-97f6-4e38-8f6a-c167a42f8923",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "What is the patient's NHIF status?",
-							"id": "nhifStatus",
-							"questionInfo": "Indicate if the patient has been remitting monthly contributions towards the NHIF medical cover.",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "548e6743-67c0-4a6b-bb07-b5f799f63bc1",
-								"answers": [
-									{
-										"concept": "b058a9ad-a0e4-4b37-9214-75b8aed1eaa4",
-										"label": "Active"
-									},
-									{
-										"concept": "dd373348-1a7f-4625-9e69-9904fa1cc9c7",
-										"label": "Inactive"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "nhif !== '8b715fed-97f6-4e38-8f6a-c167a42f8923'"
-							}
-						},
-						{
-							"label": "What other insurance do you have?",
-							"id": "healthInsurance",
-							"questionInfo": "Indicate if the patient has another medical cover.",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "a8b02524-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									},
-									{
-										"concept": "0bfb0150-949b-4625-98b8-b9d8275bcf44",
-										"label": "Employer based health insurance"
-									},
-									{
-										"concept": "6fac74c3-fe25-4170-92a4-3ecb8859152e",
-										"label": "Individual private health insurance"
-									},
-									{
-										"concept": "cb0b7a67-961b-485d-8dde-4fa65cec476b",
-										"label": "Linda mama services"
-									},
-									{
-										"concept": "21eb8488-76ae-47ce-a542-bb3038ab05de",
-										"label": "Zuri health insurance"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "nhif !== 'a899e0ac-1350-11df-a1f1-0026b9348838'"
-							}
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Clinical History",
-			"sections": [
-				{
-					"label": "Social History",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Civil status:",
-							"type": "obs",
-							"historicalExpression": "HD.getObject('prevEnc').getValue('a899a9f2-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "a899a9f2-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899af10-1350-11df-a1f1-0026b9348838",
-										"label": "Cohabitating"
-									},
-									{
-										"concept": "a899ad58-1350-11df-a1f1-0026b9348838",
-										"label": "Divorced"
-									},
-									{
-										"concept": "a8aa76b0-1350-11df-a1f1-0026b9348838",
-										"label": "Married monogamous"
-									},
-									{
-										"concept": "a8b03712-1350-11df-a1f1-0026b9348838",
-										"label": "Married polygamous"
-									},
-									{
-										"concept": "a899aba0-1350-11df-a1f1-0026b9348838",
-										"label": "Separated"
-									},
-									{
-										"concept": "a899ac7c-1350-11df-a1f1-0026b9348838",
-										"label": "Single"
-									},
-									{
-										"concept": "a899ae34-1350-11df-a1f1-0026b9348838",
-										"label": "Widowed"
-									}
-								]
-							},
-							"validators": [],
-							"id": "__pDtIu3KJK"
-						},
-						{
-							"label": "Discordant couple:",
-							"required": "true",
-							"questionOptions": {
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									},
-									{
-										"concept": "a899b50a-1350-11df-a1f1-0026b9348838",
-										"label": "Unknown"
-									},
-									{
-										"concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
-										"label": "N/A"
-									}
-								],
-								"concept": "a8af49d8-1350-11df-a1f1-0026b9348838",
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"id": "__HtF2FGyLo"
-						}
-					]
-				},
-				{
-					"label": "Partner Notification Service",
-					"questions": [
-						{
-							"type": "obsGroup",
-							"label": "Partner notification",
-							"id": "pns",
-							"questionOptions": {
-								"concept": "8767734c-0f98-4084-b960-6453f8679600",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Sexual partner tested?",
-									"id": "sexPartnerTested",
-									"questionOptions": {
-										"answers": [
-											{
-												"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-												"label": "Yes"
-											},
-											{
-												"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-												"label": "No"
-											}
-										],
-										"concept": "a8a4636a-1350-11df-a1f1-0026b9348838",
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": []
-								},
-								{
-									"label": "Do you have a new sexual partner?",
-									"id": "newSexPartner",
-									"questionOptions": {
-										"answers": [
-											{
-												"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-												"label": "Yes"
-											},
-											{
-												"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-												"label": "No"
-											}
-										],
-										"concept": "79f74b25-3f97-4367-a57d-7571bba1d7b4",
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": []
-								},
-								{
-									"label": "Name of new sexual partner:",
-									"id": "nameSexPartner",
-									"questionOptions": {
-										"answers": [],
-										"concept": "dcb0f31c-d070-4f03-8e6e-5d07367e1500",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "newSexPartner !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							]
-						}
-					]
-				},
-				{
-					"label": "Prevention With Positives",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Prevention with positives: At risk population:",
-							"required": "true",
-							"historicalExpression": "HD.getObject('prevEnc').getValue('93aa3f1d-1c39-4196-b5e6-8adc916cd5d6')",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "93aa3f1d-1c39-4196-b5e6-8adc916cd5d6",
-								"answers": [
-									{
-										"concept": "5da55301-e28e-4fdf-8b64-02622dedc8b0",
-										"label": "Client of sex worker"
-									},
-									{
-										"concept": "a89ff438-1350-11df-a1f1-0026b9348838",
-										"label": "Commercial sex worker"
-									},
-									{
-										"concept": "a8af49d8-1350-11df-a1f1-0026b9348838",
-										"label": "Discordant couple"
-									},
-									{
-										"concept": "a890d57a-1350-11df-a1f1-0026b9348838",
-										"label": "IV drug use"
-									},
-									{
-										"concept": "e19c35f0-12f0-46c2-94ea-97050f37b811",
-										"label": "MSM"
-									},
-									{
-										"concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
-										"label": "N/A"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [],
-							"id": "__vnK5zxMFx"
-						},
-						{
-							"label": "Prevention with positives: PWP services:",
-							"id": "pwpServices",
-							"required": "true",
-							"historicalExpression": "HD.getObject('prevEnc').getValue('9ce5dbf0-a141-4ad8-8c9d-cd2bf84fe72b')",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "9ce5dbf0-a141-4ad8-8c9d-cd2bf84fe72b",
-								"answers": [
-									{
-										"concept": "f0a280e8-eb88-41a8-837a-f9949ed1b9cd",
-										"label": "Condom promotion/provision"
-									},
-									{
-										"concept": "bf51f71e-937c-4da5-ae07-654acf59f5bb",
-										"label": "Couple counseling"
-									},
-									{
-										"concept": "91f43249-73c7-427c-8300-2038fc0d6be8",
-										"label": "Needle exchange"
-									},
-									{
-										"concept": "05656545-86be-4605-9527-34fb580534b1",
-										"label": "Targeted risk reduction"
-									},
-									{
-										"concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
-										"label": "N/A"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "Hospitalization History",
-					"questions": [
-						{
-							"type": "obsGroup",
-							"label": "Recent hospitalizations",
-							"questionOptions": {
-								"rendering": "group",
-								"concept": "a8a003a6-1350-11df-a1f1-0026b9348838"
-							},
-							"questions": [
-								{
-									"label": "Was the patient hospitalized since last visit?",
-									"id": "wasHospitalized",
-									"questionOptions": {
-										"concept": "a898c56e-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-												"label": "Yes"
-											},
-											{
-												"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-												"label": "No"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": []
-								}
-							],
-							"id": "__ty3FIrHrq"
-						},
-						{
-							"type": "obsGroup",
-							"label": "If yes reason for hospitalization:",
-							"questionOptions": {
-								"concept": "a8a003a6-1350-11df-a1f1-0026b9348838",
-								"rendering": "repeating"
-							},
-							"questions": [
-								{
-									"label": "Reason for hospitalization:",
-									"id": "hospReason",
-									"questionOptions": {
-										"concept": "a8a07a48-1350-11df-a1f1-0026b9348838",
-										"rendering": "problem"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "conditionalAnswered",
-											"message": "Providing diagnosis but didn't answer that patient was hospitalized in question",
-											"referenceQuestionId": "wasHospitalized",
-											"referenceQuestionAnswers": [
-												"a899b35c-1350-11df-a1f1-0026b9348838"
-											]
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "isEmpty(myValue) && !isEmpty(wasHospitalized) && wasHospitalized === 'a899b35c-1350-11df-a1f1-0026b9348838'",
-											"message": "Patient previously marked as hospitalized. Please provide hospitalization reason."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "wasHospitalized !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							],
-							"id": "__y5xuGIE2H"
-						}
-					]
-				},
-				{
-					"label": "Reproductive History",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "How many pregnancies have you had?",
-							"type": "obs",
-							"id": "noPregnancy",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8aaf59a-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8aaf59a-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a8aaf59a-1350-11df-a1f1-0026b9348838",
-								"rendering": "number",
-								"max": "50",
-								"min": "0"
-							},
-							"hide": {
-								"hideWhenExpression": "sex !== 'F'"
-							}
-						},
-						{
-							"label": "How many pregnancies have you delivered (more than 24 weeks)?",
-							"type": "obs",
-							"id": "noDelivery",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a899a920-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a899a920-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a899a920-1350-11df-a1f1-0026b9348838",
-								"rendering": "number",
-								"min": "0",
-								"max": "50"
-							},
-							"hide": {
-								"hideWhenExpression": "sex !== 'F'"
-							}
-						},
-						{
-							"label": "Reproductive age status:",
-							"id": "menStatus",
-							"required": "true",
-							"questionOptions": {
-								"concept": "a8a185d2-1350-11df-a1f1-0026b9348838",
-								"rendering": "select",
-								"answers": [
-									{
-										"label": "Menstruating",
-										"concept": "a8ad2b4e-1350-11df-a1f1-0026b9348838"
-									},
-									{
-										"label": "Postmenopausal",
-										"concept": "5cc1c1a7-dfcc-47dc-ad73-c386c188fad8"
-									},
-									{
-										"label": "Amenorrhea",
-										"concept": "a8a18514-1350-11df-a1f1-0026b9348838"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "sex !== 'F'"
-							}
-						},
-						{
-							"label": "LMP:",
-							"id": "lmpDate1",
-							"questionOptions": {
-								"concept": "a89ff758-1350-11df-a1f1-0026b9348838",
-								"rendering": "date"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "date"
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(pattype1) && pattype1 === '375e6d4a-ba94-41ac-8ac3-5a56015c4d92'",
-									"message": "Patient is antenatal. Please provide LMP."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(menStatus) && menStatus === 'a8ad2b4e-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient is menstruating. Please provide LMP."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": " sex !== 'F' || menStatus !== 'a8ad2b4e-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Is the patient pregnant?",
-							"id": "pregnant",
-							"questionOptions": {
-								"concept": "6b4f1d00-0a27-41dd-a299-fb7dc730819c",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && moment(encDate).diff(moment(lmpDate1), 'days') >= 35",
-									"message": "Last LMP is greater than 35 days. Please indicate patient's pregnancy status."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "sex !== 'F' || menStatus === '5cc1c1a7-dfcc-47dc-ad73-c386c188fad8' || visitTypeUuid === 'b1a978ca-9315-4ba2-ac2b-84efb9a68c5c'"
-							}
-						},
-						{
-							"label": "EDD:",
-							"id": "delDate",
-							"required": "true",
-							"questionOptions": {
-								"concept": "a8aaddbc-1350-11df-a1f1-0026b9348838",
-								"rendering": "date",
-								"calculate": {
-									"calculateExpression": "moment(lmpDate1).isValid() ? moment(lmpDate1).add(280, 'days').toDate():''"
-								}
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "(new moment(lmpDate1)).isAfter((new moment(myValue)), 'day') || (new moment(lmpDate1)).isSame((new moment(myValue)), 'day')",
-									"message": "EDD should be greater than the encounter date."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(pregnant) && pregnant === 'a899b35c-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient is pregnant. Please provide EDD."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "pregnant !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Reason patient not pregnant?",
-							"id": "reasonNotPreg",
-							"questionOptions": {
-								"concept": "f701166d-9820-420d-b0bc-c98ad4747dec",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "5bafcbc0-e499-4741-85e3-52e93f68f08c",
-										"label": "Pregnancy not suspected"
-									},
-									{
-										"concept": "6cb93e09-cd9a-4333-994a-9cd65dfa8c12",
-										"label": "Pregnancy test is negative"
-									},
-									{
-										"concept": "c662737e-d529-4b49-9ad3-2d72eeb56b45",
-										"label": "Using hormonal contraceptive"
-									},
-									{
-										"concept": "3bca6c9c-333c-433e-ac07-7e44e0501b49",
-										"label": "postpartum < 6 weeks"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(pregnant) && pregnant === 'a899b42e-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient is not pregnant. Please provide reasons."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "pregnant !== 'a899b42e-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Actual date of delivery:",
-							"id": "actualDelDate",
-							"questionOptions": {
-								"concept": "a8aae050-1350-11df-a1f1-0026b9348838",
-								"rendering": "date"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "!arrayContains (['0b1b6194-d2d5-4e4b-9f7c-c3b778ccc354','53954785-4d53-4012-8f30-1c37fa870906','0d4512f1-47b5-44e6-8035-feec9be25b4b','161f3383-65d8-4c19-9554-52ee5c3d43ff'],visitTypeUuid )"
-							}
-						},
-						{
-							"label": "Gestation in weeks:",
-							"id": "gestationWeeks",
-							"questionOptions": {
-								"concept": "0670d3d9-950c-4836-b147-0dc8e6b013aa",
-								"rendering": "number"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "pregnant !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','55c74fa8-c810-4b37-a918-14a851bba6f3','44032888-08e1-4900-b9dd-7d236d79276c'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Pregnancy outcome:",
-							"id": "pregOutcome",
-							"questionOptions": {
-								"concept": "a8aff7e8-1350-11df-a1f1-0026b9348838",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "a890a1b8-1350-11df-a1f1-0026b9348838",
-										"label": "Abortion/Miscarriage/Terminated"
-									},
-									{
-										"concept": "e8074110-b989-45e3-b89c-d6092d1a2fd7",
-										"label": "Live birth (Preterm)"
-									},
-									{
-										"concept": "bdde6796-fc68-4a84-b569-56cbeb7e5101",
-										"label": "Live birth (Term)"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "!arrayContains (['0b1b6194-d2d5-4e4b-9f7c-c3b778ccc354','53954785-4d53-4012-8f30-1c37fa870906','0d4512f1-47b5-44e6-8035-feec9be25b4b','161f3383-65d8-4c19-9554-52ee5c3d43ff'],visitTypeUuid)"
-							}
-						}
-					]
-				},
-				{
-					"label": "Family Planning Profile",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Is the client using condoms?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8a00090-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8a00090-1350-11df-a1f1-0026b9348838')",
-							"id": "condomUse",
-							"questionOptions": {
-								"concept": "a8a00090-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','55c74fa8-c810-4b37-a918-14a851bba6f3','44032888-08e1-4900-b9dd-7d236d79276c'], visitTypeUuid)"
-							}
-						},
-						{
-							"type": "obsGroup",
-							"label": "Family planning, detailed",
-							"questionOptions": {
-								"concept": "767e8060-5272-4927-ab78-97534a4499ef",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Select modern contraception method:",
-									"required": "true",
-									"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('767e8060-5272-4927-ab78-97534a4499ef.a894b1cc-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('767e8060-5272-4927-ab78-97534a4499ef.a894b1cc-1350-11df-a1f1-0026b9348838')",
-									"id": "fpMethod",
-									"questionOptions": {
-										"concept": "a894b1cc-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-												"label": "None"
-											},
-											{
-												"concept": "a8a713f8-1350-11df-a1f1-0026b9348838",
-												"label": "Bilateral tubal ligation"
-											},
-											{
-												"concept": "a123d949-31f3-4abf-98e3-8504e17ebc00",
-												"label": "3-year implant"
-											},
-											{
-												"concept": "feb48308-a56f-4754-8e8f-8c1698e570cb",
-												"label": "5-year implant"
-											},
-											{
-												"concept": "f8c66a32-3660-4233-ae51-d3a4a1eac44e",
-												"label": "IUCD copper"
-											},
-											{
-												"concept": "236dba53-1062-46b4-8067-ec8711897dbf",
-												"label": "IUCD hormonal"
-											},
-											{
-												"concept": "a8988b44-1350-11df-a1f1-0026b9348838",
-												"label": "Injectables (Depo)"
-											},
-											{
-												"concept": "a8aff1b2-1350-11df-a1f1-0026b9348838",
-												"label": "Combined hormone oral contraceptive pills"
-											},
-											{
-												"concept": "a8afeb54-1350-11df-a1f1-0026b9348838",
-												"label": "Projestin only pills"
-											},
-											{
-												"concept": "eaa5796d-0b1c-478b-8c9d-d23cf4c3bddc",
-												"label": "Vasectomy"
-											},
-											{
-												"concept": "4a740e33-fee5-4a2b-b679-1904722e3d9e",
-												"label": "Lactational amenohhrea method"
-											},
-											{
-												"concept": "a8a71588-1350-11df-a1f1-0026b9348838",
-												"label": "Diaphram/Cervical cap"
-											},
-											{
-												"concept": "b75702a6-908d-491b-9399-6495712c81cc",
-												"label": "Emergency contraceptive pills"
-											},
-											{
-												"concept": "a8aff284-1350-11df-a1f1-0026b9348838",
-												"label": "Periodic abstinence"
-											},
-											{
-												"concept": "856a7f0d-8359-4316-97c1-2d37813414f0",
-												"label": "Undecided"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "sex !== 'F' || menStatus === '5cc1c1a7-dfcc-47dc-ad73-c386c188fad8' || arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','55c74fa8-c810-4b37-a918-14a851bba6f3','44032888-08e1-4900-b9dd-7d236d79276c'], visitTypeUuid)"
-									}
-								},
-								{
-									"type": "obs",
-									"label": "Approximate start date (If FP is 3-year implant/5-year implant/Injectables/Vasectomy/IUCD Copper/IUCD Hormonal/Bilateral tubal ligation)",
-									"id": "appStartDate",
-									"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('767e8060-5272-4927-ab78-97534a4499ef.a89ae092-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('767e8060-5272-4927-ab78-97534a4499ef.a89ae092-1350-11df-a1f1-0026b9348838')",
-									"questionOptions": {
-										"concept": "a89ae092-1350-11df-a1f1-0026b9348838",
-										"rendering": "date"
-									},
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "(new moment(encDate)).isBefore((new moment(myValue)), 'day') || (new moment(encDate)).isSame((new moment(myValue)), 'day')",
-											"message": "Start date should be before the encounter date."
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "isEmpty(myValue) && !(isEmpty(fpMethod) || !arrayContainsAny(fpMethod,['a123d949-31f3-4abf-98e3-8504e17ebc00','feb48308-a56f-4754-8e8f-8c1698e570cb','eaa5796d-0b1c-478b-8c9d-d23cf4c3bddc','a8988b44-1350-11df-a1f1-0026b9348838','a8a713f8-1350-11df-a1f1-0026b9348838','f8c66a32-3660-4233-ae51-d3a4a1eac44e','236dba53-1062-46b4-8067-ec8711897dbf']))",
-											"message": "Start date is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(fpMethod) || arrayContains(['a899e0ac-1350-11df-a1f1-0026b9348838','a897dbd6-1350-11df-a1f1-0026b9348838'],fpMethod) && visitTypeUuid !== 'b1a978ca-9315-4ba2-ac2b-84efb9a68c5c'"
-									}
-								}
-							],
-							"id": "__zuFzDwJn4"
-						}
-					]
-				},
-				{
-					"label": "Cancer Screening",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Cervical cancer screening done:",
-							"required": "true",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('3086a740-face-4fcd-825b-1e627a66c93a')) ? undefined : HD.getObject('prevEnc').getValue('3086a740-face-4fcd-825b-1e627a66c93a')",
-							"id": "cervCanScreen",
-							"questionOptions": {
-								"concept": "3086a740-face-4fcd-825b-1e627a66c93a",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									},
-									{
-										"concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
-										"label": "N/A"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "sex !== 'F'"
-							}
-						},
-						{
-							"label": "Cervical cancer screening test result:",
-							"type": "obs",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('6bad2971-c776-4f0e-ae15-a3fc0cbd7d0f')) ? undefined : HD.getObject('prevEnc').getValue('6bad2971-c776-4f0e-ae15-a3fc0cbd7d0f')",
-							"id": "caTestResult",
-							"questionOptions": {
-								"concept": "6bad2971-c776-4f0e-ae15-a3fc0cbd7d0f",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-										"label": "Positive"
-									},
-									{
-										"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-										"label": "Negative"
-									}
-								]
-							},
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "sex !== 'F' ||cervCanScreen !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Cervical cancer result date:",
-							"type": "obs",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('958b9055-88be-4bf1-9a2c-f209424a03ac')) ? undefined : HD.getObject('prevEnc').getValue('958b9055-88be-4bf1-9a2c-f209424a03ac')",
-							"default": "",
-							"id": "cercanDate",
-							"questionOptions": {
-								"rendering": "date",
-								"concept": "958b9055-88be-4bf1-9a2c-f209424a03ac"
-							},
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(caTestResult) && caTestResult !== 'a89ad3a4-1350-11df-a1f1-0026b9348838' ",
-									"message": "Date is result is required."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "isEmpty(caTestResult)"
-							}
-						},
-						{
-							"label": "If cervical cancer is positive, is patient on treatment?",
-							"id": "caTreatment",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('3e4943b5-8499-43fb-b254-e1bb1dacfdb7')) ? undefined : HD.getObject('prevEnc').getValue('3e4943b5-8499-43fb-b254-e1bb1dacfdb7')",
-							"questionOptions": {
-								"concept": "3e4943b5-8499-43fb-b254-e1bb1dacfdb7",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									},
-									{
-										"concept": "a89c1ef8-1350-11df-a1f1-0026b9348838",
-										"label": "Completed"
-									},
-									{
-										"concept": "a899b50a-1350-11df-a1f1-0026b9348838",
-										"label": "Unknown"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "caTestResult !== 'a896f3a6-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "If patient on treatment, indicate below:",
-							"type": "obs",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('94f54710-6ee0-45cd-ad5f-a990fcb47bc1')) ? undefined : HD.getObject('prevEnc').getValue('94f54710-6ee0-45cd-ad5f-a990fcb47bc1')",
-							"id": "caTreatmentMode",
-							"questionOptions": {
-								"concept": "94f54710-6ee0-45cd-ad5f-a990fcb47bc1",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "dcb72b0b-c1cb-4f32-aa82-e8f7b74cc16e",
-										"label": "Cryotherapy"
-									},
-									{
-										"concept": "ca10f28c-586a-427a-8bcc-816f0835ab18",
-										"label": "Chemotherapy"
-									},
-									{
-										"concept": "a8a713f8-1350-11df-a1f1-0026b9348838",
-										"label": "Hysterectomy"
-									},
-									{
-										"concept": "12afc118-5acd-48c6-89a0-1b6156c33d10",
-										"label": "Radiotherapy"
-									},
-									{
-										"concept": "b6fccd82-c622-4c3e-9563-39899e709b3b",
-										"label": "Thermo-coagulation/Loop Electrosurgical Excision Procedure"
-									}
-								]
-							},
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "caTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						}
-					]
-				},
-				{
-					"label": "GBV Screening",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Within the past 3 months, have you been hit, slapped, kicked or physically hurt by someone in any way?",
-							"required": "true",
-							"id": "physical",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "8fca5b8a-0674-49e5-8111-003db067ee22",
-								"rendering": "select",
-								"answers": [
-									{
-										"label": "Yes",
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838"
-									},
-									{
-										"label": "No",
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838"
-									}
-								]
-							}
-						},
-						{
-							"label": "Are you in a relationship with a person who physically hit you?",
-							"required": "true",
-							"id": "domestic",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "4045cb6c-793c-4784-bea5-6e2b7bfd8467",
-								"rendering": "select",
-								"answers": [
-									{
-										"label": "Yes",
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838"
-									},
-									{
-										"label": "No",
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838"
-									}
-								]
-							}
-						},
-						{
-							"label": "Are you in a relationship with a person who threatens, frightens or insults you or treats you badly?",
-							"required": "true",
-							"id": "emotional",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "374a34e2-71a0-4221-b59e-8d50721330ee",
-								"rendering": "select",
-								"answers": [
-									{
-										"label": "Yes",
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838"
-									},
-									{
-										"label": "No",
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838"
-									}
-								]
-							}
-						},
-						{
-							"label": "Are you in relationship with a person who forces you to participate in sexual activities that make you feel uncomfortable?",
-							"required": "true",
-							"id": "sexual",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "920709bc-dde6-4d21-863e-851e63c084e4",
-								"rendering": "select",
-								"answers": [
-									{
-										"label": "Yes",
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838"
-									},
-									{
-										"label": "No",
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838"
-									}
-								]
-							}
-						},
-						{
-							"label": "Have you ever experienced any of the above with someone you do not have a relationship with?",
-							"required": "true",
-							"id": "nonfamily",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "588b29de-2200-4dc5-ba38-9992771aa535",
-								"rendering": "select",
-								"answers": [
-									{
-										"label": "Yes",
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838"
-									},
-									{
-										"label": "No",
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838"
-									}
-								]
-							}
-						}
-					]
-				},
-				{
-					"label": "Adult Vaccination",
-					"questions": [
-						{
-							"label": "Immunization history:",
-							"type": "obs",
-							"questionOptions": {
-								"rendering": "multiCheckbox",
-								"concept": "b29b512f-cd46-41ee-a568-bdaafa0bb874",
-								"answers": [
-									{
-										"concept": "a897dd84-1350-11df-a1f1-0026b9348838",
-										"label": "Hepatitis B"
-									},
-									{
-										"concept": "a8a70746-1350-11df-a1f1-0026b9348838",
-										"label": "Flu"
-									},
-									{
-										"concept": "a890a654-1350-11df-a1f1-0026b9348838",
-										"label": "Tetanus booster"
-									}
-								]
-							},
-							"validators": [],
-							"id": "__yKrIpr8pC"
-						}
-					]
-				},
-				{
-					"label": "Breastfeeding",
-					"questions": [
-						{
-							"label": "Child breastfeeding?",
-							"required": "true",
-							"id": "childBreFeeding",
-							"questionOptions": {
-								"concept": "a8aafc70-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": " !arrayContainsAny(['0b1b6194-d2d5-4e4b-9f7c-c3b778ccc354','53954785-4d53-4012-8f30-1c37fa870906','0d4512f1-47b5-44e6-8035-feec9be25b4b','161f3383-65d8-4c19-9554-52ee5c3d43ff'], visitTypeUuid)"
-							}
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Medication History",
-			"sections": [
-				{
-					"label": "ART History",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Is the patient on ART?",
-							"required": "true",
-							"id": "onArt",
-							"historicalExpression": "arrayContainsAny(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838'], HD.getObject('prevEnc').getValue('a89b75d4-1350-11df-a1f1-0026b9348838')) ? 'a899b35c-1350-11df-a1f1-0026b9348838' : HD.getObject('prevEnc').getValue('a89ae254-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a89ae254-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(transferInControl) && transferInControl === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], myValue)",
-									"message": "In the enrollment section, patient not marked as transfer in. Kindly confirm."
-								}
-							]
-						},
-						{
-							"label": "Is the patient on ART 2?",
-							"required": "true",
-							"id": "onArt2",
-							"historicalExpression": "arrayContainsAny(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838'], HD.getObject('prevEnc').getValue('a89b75d4-1350-11df-a1f1-0026b9348838')) ? 'a899b35c-1350-11df-a1f1-0026b9348838' : HD.getObject('prevEnc').getValue('a89ae254-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a89ae254-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(transferInControl) && transferInControl === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], myValue)",
-									"message": "In the enrollment section, patient not marked as transfer in. Kindly confirm."
-								}
-							]
-						},
-						{
-							"label": "Reason for use:",
-							"id": "reasonUse",
-							"type": "obs",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8a30d1c-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8a30d1c-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a8a30d1c-1350-11df-a1f1-0026b9348838",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "a89adc46-1350-11df-a1f1-0026b9348838",
-										"label": "Treatment"
-									},
-									{
-										"concept": "a8a19c20-1350-11df-a1f1-0026b9348838",
-										"label": "PEP"
-									},
-									{
-										"concept": "27ac429d-8a42-476e-b2f6-65bde0b8c935",
-										"label": "Prep"
-									},
-									{
-										"concept": "a89fbedc-1350-11df-a1f1-0026b9348838",
-										"label": "PMTCT"
-									}
-								]
-							},
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "If patient started ART since last visit, enter start date:",
-							"id": "startDate",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a89d200a-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a89d200a-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a89d200a-1350-11df-a1f1-0026b9348838",
-								"rendering": "date"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "date"
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Line of ART patient is taking:",
-							"id": "current_arv_line",
-							"historicalExpression": "!_.isEmpty(HD.getObject('prevEnc').getValue('a89b6a62-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('04616f5d-b961-4f41-bbd7-bcc0dd235577')",
-							"questionOptions": {
-								"concept": "04616f5d-b961-4f41-bbd7-bcc0dd235577",
-								"answers": [
-									{
-										"concept": "034047bd-3fa1-4b2a-b0f0-2787e9b9f7b3",
-										"label": "First line regimen"
-									},
-									{
-										"concept": "8f8a715d-e49a-4b2c-aa3a-83fa9d7a4254",
-										"label": "Second line regimen"
-									},
-									{
-										"concept": "a90ebdd2-351f-485a-b850-4938fcca2729",
-										"label": "Third line regimen"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient previously marked as on ART. Please provide the treatment category."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Patient's ART regimen, adults:",
-							"id": "current_art_regimen_adult",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a89b6a62-1350-11df-a1f1-0026b9348838')) ? (_.isEmpty(HD.getObject('prevEnc').getValue('a8a08344-1350-11df-a1f1-0026b9348838'))? HD.getObject('prevEnc').getValue('a899cf5e-1350-11df-a1f1-0026b9348838') : HD.getObject('prevEnc').getValue('a899cf5e-1350-11df-a1f1-0026b9348838')) : HD.getObject('prevEnc').getValue('a89b6a62-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a899cf5e-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "18e86e1f-92b8-40cd-8266-0df0ab0a4a50",
-										"label": "DTG50mg/3TC300mg/TDF300mg"
-									},
-									{
-										"concept": "1c4a75d0-cc91-4752-b0a5-4b833326ff7a",
-										"label": "TDF300mg/3TC300mg/EFV600mg"
-									},
-									{
-										"concept": "ea501f4e-cbc5-4942-b9c8-0ac415929f08",
-										"label": "TDF300mg/3TC300mg/EFV400mg"
-									},
-									{
-										"concept": "6a73f32d-1870-4527-af6e-74443251ded2",
-										"label": "NVP200/ZDV300/3TC150"
-									},
-									{
-										"concept": "e78843da-fdb6-446d-8e99-873c278b3540",
-										"label": "ABC600mg/3TC300mg"
-									},
-									{
-										"concept": "a89cc876-1350-11df-a1f1-0026b9348838",
-										"label": "3TC300mg/TDF300mg"
-									},
-									{
-										"concept": "a896758e-1350-11df-a1f1-0026b9348838",
-										"label": "3TC150mg/ZDV300mg"
-									},
-									{
-										"concept": "a8afcf84-1350-11df-a1f1-0026b9348838",
-										"label": "Emtri200mg/TDF300(Truvada)"
-									},
-									{
-										"concept": "a897e7c0-1350-11df-a1f1-0026b9348838",
-										"label": "Aluvia(Kaletra)200mg/LPV50mg"
-									},
-									{
-										"concept": "a8afc066-1350-11df-a1f1-0026b9348838",
-										"label": "Atazanavir300/Ritonavir100"
-									},
-									{
-										"concept": "dabf36cb-dd9a-4542-a8ef-874c1ee5be4a",
-										"label": "FTC200mg/RPV25mg/TDF245mg(Eviplera)"
-									},
-									{
-										"concept": "98b0baf6-0b73-4429-9264-6233684b0969",
-										"label": "Dolutegravir 50mg"
-									},
-									{
-										"concept": "a897f8a0-1350-11df-a1f1-0026b9348838",
-										"label": "Abacavir300mg"
-									},
-									{
-										"concept": "db3c194b-3e1b-4001-9a1c-a5df1728fc28",
-										"label": "Efavirenz 200mg"
-									},
-									{
-										"concept": "a89673f4-1350-11df-a1f1-0026b9348838",
-										"label": "Lamivudine150mg"
-									},
-									{
-										"concept": "a8afbd64-1350-11df-a1f1-0026b9348838",
-										"label": "Raltegravir 400mg"
-									},
-									{
-										"concept": "a897ea4a-1350-11df-a1f1-0026b9348838",
-										"label": "Zidovudine300mg"
-									},
-									{
-										"concept": "68a0a5dd-1e91-43a2-8dce-c6e84a14de04",
-										"label": "Darunavir 600mg"
-									},
-									{
-										"concept": "1baf254e-1429-4fd9-8db1-edf6523cea13",
-										"label": " Ritonavir 100mg"
-									},
-									{
-										"concept": "42ef7c4d-d6fb-49c0-a46e-019c42dea203",
-										"label": " Ritonavir 80mg"
-									},
-									{
-										"concept": "38fbba9c-4b26-412d-9659-8dd649514d66",
-										"label": "Etravirine 100mg"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient  marked as on ART. Please provide the Regimen."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"type": "obsGroup",
-							"label": "ART adherence",
-							"questionOptions": {
-								"concept": "bc3834dd-ef07-4027-be30-729baa069291",
-								"rendering": "group"
-							},
-							"questions": [],
-							"id": "__x8EsJHxFJ"
-						}
-					]
-				},
-				{
-					"label": "Morisky Adherence",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Do you ever forget to take your medicines? (0=No, 1=Yes)",
-							"id": "forget",
-							"questionOptions": {
-								"concept": "99a99956-90b0-431e-a453-bf8efffeb7d3",
-								"rendering": "number",
-								"max": "1",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Patient on ARVs. Please provide morisky adherence history."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Are you sometimes not keen about taking your medications? (0=No, 1=Yes)",
-							"id": "notKeen",
-							"questionOptions": {
-								"concept": "26b3c8c9-20be-4585-98f7-c8b8bf2c9207",
-								"rendering": "number",
-								"max": "1",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Patient on ARVs. Please provide morisky adherence history."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Do you stop taking medicine at times when you feel worse? (0=No, 1=Yes)",
-							"id": "feelWorse",
-							"questionOptions": {
-								"concept": "ccffa130-12c6-45e8-a24a-b16c0395abd5",
-								"rendering": "number",
-								"max": "1",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Patient on ARVs. Please provide morisky adherence history."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "If you feel better, do you sometimes stop taking your medicine? (0=No, 1=Yes)",
-							"id": "feelBetter",
-							"questionOptions": {
-								"concept": "f9eb1023-4cd7-47a7-87cd-b3353824c2c7",
-								"rendering": "number",
-								"max": "1",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Patient on ARVs. Please provide morisky adherence history."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Morisky 4 total score:",
-							"id": "moriskyScore4",
-							"questionOptions": {
-								"concept": "315472dc-2b5e-4add-b3b7-bbcf21a8959b",
-								"rendering": "number",
-								"max": "4",
-								"min": "0",
-								"calculate": {
-									"calculateExpression": "isNaN(parseFloat(feelBetter)+ parseFloat(feelWorse)+ parseFloat(notKeen)+ parseFloat(forget)) ? undefined: (parseFloat(feelBetter)+ parseFloat(feelWorse)+ parseFloat(notKeen)+ parseFloat(forget))"
-								}
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Morisky score rating:",
-							"id": "scoreMo4",
-							"questionOptions": {
-								"concept": "",
-								"rendering": "text",
-								"calculate": {
-									"calculateExpression": "parseInt(moriskyScore4) === 0 && parseInt(moriskyScore4) < 1 ? 'Good' : parseInt(moriskyScore4) >=1 && parseInt(moriskyScore4) <= 2 ? 'Inadequate' : parseInt(moriskyScore4) >= 3 && parseInt(moriskyScore4) <= 4 ? 'Poor' : 'Unknown'"
-								}
-							},
-							"type": "control",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Did you forget to take your medicine yesterday? (0=No, 1=Yes)",
-							"id": "medicineYesterday",
-							"questionOptions": {
-								"concept": "2860acd4-2391-4467-9e69-e848d1672f96",
-								"rendering": "number",
-								"max": "1",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(moriskyScore4) && moriskyScore4 >=3 && isEmpty(myValue)",
-									"message": "Patient on ARVs. Please provide morisky adherence history."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
-							}
-						},
-						{
-							"label": "Do you sometimes stop taking medicine if you feel like your symptoms are under control? (0=No, 1=Yes)",
-							"id": "symptomControl",
-							"questionOptions": {
-								"concept": "8fcb3ada-2188-4e0a-8c68-18c26fd123b2",
-								"rendering": "number",
-								"max": "1",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(moriskyScore4) && moriskyScore4 >=3 && isEmpty(myValue)",
-									"message": "Patient on ARVs. Please provide morisky adherence history."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
-							}
-						},
-						{
-							"label": "Do you ever feel under pressure about sticking to your treatment plan? (0=No, 1=Yes)",
-							"id": "underPressure",
-							"questionOptions": {
-								"concept": "87ba16a0-6f57-4b0b-a76e-753977f1ef7f",
-								"rendering": "number",
-								"max": "1",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(moriskyScore4) && moriskyScore4 >=3 && isEmpty(myValue)",
-									"message": "Patient on ARVs. Please provide morisky adherence history."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
-							}
-						},
-						{
-							"label": "How often do you have difficulty remembering to take all your medication? (0=Never/Rarely, 1/4=Once in a while, 1/2=Sometimes, 3/4=Usually,1=All the time)",
-							"id": "difficultyRemembering",
-							"questionOptions": {
-								"concept": "658523c7-77d2-4419-9633-eba789a7d64d",
-								"rendering": "number",
-								"max": "1",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(moriskyScore4) && moriskyScore4 >=3 && isEmpty(myValue)",
-									"message": "Patient on ARVs. Please provide morisky adherence history."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
-							}
-						},
-						{
-							"label": "Morisky 8 total score:",
-							"id": "moriskyScore",
-							"questionOptions": {
-								"concept": "857caa4e-b566-4a43-ab78-f911c1a8a727",
-								"rendering": "number",
-								"max": "8",
-								"min": "0",
-								"calculate": {
-									"calculateExpression": "isNaN(parseFloat(difficultyRemembering) + parseFloat(underPressure) + parseFloat(symptomControl)+ parseFloat(medicineYesterday)+ parseFloat(feelBetter)+ parseFloat(feelWorse)+ parseFloat(notKeen)+ parseFloat(forget)) ? undefined: (parseFloat(difficultyRemembering) + parseFloat(underPressure) + parseFloat(symptomControl)+ parseFloat(medicineYesterday)+ parseFloat(feelBetter)+ parseFloat(feelWorse)+ parseFloat(notKeen)+ parseFloat(forget))"
-								}
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
-							}
-						},
-						{
-							"label": "Morisky score rating:",
-							"id": "scoreMo",
-							"questionOptions": {
-								"concept": "",
-								"rendering": "text",
-								"calculate": {
-									"calculateExpression": "parseInt(moriskyScore) === 0 && parseFloat(moriskyScore) <= 0.25 ? 'Good' : parseFloat(moriskyScore) >=0.5 && parseInt(moriskyScore) <= 2 ? 'Inadequate' : parseInt(moriskyScore) >= 3 && parseInt(moriskyScore) <= 8 ? 'Poor' : 'Unknown'"
-								}
-							},
-							"type": "control",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
-							}
-						}
-					]
-				},
-				{
-					"label": "Enhanced Adherence",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Has a home visit been done?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('fe6800a2-76f1-42a4-a1c8-553e1fec18e9')) ? undefined : HD.getObject('prevEnc').getValue('fe6800a2-76f1-42a4-a1c8-553e1fec18e9')",
-							"id": "homeVisit",
-							"questionOptions": {
-								"concept": "fe6800a2-76f1-42a4-a1c8-553e1fec18e9",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If yes, number of visits:",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('7458141a-2cb6-4425-8e51-1d4f0a858683')) ? undefined : HD.getObject('prevEnc').getValue('7458141a-2cb6-4425-8e51-1d4f0a858683')",
-							"id": "noVisits",
-							"questionOptions": {
-								"concept": "7458141a-2cb6-4425-8e51-1d4f0a858683",
-								"answers": [],
-								"rendering": "number",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(homeVisit) && homeVisit === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Home visit was done. Please indicate number of visits."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "homeVisit !== 'a899b35c-1350-11df-a1f1-0026b9348838' ||  onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If yes, what were the findings:",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('743bee17-bb4d-4bf5-bbfe-a58a7cca5a3f')) ? undefined : HD.getObject('prevEnc').getValue('743bee17-bb4d-4bf5-bbfe-a58a7cca5a3f')",
-							"id": "homeVisitFinindgs",
-							"questionOptions": {
-								"concept": "743bee17-bb4d-4bf5-bbfe-a58a7cca5a3f",
-								"answers": [],
-								"rendering": "text"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(homeVisit) && homeVisit === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Home visit was done. Please indicate findings."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "homeVisit !== 'a899b35c-1350-11df-a1f1-0026b9348838' ||  onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If no, wish to refer to the social worker:",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('6ada1724-aab2-4b78-af41-91498d211ca2')) ? undefined : HD.getObject('prevEnc').getValue('6ada1724-aab2-4b78-af41-91498d211ca2')",
-							"id": "socialworkRef",
-							"questionOptions": {
-								"concept": "6ada1724-aab2-4b78-af41-91498d211ca2",
-								"rendering": "select",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(homeVisit) && homeVisit === 'a899b42e-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Home visit was not done. Please refer client to social work."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "homeVisit !== 'a899b42e-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "What are the support structures in place?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a7958e13-c78c-4085-9fdf-b475d602b2b8')) ? undefined : HD.getObject('prevEnc').getValue('a7958e13-c78c-4085-9fdf-b475d602b2b8')",
-							"id": "supportStructures",
-							"questionOptions": {
-								"concept": "a7958e13-c78c-4085-9fdf-b475d602b2b8",
-								"answers": [
-									{
-										"concept": "01b957da-23bb-4862-819d-036364fe3faf",
-										"label": "Treatment supporter"
-									},
-									{
-										"concept": "a89e2df6-1350-11df-a1f1-0026b9348838",
-										"label": "Support group"
-									},
-									{
-										"concept": "a89cd280-1350-11df-a1f1-0026b9348838",
-										"label": "Caregiver"
-									},
-									{
-										"concept": "a8b03bb8-1350-11df-a1f1-0026b9348838",
-										"label": "Family"
-									},
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Has directly observed treatment (DOT) been done?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('4b3c4263-9f86-4f3c-985b-1a71e2a57495')) ? undefined : HD.getObject('prevEnc').getValue('4b3c4263-9f86-4f3c-985b-1a71e2a57495')",
-							"id": "priorDotDone",
-							"questionOptions": {
-								"concept": "4b3c4263-9f86-4f3c-985b-1a71e2a57495",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Number of directly observed treatment (DOT) done (days):",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('438c22e0-fcb9-4737-b3a6-55cc1f391e0c')) ? undefined : HD.getObject('prevEnc').getValue('438c22e0-fcb9-4737-b3a6-55cc1f391e0c')",
-							"id": "dotDone",
-							"questionOptions": {
-								"concept": "438c22e0-fcb9-4737-b3a6-55cc1f391e0c",
-								"answers": [],
-								"rendering": "number",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(priorDotDone) && priorDotDone === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "DOT was done. Please indicate number of DOTs done."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "priorDotDone !== 'a899b35c-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Likely causes of poor adherence: (Choose all that apply)",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a89ebbc2-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a89ebbc2-1350-11df-a1f1-0026b9348838')",
-							"id": "poorAdherence",
-							"questionOptions": {
-								"concept": "a89ebbc2-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a89eba46-1350-11df-a1f1-0026b9348838",
-										"label": "Stigma"
-									},
-									{
-										"concept": "945f0a33-dd89-4ca4-9eb3-d74128a2adc8",
-										"label": "School related stigma"
-									},
-									{
-										"concept": "b858568f-c722-411d-85ca-97d46bc98b3c",
-										"label": "Home related stigma"
-									},
-									{
-										"concept": "24ff3f30-b7ff-4464-b1b3-fda5ed5714a3",
-										"label": "Improper disclosure to child"
-									},
-									{
-										"concept": "e91a0b75-133d-4aae-81c9-2b4423e48379",
-										"label": "Inadequate supervision"
-									},
-									{
-										"concept": "a89d25fa-1350-11df-a1f1-0026b9348838",
-										"label": "Child refusing to take drugs"
-									},
-									{
-										"concept": "6a377e01-fa40-4ac2-98a9-0cb09cfbea36",
-										"label": "Pill related size"
-									},
-									{
-										"concept": "1c811199-3cc1-4495-8e05-980bebb045ab",
-										"label": "Pill taste"
-									},
-									{
-										"concept": "53956fb4-d7d9-438c-addf-c5f67b2a3866",
-										"label": "Pill color"
-									},
-									{
-										"concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
-										"label": "Pill burden"
-									},
-									{
-										"concept": "a89ecaa4-1350-11df-a1f1-0026b9348838",
-										"label": "Disclosure"
-									},
-									{
-										"concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
-										"label": "Side effects"
-									},
-									{
-										"concept": "a89ced88-1350-11df-a1f1-0026b9348838",
-										"label": "Alcohol"
-									},
-									{
-										"concept": "a89ebb04-1350-11df-a1f1-0026b9348838",
-										"label": "Other drugs"
-									},
-									{
-										"concept": "a890b810-1350-11df-a1f1-0026b9348838",
-										"label": "Mental health issues"
-									},
-									{
-										"concept": "a8935fde-1350-11df-a1f1-0026b9348838",
-										"label": "Depression"
-									},
-									{
-										"concept": "abf95bf2-c481-490f-9e9f-84fa2d7b2f8c",
-										"label": "Caregiver changes"
-									},
-									{
-										"concept": "a89e3396-1350-11df-a1f1-0026b9348838",
-										"label": "Religious beliefs"
-									},
-									{
-										"concept": "b5c3006f-97fd-466f-b4ab-596e23ddc4d9",
-										"label": "Inadequate treatment preparation"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'|| !arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"type": "obsGroup",
-							"label": "Poor adherence",
-							"questionOptions": {
-								"concept": "04edb08f-d1fd-43ac-98b1-adc5e7d73ba1",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "If other causes of poor adherence, explain:",
-									"id": "otherCausesSpecify",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"answers": [],
-										"rendering": "text"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(poorAdherence) && arrayContainsAny(['a8aaf3e2-1350-11df-a1f1-0026b9348838'], poorAdherence) && isEmpty(myValue)",
-											"message": "Other selected as cause of poor adherence. Please indicate the cause."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(poorAdherence) || !arrayContainsAny(['a8aaf3e2-1350-11df-a1f1-0026b9348838'], poorAdherence)"
-									}
-								}
-							],
-							"id": "__srpHHtMnD"
-						},
-						{
-							"label": "Is patient enrolled in support group?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('ed1e7a5d-a9f4-4adf-a033-4e895409fafe')) ? undefined : HD.getObject('prevEnc').getValue('ed1e7a5d-a9f4-4adf-a033-4e895409fafe')",
-							"id": "supportGroupEnroll",
-							"questionOptions": {
-								"concept": "ed1e7a5d-a9f4-4adf-a033-4e895409fafe",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If no, wishes to enroll?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('c796c49d-2e33-40c4-aadd-c5508e733c30')) ? undefined : HD.getObject('prevEnc').getValue('c796c49d-2e33-40c4-aadd-c5508e733c30')",
-							"id": "wishesToEnroll",
-							"questionOptions": {
-								"concept": "c796c49d-2e33-40c4-aadd-c5508e733c30",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(supportGroupEnroll) && supportGroupEnroll === 'a899b42e-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Patient is not enrolled in any group. Please indicate if they wish to enroll in any group."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "supportGroupEnroll !== 'a899b42e-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If yes, name of support group:",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('aab3dcc5-f984-45d2-b0c4-7a3ba746951b')) ? undefined : HD.getObject('prevEnc').getValue('aab3dcc5-f984-45d2-b0c4-7a3ba746951b')",
-							"id": "supportGroupName",
-							"questionOptions": {
-								"concept": "aab3dcc5-f984-45d2-b0c4-7a3ba746951b",
-								"answers": [],
-								"rendering": "text"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(supportGroupEnroll) && supportGroupEnroll === 'a8aaf3e2-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Patient is enrolled in a group. Please indicate name of the group."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "supportGroupEnroll !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Has age appropriate disclosure been completed?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('6a40a88b-555e-4d7e-b7ce-db677a02609f')) ? undefined : HD.getObject('prevEnc').getValue('6a40a88b-555e-4d7e-b7ce-db677a02609f')",
-							"id": "childDisclosure",
-							"questionOptions": {
-								"concept": "6a40a88b-555e-4d7e-b7ce-db677a02609f",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "age>=18 || !arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Has a pill count been done?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('067e6d30-4962-46eb-9090-be55478d4afd')) ? undefined : HD.getObject('prevEnc').getValue('067e6d30-4962-46eb-9090-be55478d4afd')",
-							"id": "pillCountDone",
-							"questionOptions": {
-								"concept": "067e6d30-4962-46eb-9090-be55478d4afd",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If yes, what are the findings:",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('9bf98c27-1821-407f-9c06-5609357f3698')) ? undefined : HD.getObject('prevEnc').getValue('9bf98c27-1821-407f-9c06-5609357f3698')",
-							"id": "pillCountFindings",
-							"questionOptions": {
-								"concept": "9bf98c27-1821-407f-9c06-5609357f3698",
-								"answers": [
-									{
-										"concept": "5b1bf823-da30-4e23-a777-0d8ef93a6211",
-										"label": "Accurate"
-									},
-									{
-										"concept": "64433aeb-81fb-43a5-be42-3efce1692063",
-										"label": "Missed doses"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(pillCountDone) && pillCountDone === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "Pill count done. Indicate the findings."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "pillCountDone !== 'a899b35c-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Other possible causes of treatment failure:",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('bc764345-2e57-42f5-aee9-c7d5bd012c97')) ? undefined : HD.getObject('prevEnc').getValue('bc764345-2e57-42f5-aee9-c7d5bd012c97')",
-							"id": "treatmentFailure",
-							"questionOptions": {
-								"concept": "bc764345-2e57-42f5-aee9-c7d5bd012c97",
-								"answers": [
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									},
-									{
-										"concept": "4a98eaa4-e5df-4e76-9b58-5191d61666eb",
-										"label": "Inadequate dosing/dose adjustments"
-									},
-									{
-										"concept": "01eedbcc-ea21-40cc-b150-fcaca5eef501",
-										"label": "Drug-drug interaction"
-									},
-									{
-										"concept": "c6f38251-5b52-489c-854e-ec2d3994a6cd",
-										"label": "Drug-food interaction"
-									},
-									{
-										"concept": "cfef32f6-2807-427e-9607-1397e8d7e347",
-										"label": "Impaired absorption (such as chronic severe diarrhea)"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If drug causes treatment failure, indicate drug:",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('1682a920-c93d-4aad-b9cb-4a2b2c41ff1a')) ? undefined : HD.getObject('prevEnc').getValue('1682a920-c93d-4aad-b9cb-4a2b2c41ff1a')",
-							"id": "drugCausingFailure",
-							"questionOptions": {
-								"concept": "1682a920-c93d-4aad-b9cb-4a2b2c41ff1a",
-								"rendering": "drug"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "treatmentFailure !== '01eedbcc-ea21-40cc-b150-fcaca5eef501' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'|| !arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Does this patient have other co morbidities?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8b010e8-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8b010e8-1350-11df-a1f1-0026b9348838')",
-							"id": "coMorbidities",
-							"questionOptions": {
-								"concept": "a8b010e8-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a8935f0c-1350-11df-a1f1-0026b9348838",
-										"label": "Convulsive disease"
-									},
-									{
-										"concept": "a890b810-1350-11df-a1f1-0026b9348838",
-										"label": "Mental health disorders"
-									},
-									{
-										"concept": "a893436e-1350-11df-a1f1-0026b9348838",
-										"label": "Diabetes"
-									},
-									{
-										"concept": "a8ad5254-1350-11df-a1f1-0026b9348838",
-										"label": "Renal disease"
-									},
-									{
-										"concept": "a8ad516e-1350-11df-a1f1-0026b9348838",
-										"label": "Liver disease"
-									},
-									{
-										"concept": "a8986880-1350-11df-a1f1-0026b9348838",
-										"label": "Hypertention"
-									},
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Has drug resistance test (DRT) been done?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('2ae99396-0e12-463f-8968-1cba7cf24bc0')) ? undefined : HD.getObject('prevEnc').getValue('2ae99396-0e12-463f-8968-1cba7cf24bc0')",
-							"id": "dstDone",
-							"questionOptions": {
-								"concept": "2ae99396-0e12-463f-8968-1cba7cf24bc0",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If DRT result available, upload image:",
-							"type": "obs",
-							"default": "",
-							"id": "dstImage",
-							"questionOptions": {
-								"concept": "8ec7c519-502e-46ea-8a98-181ed5a088be",
-								"rendering": "file"
-							},
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(dstDone) && dstDone === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-									"message": "DST was done.Please upload the image for the results."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "dstDone !== 'a899b35c-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Has an MDT been done?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('946dabee-3079-4dd1-9f84-1a1ab5507a26')) ? undefined : HD.getObject('prevEnc').getValue('946dabee-3079-4dd1-9f84-1a1ab5507a26')",
-							"id": "mdtDone",
-							"questionOptions": {
-								"concept": "946dabee-3079-4dd1-9f84-1a1ab5507a26",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "If No, wish to refer?",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('88a8c7d1-95ac-4aa4-8058-df99a3598390')) ? undefined : HD.getObject('prevEnc').getValue('88a8c7d1-95ac-4aa4-8058-df99a3598390')",
-							"id": "wishRefertoMDT",
-							"questionOptions": {
-								"concept": "88a8c7d1-95ac-4aa4-8058-df99a3598390",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "mdtDone !== 'a899b42e-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
-							}
-						}
-					]
-				},
-				{
-					"label": "PCP Prophylaxis History",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Is the patient on any PCP prophylaxis?",
-							"id": "pcpProphylaxisCurrent",
-							"historicalExpression": "HD.getObject('prevEnc').getValue('a899e282-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a899e282-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									},
-									{
-										"concept": "a8989396-1350-11df-a1f1-0026b9348838",
-										"label": "Septrin"
-									},
-									{
-										"concept": "a890c9e0-1350-11df-a1f1-0026b9348838",
-										"label": "Dapsone 100mg"
-									}
-								],
-								"rendering": "select"
-							},
-							"required": "true",
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"type": "obsGroup",
-							"label": "PCP prophylaxis adherence:",
-							"questionOptions": {
-								"concept": "275eee16-c358-4f3a-ac16-e8f24659df87",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Patient's adherence on PCP prophylaxis:",
-									"id": "pcpProphylaxisAdherence",
-									"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('115c744a-cf54-469f-bd5f-820352ffe9be')) ? undefined : HD.getObject('prevEnc').getValue('115c744a-cf54-469f-bd5f-820352ffe9be')",
-									"questionOptions": {
-										"concept": "115c744a-cf54-469f-bd5f-820352ffe9be",
-										"answers": [
-											{
-												"concept": "a8b0f882-1350-11df-a1f1-0026b9348838",
-												"label": "Good"
-											},
-											{
-												"concept": "a73d20b3-d721-4763-a362-14a0c41a6b5e",
-												"label": "Fair"
-											},
-											{
-												"concept": "fdaf8b47-ea14-4d28-80fa-e1da58a30e8b",
-												"label": "Poor"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(pcpProphylaxisCurrent) && arrayContains(['a8989396-1350-11df-a1f1-0026b9348838', 'a890c9e0-1350-11df-a1f1-0026b9348838'], pcpProphylaxisCurrent) && isEmpty(myValue)",
-											"message": "Patient on PCP Prophylaxis. Please provide adherence history"
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(pcpProphylaxisCurrent) || pcpProphylaxisCurrent === 'a899e0ac-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "Adherence (PCP) reasons for poor/fair:",
-									"id": "pcpAdherence",
-									"questionOptions": {
-										"concept": "a89ebbc2-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a89ced88-1350-11df-a1f1-0026b9348838",
-												"label": "Alcohol"
-											},
-											{
-												"concept": "a8935fde-1350-11df-a1f1-0026b9348838",
-												"label": "Depression"
-											},
-											{
-												"concept": "a89eac04-1350-11df-a1f1-0026b9348838",
-												"label": "Felt well"
-											},
-											{
-												"concept": "a89eacc2-1350-11df-a1f1-0026b9348838",
-												"label": "Forgot"
-											},
-											{
-												"concept": "7211031b-0685-44bc-a5e9-5a018d0173ea",
-												"label": "Gave away"
-											},
-											{
-												"concept": "a8af4cee-1350-11df-a1f1-0026b9348838",
-												"label": "Lost/ran out of pills"
-											},
-											{
-												"concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
-												"label": "Pill burden"
-											},
-											{
-												"concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
-												"label": "Side effects"
-											},
-											{
-												"concept": "a89eba46-1350-11df-a1f1-0026b9348838",
-												"label": "Stigma"
-											},
-											{
-												"concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
-												"label": "Stock out"
-											},
-											{
-												"concept": "a89de2d8-1350-11df-a1f1-0026b9348838",
-												"label": "Too ill"
-											},
-											{
-												"concept": "a897fdaa-1350-11df-a1f1-0026b9348838",
-												"label": "Travel problems"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "multiCheckbox"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "isEmpty(pcpProphylaxisCurrent) || pcpProphylaxisCurrent === 'a899e0ac-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], pcpProphylaxisAdherence)"
-									}
-								},
-								{
-									"label": "Adherence (PCP): Other (specify):",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"id": "pcpOtherAdherence",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "isEmpty(pcpProphylaxisCurrent) || pcpProphylaxisCurrent === 'a899e0ac-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], pcpProphylaxisAdherence)"
-									}
-								}
-							],
-							"id": "__twvv36Kuq"
-						}
-					]
-				},
-				{
-					"label": "TB Prophylaxis History",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Is the patient on any TB prophylaxis?",
-							"type": "obs",
-							"required": "true",
-							"id": "onTbProphylaxis",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('163784d2-6c55-4ceb-abf0-df8cebb385f1')) ? undefined : HD.getObject('prevEnc').getValue('163784d2-6c55-4ceb-abf0-df8cebb385f1')",
-							"questionOptions": {
-								"concept": "163784d2-6c55-4ceb-abf0-df8cebb385f1",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"validators": []
-						},
-						{
-							"label": "If yes select drug",
-							"type": "obs",
-							"id": "onTbProphylaxisDrug",
-							"historicalExpression": "HD.getObject('prevEnc').getValue('a899e35e-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a899e35e-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "162724df-5a66-4ae3-bbf6-5dc6dbba4ebb",
-										"label": "Isoniazid 100mg (6H)"
-									},
-									{
-										"concept": "b150ccdc-e7ec-4f99-b592-6f3fa73b3aea",
-										"label": "Isoniazid 300mg (6H)"
-									},
-									{
-										"concept": "aeaed1af-5b0d-401e-a32a-e96cf4072ab5",
-										"label": "Isoniazid 300mg and Rifapentine 300mg (3HP)"
-									},
-									{
-										"concept": "177635d0-793b-4a66-8324-976c46f795af",
-										"label": "Rifampicin 150mg and Isonaizid 75mg (3RH)"
-									},
-									{
-										"concept": "e5e24e6d-e6b0-4c81-8f7b-0e366df29426",
-										"label": "Rifampicin 70mg and Isonaizid 50mg (3RH)"
-									}
-								],
-								"rendering": "select"
-							},
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(onTbProphylaxis) && onTbProphylaxis === 'a899b35c-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient  marked as on TB Prophylaxis. Please provide the drug."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onTbProphylaxis !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"type": "obsGroup",
-							"label": "TB prophylaxis ever",
-							"questionOptions": {
-								"concept": "d86c36dc-c523-42e3-b07d-eb4c3c4fbf99",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "If no, have you ever used the drugs in the past?",
-									"type": "obs",
-									"id": "pastTbProphylaxisDrug",
-									"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('59077bc1-7ef7-4b27-a33b-113e2841bd4f')) ? undefined : HD.getObject('prevEnc').getValue('59077bc1-7ef7-4b27-a33b-113e2841bd4f')",
-									"questionOptions": {
-										"concept": "59077bc1-7ef7-4b27-a33b-113e2841bd4f",
-										"answers": [
-											{
-												"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-												"label": "Yes"
-											},
-											{
-												"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-												"label": "No"
-											}
-										],
-										"rendering": "select"
-									},
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "onTbProphylaxis !== 'a899b42e-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "Start date of past TB prophylaxis treatment:",
-									"id": "pastStartTbProphTreatment",
-									"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('67785e82-c2f7-4417-8ada-cc8e85abbfc1')) ? undefined : HD.getObject('prevEnc').getValue('67785e82-c2f7-4417-8ada-cc8e85abbfc1')",
-									"questionOptions": {
-										"concept": "67785e82-c2f7-4417-8ada-cc8e85abbfc1",
-										"rendering": "date"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "date"
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "pastTbProphylaxisDrug !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "End date of past TB prophylaxis treatment:",
-									"id": "pastEndTbProphTreatment",
-									"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('d4f18a59-9bb4-4089-8cd6-1410491569a0')) ? undefined : HD.getObject('prevEnc').getValue('d4f18a59-9bb4-4089-8cd6-1410491569a0')",
-									"questionOptions": {
-										"concept": "d4f18a59-9bb4-4089-8cd6-1410491569a0",
-										"rendering": "date"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "date"
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "pastTbProphylaxisDrug !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							],
-							"id": "__IvxxM4zxt"
-						},
-						{
-							"label": "TB prophylaxis adherence",
-							"type": "obsGroup",
-							"questionOptions": {
-								"concept": "3a69cfcf-f129-4702-a8dd-d061d2a16b9d",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Patient's adherence on TB prophylaxis:",
-									"id": "adherenceOnTbProphy",
-									"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('3a69cfcf-f129-4702-a8dd-d061d2a16b9d','ebfdb93a-9292-4245-9a27-0faf49545720')) ? undefined : HD.getObject('prevEnc').getValue('3a69cfcf-f129-4702-a8dd-d061d2a16b9d','ebfdb93a-9292-4245-9a27-0faf49545720')",
-									"questionOptions": {
-										"concept": "ebfdb93a-9292-4245-9a27-0faf49545720",
-										"answers": [
-											{
-												"concept": "a8b0f882-1350-11df-a1f1-0026b9348838",
-												"label": "Good"
-											},
-											{
-												"concept": "a73d20b3-d721-4763-a362-14a0c41a6b5e",
-												"label": "Fair"
-											},
-											{
-												"concept": "fdaf8b47-ea14-4d28-80fa-e1da58a30e8b",
-												"label": "Poor"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(onTbProphylaxis) && arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], onTbProphylaxis) && isEmpty(myValue)",
-											"message": "Patient on TB Prophylaxis. Please provide adherence history."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(onTbProphylaxis)|| onTbProphylaxis !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "Adherence (TB Prophylaxis) reasons for poor/fair:",
-									"id": "tbProphylaxisAdherence",
-									"questionOptions": {
-										"concept": "a89ebbc2-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a89ced88-1350-11df-a1f1-0026b9348838",
-												"label": "Alcohol"
-											},
-											{
-												"concept": "a8935fde-1350-11df-a1f1-0026b9348838",
-												"label": "Depression"
-											},
-											{
-												"concept": "a89eac04-1350-11df-a1f1-0026b9348838",
-												"label": "Felt well"
-											},
-											{
-												"concept": "a89eacc2-1350-11df-a1f1-0026b9348838",
-												"label": "Forgot"
-											},
-											{
-												"concept": "7211031b-0685-44bc-a5e9-5a018d0173ea",
-												"label": "Gave away"
-											},
-											{
-												"concept": "a8af4cee-1350-11df-a1f1-0026b9348838",
-												"label": "Lost/Ran out of pills"
-											},
-											{
-												"concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
-												"label": "Pill burden"
-											},
-											{
-												"concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
-												"label": "Side effects"
-											},
-											{
-												"concept": "a89eba46-1350-11df-a1f1-0026b9348838",
-												"label": "Stigma"
-											},
-											{
-												"concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
-												"label": "Stock out"
-											},
-											{
-												"concept": "a89de2d8-1350-11df-a1f1-0026b9348838",
-												"label": "Too ill"
-											},
-											{
-												"concept": "a897fdaa-1350-11df-a1f1-0026b9348838",
-												"label": "Travel problems"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "multiCheckbox"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "isEmpty(onTbProphylaxis) || onTbProphylaxis !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], adherenceOnTbProphy)"
-									}
-								},
-								{
-									"label": "Adherence (TB Prophylaxis): Other (specify):",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"id": "tbProphylaxisOtherAdherence",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "isEmpty(onTbProphylaxis) || onTbProphylaxis !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], adherenceOnTbProphy)"
-									}
-								}
-							],
-							"id": "__Dwx8svpyL"
-						}
-					]
-				},
-				{
-					"label": "Tuberculosis History",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"id": "onTbTreatment",
-							"required": "true",
-							"label": "Is patient on TB treatment?",
-							"historicalExpression": "HD.getObject('prevEnc').getValue('a8afcc82-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a8afcc82-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs"
-						},
-						{
-							"label": "Start date of TB treatment:",
-							"id": "startDateOfTbTreatment",
-							"historicalExpression": "HD.getObject('prevEnc').getValue('a899e5f2-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a899e5f2-1350-11df-a1f1-0026b9348838",
-								"rendering": "date"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "date"
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onTbTreatment) && arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], onTbTreatment) && isEmpty(myValue)",
-									"message": "You indicated patient on tb treatment, indicate start date."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "(isEmpty(onTbTreatment) || !arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], onTbTreatment)) && !isEmpty(myValue)",
-									"message": "You indicated patient is not on tb treatment, therefore start date should not be indicated."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "Tuberculosis treatment phase:",
-							"type": "obs",
-							"id": "tbPhase",
-							"questionOptions": {
-								"concept": "a8afdf4c-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a8afdd08-1350-11df-a1f1-0026b9348838",
-										"label": "Continuation phase"
-									},
-									{
-										"concept": "a8afddc6-1350-11df-a1f1-0026b9348838",
-										"label": "Retreatment phase"
-									},
-									{
-										"concept": "a8afdc4a-1350-11df-a1f1-0026b9348838",
-										"label": "Induction phase"
-									},
-									{
-										"concept": "a8afde8e-1350-11df-a1f1-0026b9348838",
-										"label": "Retreated phase"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"rendering": "select"
-							},
-							"hide": {
-								"hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"type": "obsGroup",
-							"label": "Current TB regimen",
-							"questionOptions": {
-								"concept": "a8afdb8c-1350-11df-a1f1-0026b9348838",
-								"rendering": "repeating"
-							},
-							"questions": [
-								{
-									"label": "Current TB regimen:",
-									"type": "obs",
-									"id": "tb_current",
-									"questionOptions": {
-										"concept": "a899e444-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a899f51a-1350-11df-a1f1-0026b9348838",
-												"label": "RHZE"
-											},
-											{
-												"concept": "a897d1a4-1350-11df-a1f1-0026b9348838",
-												"label": "RHZ"
-											},
-											{
-												"concept": "a8a382ba-1350-11df-a1f1-0026b9348838",
-												"label": "RHE"
-											},
-											{
-												"concept": "a89b1ca6-1350-11df-a1f1-0026b9348838",
-												"label": "RH"
-											},
-											{
-												"concept": "a899e19c-1350-11df-a1f1-0026b9348838",
-												"label": "EH"
-											},
-											{
-												"concept": "a8971c64-1350-11df-a1f1-0026b9348838",
-												"label": "Ethambutol"
-											},
-											{
-												"concept": "a8a3243c-1350-11df-a1f1-0026b9348838",
-												"label": "MDR drugs"
-											},
-											{
-												"concept": "a896cc00-1350-11df-a1f1-0026b9348838",
-												"label": "INH"
-											},
-											{
-												"concept": "a8ac5f2a-1350-11df-a1f1-0026b9348838",
-												"label": "Pyrazinamide"
-											},
-											{
-												"concept": "a8952e4a-1350-11df-a1f1-0026b9348838",
-												"label": "Streptomycin"
-											},
-											{
-												"concept": "b8aa06ca-93c6-40ea-b144-c74f841926f4",
-												"label": "Rifabutin"
-											},
-											{
-												"concept": "a897d0be-1350-11df-a1f1-0026b9348838",
-												"label": "Rifampicin"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "select"
-									},
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "tabs/day:",
-									"questionOptions": {
-										"concept": "a8a07386-1350-11df-a1f1-0026b9348838",
-										"max": "30",
-										"min": "0",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"hide": {
-										"field": "tb_current",
-										"value": [
-											"a899f51a-1350-11df-a1f1-0026b9348838",
-											"a897d1a4-1350-11df-a1f1-0026b9348838",
-											"a8a382ba-1350-11df-a1f1-0026b9348838"
-										]
-									},
-									"id": "__uoEvFzpJ3"
-								},
-								{
-									"label": "mg:",
-									"questionOptions": {
-										"concept": "a8a063c8-1350-11df-a1f1-0026b9348838",
-										"max": "2000",
-										"min": "0",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"hide": {
-										"field": "tb_current",
-										"value": [
-											"a899e19c-1350-11df-a1f1-0026b9348838",
-											"a8ac5f2a-1350-11df-a1f1-0026b9348838",
-											"a8952e4a-1350-11df-a1f1-0026b9348838"
-										]
-									},
-									"id": "__K0sIqqpLx"
-								},
-								{
-									"label": "mg/day:",
-									"questionOptions": {
-										"concept": "a8a0744e-1350-11df-a1f1-0026b9348838",
-										"max": "2000",
-										"min": "0",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"hide": {
-										"field": "tb_current",
-										"value": [
-											"a896cc00-1350-11df-a1f1-0026b9348838",
-											"a8971c64-1350-11df-a1f1-0026b9348838"
-										]
-									},
-									"id": "__GLnzrzFDx"
-								},
-								{
-									"label": "tabs:",
-									"questionOptions": {
-										"concept": "a8a0630a-1350-11df-a1f1-0026b9348838",
-										"max": "180",
-										"min": "0",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"hide": {
-										"field": "tb_current",
-										"value": [
-											"b8aa06ca-93c6-40ea-b144-c74f841926f4"
-										]
-									},
-									"id": "__ptxCzFD2s"
-								}
-							],
-							"id": "__F7qwFJrHF"
-						},
-						{
-							"label": "TB treatment completion date:",
-							"type": "obs",
-							"id": "tbComplDate",
-							"questionOptions": {
-								"concept": "a8a176b4-1350-11df-a1f1-0026b9348838",
-								"rendering": "date"
-							},
-							"hide": {
-								"hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "TB treatment defaulted year:",
-							"type": "obs",
-							"id": "tbDefaultDate",
-							"questionOptions": {
-								"concept": "a8a18758-1350-11df-a1f1-0026b9348838",
-								"rendering": "number"
-							},
-							"hide": {
-								"hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"type": "obsGroup",
-							"id": "tbadhere",
-							"label": "Patient adherence to TB medications",
-							"questionOptions": {
-								"concept": "2a4b87dd-977d-4ce8-a321-1f13df4a31b2",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Patient adherence to TB medications:",
-									"id": "tb_adherence",
-									"questionOptions": {
-										"concept": "479decbd-e964-41c3-9576-98b39089ebd3",
-										"answers": [
-											{
-												"concept": "a8b0f882-1350-11df-a1f1-0026b9348838",
-												"label": "Good"
-											},
-											{
-												"concept": "a73d20b3-d721-4763-a362-14a0c41a6b5e",
-												"label": "Fair"
-											},
-											{
-												"concept": "fdaf8b47-ea14-4d28-80fa-e1da58a30e8b",
-												"label": "Poor"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(onTbTreatment) && onTbTreatment === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
-											"message": "Patient on TB Treament. Please provide adherence history."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "Adherence (TB Treatment) reasons for poor/fair:",
-									"id": "adherenceTbTreatment",
-									"questionOptions": {
-										"concept": "a89ebbc2-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a89ced88-1350-11df-a1f1-0026b9348838",
-												"label": "Alcohol"
-											},
-											{
-												"concept": "a8935fde-1350-11df-a1f1-0026b9348838",
-												"label": "Depression"
-											},
-											{
-												"concept": "a89eac04-1350-11df-a1f1-0026b9348838",
-												"label": "Felt well"
-											},
-											{
-												"concept": "a89eacc2-1350-11df-a1f1-0026b9348838",
-												"label": "Forgot"
-											},
-											{
-												"concept": "7211031b-0685-44bc-a5e9-5a018d0173ea",
-												"label": "Gave away"
-											},
-											{
-												"concept": "a8af4cee-1350-11df-a1f1-0026b9348838",
-												"label": "Lost/Ran out of pills"
-											},
-											{
-												"concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
-												"label": "Pill burden"
-											},
-											{
-												"concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
-												"label": "Side effects"
-											},
-											{
-												"concept": "a89eba46-1350-11df-a1f1-0026b9348838",
-												"label": "Stigma"
-											},
-											{
-												"concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
-												"label": "Stock out"
-											},
-											{
-												"concept": "a89de2d8-1350-11df-a1f1-0026b9348838",
-												"label": "Too ill"
-											},
-											{
-												"concept": "a897fdaa-1350-11df-a1f1-0026b9348838",
-												"label": "Travel problems"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "multiCheckbox"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], tb_adherence)"
-									}
-								},
-								{
-									"label": "Adherence (TB Treatment): Other (specify):",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"id": "adherenceTbOther",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], tb_adherence)"
-									}
-								}
-							]
-						}
-					]
-				},
-				{
-					"label": "Cryptococcal Secondary Prevention",
-					"questions": [
-						{
-							"label": "Cryptococcus Tx:",
-							"id": "cryptCurrent",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a899e516-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a899e516-1350-11df-a1f1-0026b9348838')",
-							"questionOptions": {
-								"concept": "a899e516-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									},
-									{
-										"concept": "a8971e12-1350-11df-a1f1-0026b9348838",
-										"label": "Fluconazole 400mg"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "Other Medications",
-					"questions": [
-						{
-							"label": "Please add any other medications the patient is taking",
-							"type": "obsGroup",
-							"questionOptions": {
-								"concept": "a8a072c8-1350-11df-a1f1-0026b9348838",
-								"rendering": "repeating"
-							},
-							"questions": [
-								{
-									"label": "Other drugs:",
-									"questionOptions": {
-										"concept": "a8a060c6-1350-11df-a1f1-0026b9348838",
-										"rendering": "drug"
-									},
-									"type": "obs",
-									"validators": [],
-									"id": "__qnIztHtsp"
-								}
-							],
-							"id": "__yKMrLn68C"
-						}
-					]
-				},
-				{
-					"label": "Side Effects/Toxicity",
-					"questions": [
-						{
-							"type": "obsGroup",
-							"label": "Side effects",
-							"id": "sideEff",
-							"questionOptions": {
-								"concept": "a8a072c8-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Any side effects attributable to any drug that the patient is currently taking:",
-									"id": "currSideEffect",
-									"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('30fc0cea-b6c7-48cc-bbfb-4eb53170ce41')) ? undefined : HD.getObject('prevEnc').getValue('30fc0cea-b6c7-48cc-bbfb-4eb53170ce41')",
-									"questionOptions": {
-										"concept": "30fc0cea-b6c7-48cc-bbfb-4eb53170ce41",
-										"answers": [
-											{
-												"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-												"label": "Yes"
-											},
-											{
-												"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-												"label": "No"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(current_art_regimen_adult) && isEmpty(myValue) && arrayContains(current_art_regimen_adult, '98b0baf6-0b73-4429-9264-6233684b0969')",
-											"message": "Patient is on DTG. Kindly fill the side effects."
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "obsGroup",
-							"questionOptions": {
-								"rendering": "repeating",
-								"concept": "a8a072c8-1350-11df-a1f1-0026b9348838"
-							},
-							"label": "If yes drugs suspected to be causing side effects",
-							"questions": [
-								{
-									"label": "Drug:",
-									"id": "sideEffectDrug",
-									"questionOptions": {
-										"concept": "1682a920-c93d-4aad-b9cb-4a2b2c41ff1a",
-										"rendering": "drug"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							],
-							"id": "__GsJpvoqnG"
-						},
-						{
-							"label": "If yes, tick all that apply:",
-							"id": "sideEffectype",
-							"questionOptions": {
-								"concept": "c2ecd5f7-4b47-47ae-b706-3dc5ed98b4db",
-								"answers": [
-									{
-										"concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
-										"label": "Anaemia"
-									},
-									{
-										"concept": "a8909060-1350-11df-a1f1-0026b9348838",
-										"label": "Hepatitis"
-									},
-									{
-										"concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
-										"label": "IRIS"
-									},
-									{
-										"concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
-										"label": "Lactic acidosis"
-									},
-									{
-										"concept": "a89cee50-1350-11df-a1f1-0026b9348838",
-										"label": "Lipo-dystrophy"
-									},
-									{
-										"concept": "a897fe86-1350-11df-a1f1-0026b9348838",
-										"label": "Neuropathy"
-									},
-									{
-										"concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
-										"label": "Persistent vomiting"
-									},
-									{
-										"concept": "a895776a-1350-11df-a1f1-0026b9348838",
-										"label": "Rash"
-									},
-									{
-										"concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
-										"label": "Steven-Johnson syndrome"
-									},
-									{
-										"concept": "a8ad21e4-1350-11df-a1f1-0026b9348838",
-										"label": "Nausea"
-									},
-									{
-										"concept": "a894b604-1350-11df-a1f1-0026b9348838",
-										"label": "Burning sensation"
-									},
-									{
-										"concept": "a890861a-1350-11df-a1f1-0026b9348838",
-										"label": "Diarrhea"
-									},
-									{
-										"concept": "a8966d1e-1350-11df-a1f1-0026b9348838",
-										"label": "Headache"
-									},
-									{
-										"concept": "a8ad042a-1350-11df-a1f1-0026b9348838",
-										"label": "Fatigue"
-									},
-									{
-										"concept": "a89366a0-1350-11df-a1f1-0026b9348838",
-										"label": "Jaundice"
-									},
-									{
-										"concept": "a89836ee-1350-11df-a1f1-0026b9348838",
-										"label": "Dizzy"
-									},
-									{
-										"concept": "a8932f00-1350-11df-a1f1-0026b9348838",
-										"label": "Abdominal pain"
-									},
-									{
-										"concept": "a89cec02-1350-11df-a1f1-0026b9348838",
-										"label": "Anxiety"
-									},
-									{
-										"concept": "c80dcaad-ea61-4b88-b1f7-c091d706c7de",
-										"label": "Nightmare"
-									},
-									{
-										"concept": "a8935fde-1350-11df-a1f1-0026b9348838",
-										"label": "Depression"
-									},
-									{
-										"concept": "a8ad3b02-1350-11df-a1f1-0026b9348838",
-										"label": "Confusion/abnormal thinking"
-									},
-									{
-										"concept": "a8982de8-1350-11df-a1f1-0026b9348838",
-										"label": "Insomnia"
-									},
-									{
-										"concept": "a8ae7ecc-1350-11df-a1f1-0026b9348838",
-										"label": "Poor concentration/ memory problems"
-									},
-									{
-										"concept": "a8ad392c-1350-11df-a1f1-0026b9348838",
-										"label": "Paresthesia/painful neuropathy"
-									},
-									{
-										"concept": "f5b8f79a-5460-49a5-983e-78cc203673da",
-										"label": "Suicide ideation"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(currSideEffect) && currSideEffect === 'a899b35c-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient  marked as having side effects. Please provide list."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"id": "reaction",
-							"label": "Severity of the reaction:",
-							"questionOptions": {
-								"concept": "6c1b293c-4d8c-470f-9991-93cdde1274ff",
-								"answers": [
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									},
-									{
-										"concept": "a89efccc-1350-11df-a1f1-0026b9348838",
-										"label": "Mild"
-									},
-									{
-										"concept": "a89efdee-1350-11df-a1f1-0026b9348838",
-										"label": "Moderate"
-									},
-									{
-										"concept": "a89eff1a-1350-11df-a1f1-0026b9348838",
-										"label": "Severe"
-									},
-									{
-										"concept": "a899b50a-1350-11df-a1f1-0026b9348838",
-										"label": "Unknown"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"id": "action",
-							"label": "Action plan:",
-							"questionOptions": {
-								"concept": "01fb96f5-8dc5-4481-8a11-240994b3b795",
-								"answers": [
-									{
-										"concept": "b5b9663c-9568-4f48-b70f-34c63b21bce4",
-										"label": "Stopped drugs"
-									},
-									{
-										"concept": "a8a00158-1350-11df-a1f1-0026b9348838",
-										"label": "Substitute drugs"
-									},
-									{
-										"concept": "a8a07bce-1350-11df-a1f1-0026b9348838",
-										"label": "Change drugs"
-									},
-									{
-										"concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
-										"label": "Switched drugs"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "How certain are you the drug(s) is/are the cause of the reaction?",
-							"id": "certainityOfReaction",
-							"questionOptions": {
-								"concept": "d0efbf5b-cbfc-48fc-a857-c0ca4d70f077",
-								"answers": [
-									{
-										"concept": "45eb8953-dc14-4c2e-8ce6-12cdf7da280a",
-										"label": "Certain"
-									},
-									{
-										"concept": "07e9e14e-a718-4a9e-9479-1de79e1f614a",
-										"label": "Probable/likely"
-									},
-									{
-										"concept": "260e6d24-1634-4467-a070-e8359f6827f7",
-										"label": "Possible"
-									},
-									{
-										"concept": "66b46c63-7e75-4b1d-918a-1e17348c62f7",
-										"label": "Unlikely"
-									},
-									{
-										"concept": "b1055e84-0e97-483a-ae8a-3f2dee84a623",
-										"label": "Conditional/unclassified"
-									},
-									{
-										"concept": "80d03d9f-2510-4a95-b9d6-2613aaeebd21",
-										"label": "Unassessable/unclassified"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Vitals",
-			"sections": [
-				{
-					"label": "Vital Signs",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "BP systolic:",
-							"id": "syst",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a65d5a-1350-11df-a1f1-0026b9348838",
-								"max": "250",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "BP diastolic:",
-							"id": "dias",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a65e36-1350-11df-a1f1-0026b9348838",
-								"max": "200",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "Pulse (Rate/min):",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a65f12-1350-11df-a1f1-0026b9348838",
-								"max": "230",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [],
-							"id": "__uIC58G0rw"
-						},
-						{
-							"label": "Temp (C):",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a65fee-1350-11df-a1f1-0026b9348838",
-								"max": "43",
-								"min": "25"
-							},
-							"type": "obs",
-							"validators": [],
-							"id": "__yuHJFKyxE"
-						},
-						{
-                            "label" : "Historical Calculation",
-                            "type" : "obs",
-                            "questionOptions" : {
-                                "rendering" : "number",
-                                "concept" : "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                                "max" : "",
-                                "min" : "",
-                                "showDate" : "",
-                                "useMostRecentValue": true,
-								"calculate": {
-									"calculateExpression": "parseFloat(extractObsValue(rawPrevObs,'5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',height))"
-								}
-                            },
-                            "id" : "Ht"
-                        },
-						{
-							"label": "Weight (Kg):",
-							"id": "weight",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a660ca-1350-11df-a1f1-0026b9348838",
-								"max": "250",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "Height (Cm):",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8a6619c-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8a6619c-1350-11df-a1f1-0026b9348838')",
-							"id": "height",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a6619c-1350-11df-a1f1-0026b9348838",
-								"max": "228",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "Sp02:",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a66354-1350-11df-a1f1-0026b9348838",
-								"max": "100",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [],
-							"id": "__y2oEz0ytE"
-						},
-						{
-							"label": "BMI (Kg/m2):",
-							"id": "bmi",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a89c60c0-1350-11df-a1f1-0026b9348838",
-								"max": "100",
-								"min": "0",
-								"calculate": {
-									"calculateExpression": "calcBMI(height,weight)"
-								}
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "MUAC:",
-							"id": "muac",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a89c6188-1350-11df-a1f1-0026b9348838",
-								"max": "450",
-								"min": "60"
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "Foetal heart rate:",
-							"id": "fhr",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a007a2-1350-11df-a1f1-0026b9348838",
-								"max": "230",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": " !arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966', '42de8e7e-24b2-4c16-b62b-137eb2c55ede','53b856ad-21ef-4745-9acd-81aca01bba31'], visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Fundal height:",
-							"id": "fundalHeight",
-							"questionOptions": {
-								"rendering": "number",
-								"concept": "a8a005fe-1350-11df-a1f1-0026b9348838",
-								"max": "48",
-								"min": "0"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": " !arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966', '42de8e7e-24b2-4c16-b62b-137eb2c55ede','53b856ad-21ef-4745-9acd-81aca01bba31'], visitTypeUuid)"
-							}
-						}
-					]
-				},
-				{
-					"label": "Nutrition Assessment and Diagnosis",
-					"questions": [
-						{
-							"label": "Nutrition status:",
-							"id": "nutritionStatus",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "ac5f7974-3a71-4867-af59-0c30d68ce9d8",
-								"answers": [
-									{
-										"concept": "a899e7b4-1350-11df-a1f1-0026b9348838",
-										"label": "Normal"
-									},
-									{
-										"concept": "1505faef-c8aa-422c-b356-da065b88ec9c",
-										"label": "Overweight"
-									},
-									{
-										"concept": "2a60e784-1314-4454-91ba-7ea4cc2c3b15",
-										"label": "Obese"
-									},
-									{
-										"concept": "0306539c-f24f-49f5-b059-b646adbec47c",
-										"label": "Severe acute malnutrition"
-									},
-									{
-										"concept": "f0dd06d5-6174-447f-9a9c-f8635b4a6a6d",
-										"label": "Moderate  acute malnutrition"
-									}
-								]
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Current Symptoms",
-			"sections": [
-				{
-					"label": "TB Screening Questions",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "TB Symptoms:",
-							"required": "true",
-							"questionOptions": {
-								"concept": "a8afcafc-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									},
-									{
-										"concept": "a8ad1276-1350-11df-a1f1-0026b9348838",
-										"label": "Breathlessness"
-									},
-									{
-										"concept": "a892e4b4-1350-11df-a1f1-0026b9348838",
-										"label": "Chest pain"
-									},
-									{
-										"concept": "a8afc8b8-1350-11df-a1f1-0026b9348838",
-										"label": "Cough of any duration"
-									},
-									{
-										"concept": "d7adae14-c386-49cc-8f7c-765d8ceec566",
-										"label": "Fever for = 2 weeks"
-									},
-									{
-										"concept": "3f57aafc-7162-41da-a51b-6a804cb6f5e8",
-										"label": "New exposure to household contact with TB"
-									},
-									{
-										"concept": "a89807f0-1350-11df-a1f1-0026b9348838",
-										"label": "Noticeable weight loss"
-									},
-									{
-										"concept": "e1862fef-68ed-4df4-90dd-a00152f719aa",
-										"label": "Night sweats = 2 weeks"
-									},
-									{
-										"concept": "a8ad462e-1350-11df-a1f1-0026b9348838",
-										"label": "Abdomen swelling"
-									},
-									{
-										"concept": "f218c60e-4b54-475a-a4fa-facab9216da8",
-										"label": "Groin swelling"
-									},
-									{
-										"concept": "a8a774b0-1350-11df-a1f1-0026b9348838",
-										"label": "Joints swelling"
-									},
-									{
-										"concept": "4639388c-ee31-4dcf-abb4-ad71253493bb",
-										"label": "Neck swelling"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [],
-							"id": "__sKDEGEEyv"
-						},
-						{
-							"label": "TB Status:",
-							"id": "tbstatus",
-							"required": "true",
-							"questionOptions": {
-								"concept": "02ad9357-b996-4530-b1a4-aff91a105383",
-								"answers": [
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "No signs"
-									},
-									{
-										"concept": "a8afcc82-1350-11df-a1f1-0026b9348838",
-										"label": "On TB treatment"
-									},
-									{
-										"concept": "260e6d24-1634-4467-a070-e8359f6827f7",
-										"label": "Suspect"
-									},
-									{
-										"concept": "a8af9046-1350-11df-a1f1-0026b9348838",
-										"label": "Confirmed"
-									},
-									{
-										"concept": "a899ea48-1350-11df-a1f1-0026b9348838",
-										"label": "Not assessed"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "STI",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Do you have any of the following:",
-							"required": "true",
-							"questionOptions": {
-								"concept": "a8b00562-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a8982b54-1350-11df-a1f1-0026b9348838",
-										"label": "Genital ulcers"
-									},
-									{
-										"concept": "a8ad3062-1350-11df-a1f1-0026b9348838",
-										"label": "Urethral discharge"
-									},
-									{
-										"concept": "a8ad2eb4-1350-11df-a1f1-0026b9348838",
-										"label": "Vaginal discharge"
-									},
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [],
-							"id": "__pnnryvrpL"
-						},
-						{
-							"label": "STI partner notification:",
-							"questionOptions": {
-								"concept": "7d7e1c44-a0d5-44ca-8481-8569b38c7e9b",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									},
-									{
-										"concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
-										"label": "N/A"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [],
-							"id": "__LEDCquGKJ"
-						}
-					]
-				},
-				{
-					"label": "Adult WHO Staging",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "If you are assigning a new WHO stage to patient today, select new WHO stage:",
-							"type": "obs",
-							"id": "adultWhoStage",
-							"questionOptions": {
-								"concept": "a8a8331e-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a89b2606-1350-11df-a1f1-0026b9348838",
-										"label": "1"
-									},
-									{
-										"concept": "a89b26d8-1350-11df-a1f1-0026b9348838",
-										"label": "2"
-									},
-									{
-										"concept": "a89b27be-1350-11df-a1f1-0026b9348838",
-										"label": "3"
-									},
-									{
-										"concept": "a89b289a-1350-11df-a1f1-0026b9348838",
-										"label": "4"
-									}
-								],
-								"rendering": "select"
-							},
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && arrayContains (['33d13ffb-5f0e-427e-ab80-637491fb6526'], visitTypeUuid)",
-									"message": "Required."
-								}
-							]
-						},
-						{
-							"label": "Select criteria for new WHO stage:",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a8ae88a4-1350-11df-a1f1-0026b9348838",
-								"rendering": "select-concept-answers"
-							},
-							"required": {
-								"type": "conditionalRequired",
-								"message": "Patient marked as receiving new WHO stage. Please select stage.",
-								"referenceQuestionId": "adultWhoStage",
-								"referenceQuestionAnswers": [
-									"a89b2606-1350-11df-a1f1-0026b9348838, a89b26d8-1350-11df-a1f1-0026b9348838, a89b27be-1350-11df-a1f1-0026b9348838, a89b289a-1350-11df-a1f1-0026b9348838"
-								]
-							},
-							"validators": [],
-							"id": "__KLGqFrorn"
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Test Results",
-			"sections": [
-				{
-					"label": "Chemistry Lab Tests",
-					"questions": [
-						{
-							"type": "obs",
-							"label": "Creatinine mmol/L:",
-							"id": "creatinine_test",
-							"questionOptions": {
-								"concept": "a897e450-1350-11df-a1f1-0026b9348838",
-								"rendering": "number",
-								"showDate": "true",
-								"max": "11050",
-								"min": "0",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(creatinine_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(creatinine_test)"
-									}
-								}
-							},
-							"validators": []
-						},
-						{
-							"type": "obs",
-							"label": "SGPT(ALT):",
-							"id": "sgptalt_test",
-							"questionOptions": {
-								"concept": "a896ca48-1350-11df-a1f1-0026b9348838",
-								"rendering": "number",
-								"max": "3500",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(sgptalt_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(sgptalt_test)"
-									}
-								}
-							},
-							"validators": []
-						},
-						{
-							"type": "obs",
-							"label": "AST:",
-							"id": "ast_test",
-							"questionOptions": {
-								"concept": "a896c8ae-1350-11df-a1f1-0026b9348838",
-								"rendering": "number",
-								"max": "3500",
-								"min": "0",
-								"showDate": "true"
-							},
-							"shownDateOptions": {
-								"validators": [
-									{
-										"type": "date"
-									},
-									{
-										"type": "js_expression",
-										"failsWhenExpression": "!isEmpty(ast_test) && isEmpty(myValue)",
-										"message": "Date is result is required."
-									}
-								],
-								"hide": {
-									"hideWhenExpression": "isEmpty(ast_test)"
-								}
-							}
-						},
-						{
-							"label": "RBS mmol/L:",
-							"id": "rbs_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a898418e-1350-11df-a1f1-0026b9348838",
-								"answers": [],
-								"rendering": "number",
-								"max": "50",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(rbs_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(rbs_test)"
-									}
-								}
-							}
-						},
-						{
-							"label": "FBS mmol/L:",
-							"id": "fbs_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a8b018fe-1350-11df-a1f1-0026b9348838",
-								"answers": [],
-								"rendering": "number",
-								"max": "50",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(fbs_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(fbs_test)"
-									}
-								}
-							}
-						},
-						{
-							"label": "HbA1C %:",
-							"id": "a1c_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a8af7520-1350-11df-a1f1-0026b9348838",
-								"answers": [],
-								"rendering": "number",
-								"max": "20",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(a1c_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(a1c_test)"
-									}
-								}
-							}
-						},
-						{
-							"label": "LDL mmol/L:",
-							"id": "ldl_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a898e74c-1350-11df-a1f1-0026b9348838",
-								"answers": [],
-								"rendering": "number",
-								"max": "75",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(ldl_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(ldl_test)"
-									}
-								}
-							}
-						},
-						{
-							"label": "HDL mmol/L:",
-							"id": "hdl_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a898e602-1350-11df-a1f1-0026b9348838",
-								"answers": [],
-								"rendering": "number",
-								"max": "15",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(hdl_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(hdl_test)"
-									}
-								}
-							}
-						},
-						{
-							"label": "TG mmol/L:",
-							"id": "tg_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a898e8a0-1350-11df-a1f1-0026b9348838",
-								"answers": [],
-								"rendering": "number",
-								"max": "55",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(tg_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(tg_test)"
-									}
-								}
-							}
-						},
-						{
-							"label": "Cholesterol mmol/L:",
-							"id": "chol_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a898e4b8-1350-11df-a1f1-0026b9348838",
-								"answers": [],
-								"rendering": "number",
-								"max": "100",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(chol_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(chol_test)"
-									}
-								}
-							}
-						},
-						{
-							"label": "Microalbumin test, urine mg/L:",
-							"id": "microAlb_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "7129af13-e39a-43b0-9923-6d1de22c9c5e",
-								"answers": [],
-								"rendering": "number",
-								"max": "300",
-								"min": "30",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(microAlb_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(microAlb_test)"
-									}
-								}
-							}
-						},
-						{
-							"label": "Urea mmol/L:",
-							"id": "urea_test",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a8982550-1350-11df-a1f1-0026b9348838",
-								"answers": [],
-								"rendering": "number",
-								"max": "330",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(urea_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hde": {
-										"hideWhenExpression": "isEmpty(urea_test)"
-									}
-								}
-							}
-						}
-					]
-				},
-				{
-					"label": "CBC",
-					"questions": [
-						{
-							"label": "Hgb g/dL:",
-							"id": "hgbgdl_test",
-							"questionOptions": {
-								"concept": "a8908a16-1350-11df-a1f1-0026b9348838",
-								"max": "50",
-								"min": "0",
-								"showDate": "true",
-								"rendering": "number",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(hgbgdl_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(hgbgdl_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "WBC/mm3:",
-							"id": "testWBCmm",
-							"questionOptions": {
-								"concept": "a896dea2-1350-11df-a1f1-0026b9348838",
-								"max": "500",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(testWBCmm) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(testWBCmm)"
-									}
-								},
-								"rendering": "number"
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"type": "obs",
-							"label": "Platelets:",
-							"id": "platelets_test",
-							"questionOptions": {
-								"concept": "a8970954-1350-11df-a1f1-0026b9348838",
-								"rendering": "number",
-								"max": "450000",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(platelets_test) && isEmpty(myValue)",
-											"message": "Date result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(platelets_test)"
-									}
-								}
-							},
-							"validators": []
-						},
-						{
-							"label": "ALC/ mm3:",
-							"id": "alcmm_test",
-							"questionOptions": {
-								"concept": "a898b20e-1350-11df-a1f1-0026b9348838",
-								"max": "500",
-								"min": "0",
-								"showDate": "true",
-								"rendering": "number",
-								"shownDateOptions": {
-									"historicalExpression": "HD.getObject('prevEnc').getValue('a8afdb8c-1350-11df-a1f1-0026b9348838.a898b20e-1350-11df-a1f1-0026b9348838')",
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(alcmm_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(alcmm_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "MCV:",
-							"id": "mcv_test",
-							"questionOptions": {
-								"concept": "a898201e-1350-11df-a1f1-0026b9348838",
-								"max": "500",
-								"min": "0",
-								"showDate": "true",
-								"rendering": "number",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(mcv_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(mcv_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "CD4",
-					"questions": [
-						{
-							"type": "obs",
-							"id": "cd4_test",
-							"questionOptions": {
-								"concept": "a8a8bb18-1350-11df-a1f1-0026b9348838",
-								"showDate": "true",
-								"rendering": "number",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(cd4_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(cd4_test)"
-									}
-								}
-							},
-							"label": "CD4 Count:",
-							"validators": []
-						},
-						{
-							"type": "obs",
-							"label": "CD4 %:",
-							"id": "cd4percent_test",
-							"questionOptions": {
-								"rendering": "number",
-								"max": "100",
-								"min": "0",
-								"showDate": "true",
-								"concept": "a8970a26-1350-11df-a1f1-0026b9348838",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(cd4percent_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(cd4percent_test)"
-									}
-								}
-							},
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "ART Drug Sensitivity Test",
-					"questions": [
-						{
-							"label": "ART drug sensitivity test (Upload image of the result):",
-							"id": "drugSensitivity_test",
-							"questionOptions": {
-								"concept": "8ec7c519-502e-46ea-8a98-181ed5a088be",
-								"showDate": "true",
-								"rendering": "file",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(drugSensitivity_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(drugSensitivity_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "Viral Load",
-					"questions": [
-						{
-							"type": "obs",
-							"label": "Viral load:",
-							"id": "viralLoad_test",
-							"questionOptions": {
-								"concept": "a8982474-1350-11df-a1f1-0026b9348838",
-								"rendering": "number",
-								"max": "10000000",
-								"min": "0",
-								"showDate": "true",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(viralLoad_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(viralLoad_test)"
-									}
-								}
-							},
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "Urinalysis",
-					"questions": [
-						{
-							"label": "Urinalysis:",
-							"type": "obsGroup",
-							"questionOptions": {
-								"id": "urinalysis",
-								"concept": "a8a0aa9a-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Pus cells:",
-									"id": "puscells_test",
-									"type": "obs",
-									"questionOptions": {
-										"concept": "a8a0a91e-1350-11df-a1f1-0026b9348838",
-										"rendering": "select",
-										"answers": [
-											{
-												"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-												"label": "Negative"
-											},
-											{
-												"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-												"label": "Positive (+)"
-											},
-											{
-												"concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
-												"label": "Strong positive (++)"
-											},
-											{
-												"concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
-												"label": "Stronger positive (+++)"
-											}
-										]
-									},
-									"hide": {
-										"hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
-									}
-								},
-								{
-									"label": "Protein:",
-									"type": "obs",
-									"id": "protein_test",
-									"questionOptions": {
-										"concept": "a8a47ca6-1350-11df-a1f1-0026b9348838",
-										"rendering": "select",
-										"answers": [
-											{
-												"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-												"label": "Negative"
-											},
-											{
-												"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-												"label": "Positive (+)"
-											},
-											{
-												"concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
-												"label": "Strong positive (++)"
-											},
-											{
-												"concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
-												"label": "Stronger positive (+++)"
-											}
-										]
-									},
-									"hide": {
-										"hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
-									}
-								},
-								{
-									"label": "Leucocytes:",
-									"type": "obs",
-									"id": "leucocytes_test",
-									"questionOptions": {
-										"concept": "a8b0f3e6-1350-11df-a1f1-0026b9348838",
-										"rendering": "select",
-										"answers": [
-											{
-												"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-												"label": "Negative"
-											},
-											{
-												"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-												"label": "Positive (+)"
-											},
-											{
-												"concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
-												"label": "Strong positive (++)"
-											},
-											{
-												"concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
-												"label": "Stronger positive (+++)"
-											}
-										]
-									},
-									"hide": {
-										"hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
-									}
-								},
-								{
-									"label": "Ketone:",
-									"type": "obs",
-									"id": "ketone_test",
-									"questionOptions": {
-										"concept": "b72fa772-19a9-4386-8185-6491ab97e97e",
-										"rendering": "select",
-										"answers": [
-											{
-												"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-												"label": "Negative"
-											},
-											{
-												"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-												"label": "Positive (+)"
-											},
-											{
-												"concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
-												"label": "Strong positive (++)"
-											},
-											{
-												"concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
-												"label": "Stronger positive (+++)"
-											}
-										]
-									},
-									"hide": {
-										"hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
-									}
-								},
-								{
-									"label": "Glucose:",
-									"id": "sugar_test",
-									"type": "obs",
-									"questionOptions": {
-										"concept": "a8a47d5a-1350-11df-a1f1-0026b9348838",
-										"rendering": "select",
-										"answers": [
-											{
-												"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-												"label": "Negative"
-											},
-											{
-												"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-												"label": "Positive (+)"
-											},
-											{
-												"concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
-												"label": "Strong positive (++)"
-											},
-											{
-												"concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
-												"label": "Stronger positive (+++)"
-											}
-										]
-									},
-									"hide": {
-										"hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
-									}
-								},
-								{
-									"label": "Nitrites:",
-									"id": "nitrites_test",
-									"type": "obs",
-									"questionOptions": {
-										"concept": "6ab44394-80a5-40cd-9649-32f1839e94cd",
-										"rendering": "select",
-										"answers": [
-											{
-												"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-												"label": "Negative"
-											},
-											{
-												"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-												"label": "Positive (+)"
-											},
-											{
-												"concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
-												"label": "Strong positive (++)"
-											},
-											{
-												"concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
-												"label": "Stronger positive (+++)"
-											}
-										]
-									},
-									"hide": {
-										"hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
-									}
-								}
-							],
-							"id": "__IvovCqnzL"
-						}
-					]
-				},
-				{
-					"label": "Blood Grouping",
-					"questions": [
-						{
-							"label": "Blood type:",
-							"id": "bloodGroup_test",
-							"questionOptions": {
-								"concept": "a8945754-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a896e8c0-1350-11df-a1f1-0026b9348838",
-										"label": "A positive"
-									},
-									{
-										"concept": "a896ea6e-1350-11df-a1f1-0026b9348838",
-										"label": "A negative"
-									},
-									{
-										"concept": "a896ec1c-1350-11df-a1f1-0026b9348838",
-										"label": "B positive"
-									},
-									{
-										"concept": "a896edca-1350-11df-a1f1-0026b9348838",
-										"label": "B negative"
-									},
-									{
-										"concept": "a896f04a-1350-11df-a1f1-0026b9348838",
-										"label": "O positive"
-									},
-									{
-										"concept": "a896f1f8-1350-11df-a1f1-0026b9348838",
-										"label": "O negative"
-									},
-									{
-										"concept": "a89b47a8-1350-11df-a1f1-0026b9348838",
-										"label": "AB positive"
-									},
-									{
-										"concept": "a89b48de-1350-11df-a1f1-0026b9348838",
-										"label": "AB negative"
-									},
-									{
-										"concept": "33bc1cf5-4ae5-49ba-9afd-bcbb9f7b09e5",
-										"label": "A"
-									},
-									{
-										"concept": "01e7f790-a8fc-40e9-968f-c9d79924eb6d",
-										"label": "B"
-									},
-									{
-										"concept": "0feab44f-6777-4c4b-a3ed-a3502f996fcb",
-										"label": "AB"
-									},
-									{
-										"concept": "bf9a31dc-5db4-49c2-aad2-30ec16315b24",
-										"label": "O"
-									}
-								],
-								"showDate": "true",
-								"rendering": "select",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(bloodGroup_test) && isEmpty(myValue)",
-											"message": "Date result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(bloodGroup_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "TB Test",
-					"questions": [
-						{
-							"label": "Genexpert test (Upload image of the result):",
-							"id": "genexpert_test",
-							"questionOptions": {
-								"concept": "6fa355eb-9321-4850-884c-12594194862a",
-								"showDate": "true",
-								"rendering": "file",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(genexpert_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(genexpert_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "Sputum gene xpert MTB:",
-							"id": "sputumgene_test",
-							"questionOptions": {
-								"concept": "741517cf-8bac-4755-b289-8dd2a2df7962",
-								"answers": [
-									{
-										"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-										"label": "Positive"
-									},
-									{
-										"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-										"label": "Negative"
-									},
-									{
-										"concept": "a89a7ae4-1350-11df-a1f1-0026b9348838",
-										"label": "Indeterminate"
-									},
-									{
-										"concept": "a89c3d8e-1350-11df-a1f1-0026b9348838",
-										"label": "Poor sample quality"
-									}
-								],
-								"showDate": "true",
-								"rendering": "select",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(sputumgene_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(sputumgene_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "Sputum AFB smear:",
-							"id": "sputumafp_test",
-							"questionOptions": {
-								"concept": "a8945d4e-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a8a45ab4-1350-11df-a1f1-0026b9348838",
-										"label": "1+"
-									},
-									{
-										"concept": "a8a45bd6-1350-11df-a1f1-0026b9348838",
-										"label": "2+"
-									},
-									{
-										"concept": "a8a45ca8-1350-11df-a1f1-0026b9348838",
-										"label": "3+"
-									},
-									{
-										"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-										"label": "Positive"
-									},
-									{
-										"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-										"label": "Negative"
-									},
-									{
-										"concept": "a89a7ae4-1350-11df-a1f1-0026b9348838",
-										"label": "Indeterminate"
-									},
-									{
-										"concept": "a89c3d8e-1350-11df-a1f1-0026b9348838",
-										"label": "Poor sample quality"
-									}
-								],
-								"showDate": "true",
-								"rendering": "select",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(sputumafp_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(sputumafp_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "Sputum culture:",
-							"id": "sputumculture_test",
-							"questionOptions": {
-								"concept": "a8a462a2-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-										"label": "Positive"
-									},
-									{
-										"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-										"label": "Negative"
-									},
-									{
-										"concept": "a89c3d8e-1350-11df-a1f1-0026b9348838",
-										"label": "Poor sample quality"
-									},
-									{
-										"concept": "0b4e9aa1-e470-46d1-9d2d-0d8a475561b9",
-										"label": "Mycobacterium tuberculosis"
-									},
-									{
-										"concept": "a01149c4-7f0e-4d27-8f42-dc019e3330ec",
-										"label": "Non tuberculosis mycobacteria"
-									}
-								],
-								"showDate": "true",
-								"rendering": "select",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(sputumculture_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(sputumculture_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "TST (Mantoux test):",
-							"id": "tst_test",
-							"questionOptions": {
-								"concept": "a89d278a-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-										"label": "Positive"
-									},
-									{
-										"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-										"label": "Negative"
-									},
-									{
-										"concept": "a89d2852-1350-11df-a1f1-0026b9348838",
-										"label": "Strongly positive"
-									}
-								],
-								"showDate": "true",
-								"rendering": "select",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(tst_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(tst_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "Chest Xray",
-					"questions": [
-						{
-							"label": "CXR code:",
-							"id": "cxrcode_test",
-							"questionOptions": {
-								"concept": "a8908192-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899e7b4-1350-11df-a1f1-0026b9348838",
-										"label": "Normal"
-									},
-									{
-										"concept": "a8a6aa3a-1350-11df-a1f1-0026b9348838",
-										"label": "Cardiomegaly"
-									},
-									{
-										"concept": "a8ae8c1e-1350-11df-a1f1-0026b9348838",
-										"label": "Cavitary"
-									},
-									{
-										"concept": "a8ae8a66-1350-11df-a1f1-0026b9348838",
-										"label": "Diffuse abn/non-miliary"
-									},
-									{
-										"concept": "a8ae8980-1350-11df-a1f1-0026b9348838",
-										"label": "Infiltrate"
-									},
-									{
-										"concept": "a89a77ce-1350-11df-a1f1-0026b9348838",
-										"label": "Miliary"
-									},
-									{
-										"concept": "a89a76fc-1350-11df-a1f1-0026b9348838",
-										"label": "PI effusion"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"showDate": "true",
-								"rendering": "select",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(cxrcode_test) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(cxrcode_test)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						}
-					]
-				},
-				{
-					"label": "Other Lab Tests",
-					"questions": [
-						{
-							"type": "obsGroup",
-							"label": "Test result, detailed",
-							"questionOptions": {
-								"concept": "a8a00e1e-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"type": "obs",
-									"label": "Other test results, specify:",
-									"id": "otherTestResult",
-									"questionOptions": {
-										"concept": "6f5207f4-6785-433b-943e-c2d03e7d3ea7",
-										"rendering": "text"
-									},
-									"validators": []
-								}
-							],
-							"id": "__o8FwxyxIz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Assessment",
-			"sections": [
-				{
-					"label": "Clinical Notes",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Please enter the clinical notes below:",
-							"type": "obs",
-							"id": "assNote",
-							"default": "",
-							"questionOptions": {
-								"concept": "23f710cc-7f9c-4255-9b6b-c3e240215dba",
-								"rendering": "textarea",
-								"rows": 5
-							}
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Medication Plan",
-			"sections": [
-				{
-					"label": "ART Plan",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"required": "true",
-							"id": "arvPlan",
-							"label": "ART plan:",
-							"questionOptions": {
-								"concept": "a89b75d4-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a89b7908-1350-11df-a1f1-0026b9348838",
-										"label": "Continue regimen"
-									},
-									{
-										"concept": "a898c938-1350-11df-a1f1-0026b9348838",
-										"label": "Change dose"
-									},
-									{
-										"concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
-										"label": "Change regimen"
-									},
-									{
-										"concept": "a89b7ae8-1350-11df-a1f1-0026b9348838",
-										"label": "Change formulation"
-									},
-									{
-										"concept": "a8a00158-1350-11df-a1f1-0026b9348838",
-										"label": "Drug substitution"
-									},
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "Not on ARVS"
-									},
-									{
-										"concept": "a8a00220-1350-11df-a1f1-0026b9348838",
-										"label": "Restart"
-									},
-									{
-										"concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
-										"label": "Start ARVs"
-									},
-									{
-										"concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
-										"label": "Stop all"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
-									"message": "Patient marked as on ART in ART History section. Therefore plan can only be drug substitution, continue regimen, change dose, chage regimen, change"
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
-									"message": "Patient marked as not on ART in ART History section. Therefore plan can only be None,Start"
-								}
-							]
-						},
-						{
-							"label": "Reason to start ART:",
-							"id": "arvStartReason",
-							"questionOptions": {
-								"concept": "a89b6ce2-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "c9778159-958b-4f59-9053-a6171074726f",
-										"label": "CD4 less than 500"
-									},
-									{
-										"concept": "a8af49d8-1350-11df-a1f1-0026b9348838",
-										"label": "Discordant couple"
-									},
-									{
-										"concept": "a89b27be-1350-11df-a1f1-0026b9348838",
-										"label": "WHO stage 3"
-									},
-									{
-										"concept": "a89b289a-1350-11df-a1f1-0026b9348838",
-										"label": "WHO stage 4"
-									},
-									{
-										"concept": "a89fbedc-1350-11df-a1f1-0026b9348838",
-										"label": "PMTCT"
-									},
-									{
-										"concept": "a8909060-1350-11df-a1f1-0026b9348838",
-										"label": "Hepatitis"
-									},
-									{
-										"concept": "7fa72118-ef2a-4694-993a-014440024bbc",
-										"label": "Test and treat"
-									},
-									{
-										"concept": "67f1f202-477a-4469-a2f9-769b339f682f",
-										"label": "Adherence counselling completed"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(arvPlan) && isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)",
-									"message": "You indicated patient is (re)starting ART. Please provide reason."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(arvPlan) && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)",
-									"message": "You indicated patient is not (re)starting ART, therefore no reason for starting should be selected."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "!arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)"
-							}
-						},
-						{
-							"type": "obsGroup",
-							"label": "ART change reason",
-							"questionOptions": {
-								"concept": "a8a07688-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"id": "arvChangeReason",
-									"label": "Reason for stopping/change/substitution/interruption:",
-									"questionOptions": {
-										"concept": "a89b7110-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
-												"label": "Adherence concerns"
-											},
-											{
-												"concept": "a8981934-1350-11df-a1f1-0026b9348838",
-												"label": "Clinical treatment failure"
-											},
-											{
-												"concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
-												"label": "Drug out of stock"
-											},
-											{
-												"concept": "a890a96a-1350-11df-a1f1-0026b9348838",
-												"label": "Due to new TB"
-											},
-											{
-												"concept": "057dae68-3d6f-4d79-926c-ed75a0ce7fd5",
-												"label": "Illness/hospitalization"
-											},
-											{
-												"concept": "c6537e06-9fc2-47da-b679-e2a32824407f",
-												"label": "Immunologic failure"
-											},
-											{
-												"concept": "a8a6f56c-1350-11df-a1f1-0026b9348838",
-												"label": "Lost to follow-up"
-											},
-											{
-												"concept": "a8a07b10-1350-11df-a1f1-0026b9348838",
-												"label": "New drug available"
-											},
-											{
-												"concept": "a8b03af0-1350-11df-a1f1-0026b9348838",
-												"label": "Patient lacks finances"
-											},
-											{
-												"concept": "abe0cbb6-8d08-487a-b18e-7af873945fcc",
-												"label": "Planned Rx interruption"
-											},
-											{
-												"concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
-												"label": "Pill burden"
-											},
-											{
-												"concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
-												"label": "Changing to adult regimen"
-											},
-											{
-												"concept": "a8909e8e-1350-11df-a1f1-0026b9348838",
-												"label": "Pregnancy"
-											},
-											{
-												"concept": "e38b3e51-8a27-4bf6-b0c8-e0b285e4bb2f",
-												"label": "Risk of pregnancy"
-											},
-											{
-												"concept": "a89d25fa-1350-11df-a1f1-0026b9348838",
-												"label": "Other patient desicion"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											},
-											{
-												"concept": "4ee08cb4-fc93-44a0-a330-4e3fb45ca625",
-												"label": "Optimization"
-											},
-											{
-												"concept": "a890d1ba-1350-11df-a1f1-0026b9348838",
-												"label": "Toxicity"
-											},
-											{
-												"concept": "93fe19e8-fec4-4e4b-85f1-239e1fabd761",
-												"label": "Virologic failure"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(arvPlan) && isEmpty(myValue) && arrayContains(['a898c938-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], arvPlan)",
-											"message": "You indicated patient is changing/changing dose/substituting/stopping arvs, reason for changing should be selected."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "!arrayContains(['a898c938-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], arvPlan)"
-									}
-								},
-								{
-									"id": "arvToxicityCause",
-									"label": "If toxicity, please provide cause:",
-									"questionOptions": {
-										"concept": "a8a032fe-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
-												"label": "Anaemia"
-											},
-											{
-												"concept": "a8909060-1350-11df-a1f1-0026b9348838",
-												"label": "Hepatitis"
-											},
-											{
-												"concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
-												"label": "IRIS"
-											},
-											{
-												"concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
-												"label": "Lactic acidosis"
-											},
-											{
-												"concept": "a89cee50-1350-11df-a1f1-0026b9348838",
-												"label": "Lipo-dystrophy"
-											},
-											{
-												"concept": "a897fe86-1350-11df-a1f1-0026b9348838",
-												"label": "Neuropathy"
-											},
-											{
-												"concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
-												"label": "Persistent vomiting"
-											},
-											{
-												"concept": "a895776a-1350-11df-a1f1-0026b9348838",
-												"label": "Rash"
-											},
-											{
-												"concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
-												"label": "Steven-Johnson syndrome"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(arvChangeReason)&&isEmpty(myValue) && (arvChangeReason==='a890d1ba-1350-11df-a1f1-0026b9348838')",
-											"message": "You indicated patient is changing /changing dose/substituting/stopping arvs due to toxicity, cause should be selected."
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(arvChangeReason) && !isEmpty(myValue) && (arvChangeReason!=='a890d1ba-1350-11df-a1f1-0026b9348838')",
-											"message": "You indicated patient is not changing/dose/substituting/stopping arvs due to toxicity, cause should be selected."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "arvChangeReason!=='a890d1ba-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "If toxicity: Other (specify):",
-									"id": "arvToxOther",
-									"type": "obs",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(arvToxicityCause) && isEmpty(myValue) && (arvToxicityCause==='a8aaf3e2-1350-11df-a1f1-0026b9348838')",
-											"message": "You indicated patient is changing /changing dose/substituting/stopping arvs due to other toxicity, indicate the other cause."
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(arvToxicityCause) && !isEmpty(myValue) && (arvToxicityCause!=='a8aaf3e2-1350-11df-a1f1-0026b9348838')",
-											"message": "You indicated patient is not changing /changing dose/substituting/stopping arvs due to other toxicity, other cause is not required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "arvToxicityCause!=='a8aaf3e2-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							],
-							"id": "__svwFww7EF"
-						},
-						{
-							"type": "obsGroup",
-							"label": "Eligible for ART",
-							"questionOptions": {
-								"concept": "a8a17a7e-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Eligible for ART but not started:",
-									"id": "artEligibleNotStarted",
-									"questionOptions": {
-										"concept": "a89d26cc-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
-												"label": "Adherence concerns"
-											},
-											{
-												"concept": "a8a8b26c-1350-11df-a1f1-0026b9348838",
-												"label": "On TB treatment"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											},
-											{
-												"concept": "a89d25fa-1350-11df-a1f1-0026b9348838",
-												"label": "Patient refused"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "arvPlan !== 'a899e0ac-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "Eligible for ART but not started: Other (specify):",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"id": "eligibleOther",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "artEligibleNotStarted !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							],
-							"id": "__LrLCGwsn9"
-						},
-						{
-							"label": "Plan treatment categories:",
-							"type": "obs",
-							"id": "planCate",
-							"questionOptions": {
-								"concept": "74e3b23f-b94f-49d9-a237-6baaee73f163",
-								"answers": [
-									{
-										"concept": "034047bd-3fa1-4b2a-b0f0-2787e9b9f7b3",
-										"label": "First line regimen"
-									},
-									{
-										"concept": "8f8a715d-e49a-4b2c-aa3a-83fa9d7a4254",
-										"label": "Second line regimen"
-									},
-									{
-										"concept": "a90ebdd2-351f-485a-b850-4938fcca2729",
-										"label": "Third line regimen"
-									}
-								],
-								"rendering": "select"
-							},
-							"hide": {
-								"hideWhenExpression": "!arrayContains(['a89b7ae8-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a8a00220-1350-11df-a1f1-0026b9348838'],arvPlan)"
-							}
-						},
-						{
-							"label": "ART regimen started, adult:",
-							"id": "artStartedAdult",
-							"questionOptions": {
-								"concept": "a89b6a62-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "18e86e1f-92b8-40cd-8266-0df0ab0a4a50",
-										"label": "DTG50mg/3TC300mg/TDF300mg"
-									},
-									{
-										"concept": "1c4a75d0-cc91-4752-b0a5-4b833326ff7a",
-										"label": "TDF300mg/3TC300mg/EFV600mg"
-									},
-									{
-										"concept": "ea501f4e-cbc5-4942-b9c8-0ac415929f08",
-										"label": "TDF300mg/3TC300mg/EFV400mg"
-									},
-									{
-										"concept": "e78843da-fdb6-446d-8e99-873c278b3540",
-										"label": "ABC600mg/3TC300mg"
-									},
-									{
-										"concept": "6a73f32d-1870-4527-af6e-74443251ded2",
-										"label": "NVP200/ZDV300/3TC150"
-									},
-									{
-										"concept": "a89cc876-1350-11df-a1f1-0026b9348838",
-										"label": "3TC300mg/TDF300mg"
-									},
-									{
-										"concept": "a896758e-1350-11df-a1f1-0026b9348838",
-										"label": "3TC150mg/ZDV300mg"
-									},
-									{
-										"concept": "a8afcf84-1350-11df-a1f1-0026b9348838",
-										"label": "Emtri200mg/TDF300(Truvada)"
-									},
-									{
-										"concept": "a897e7c0-1350-11df-a1f1-0026b9348838",
-										"label": "Aluvia(Kaletra)200mg/LPV50mg"
-									},
-									{
-										"concept": "a8afc066-1350-11df-a1f1-0026b9348838",
-										"label": "Atazanavir300/Ritonavir100"
-									},
-									{
-										"concept": "dabf36cb-dd9a-4542-a8ef-874c1ee5be4a",
-										"label": "FTC200mg/RPV25mg/TDF245mg(Eviplera)"
-									},
-									{
-										"concept": "98b0baf6-0b73-4429-9264-6233684b0969",
-										"label": "Dolutegravir 50mg"
-									},
-									{
-										"concept": "a897f8a0-1350-11df-a1f1-0026b9348838",
-										"label": "Abacavir300mg"
-									},
-									{
-										"concept": "db3c194b-3e1b-4001-9a1c-a5df1728fc28",
-										"label": "Efavirenz 200mg"
-									},
-									{
-										"concept": "a89673f4-1350-11df-a1f1-0026b9348838",
-										"label": "Lamivudine150mg"
-									},
-									{
-										"concept": "a8afbd64-1350-11df-a1f1-0026b9348838",
-										"label": "Raltegravir 400mg"
-									},
-									{
-										"concept": "a897ea4a-1350-11df-a1f1-0026b9348838",
-										"label": "Zidovudine300mg"
-									},
-									{
-										"concept": "68a0a5dd-1e91-43a2-8dce-c6e84a14de04",
-										"label": "Darunavir 600mg"
-									},
-									{
-										"concept": "1baf254e-1429-4fd9-8db1-edf6523cea13",
-										"label": " Ritonavir 100mg"
-									},
-									{
-										"concept": "42ef7c4d-d6fb-49c0-a46e-019c42dea203",
-										"label": " Ritonavir 80mg"
-									},
-									{
-										"concept": "38fbba9c-4b26-412d-9659-8dd649514d66",
-										"label": "Etravirine 100mg"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(arvPlan) && isEmpty(myValue) && arrayContains(['a89b7ae8-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)",
-									"message": "Based on the plan selected, you must choose a regimen."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(myValue) && !arrayContains(['a89b7ae8-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)",
-									"message": "Based on the plan selected, you may not choose a regimen."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "!arrayContains(['a89b7ae8-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a8a00220-1350-11df-a1f1-0026b9348838'],arvPlan)"
-							}
-						},
-						{
-							"label": "Indication for DTG based ART:",
-							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('3c54aae1-8b94-49b5-9961-b6aa7cacc03b')) ? undefined : HD.getObject('prevEnc').getValue('3c54aae1-8b94-49b5-9961-b6aa7cacc03b')",
-							"id": "dtgIndication",
-							"type": "obs",
-							"questionOptions": {
-								"rendering": "select",
-								"concept": "3c54aae1-8b94-49b5-9961-b6aa7cacc03b",
-								"answers": [
-									{
-										"concept": "971e804e-89f1-41a2-9cfc-82922eed3db2",
-										"label": "ART intiation"
-									},
-									{
-										"concept": "c9072a63-0075-4f5a-81af-1439d803a510",
-										"label": "Substitution for EFV intolerance/toxicity"
-									},
-									{
-										"concept": "c3bfde9d-6f9c-4a92-ba74-bbf3af8c7061",
-										"label": "Substitution for NVP"
-									},
-									{
-										"concept": "a90ebdd2-351f-485a-b850-4938fcca2729",
-										"label": "Third line regimen"
-									},
-									{
-										"concept": "24d5c8f6-e92c-47fb-becb-9cfac89939c5",
-										"label": "Substitution for ATV/r in PWID"
-									},
-									{
-										"concept": "30c754b8-e20a-470b-a2cf-b6f1f92c733d",
-										"label": "Substitution for PI/r in 2nd line with TB disease"
-									},
-									{
-										"concept": "9af59394-f330-4616-b361-86642659808a",
-										"label": "Alternative for virally suppressed 1st line PI/r based regimen"
-									},
-									{
-										"concept": "0df1b558-9598-4ca4-9678-7a1caae6265f",
-										"label": "Alternative regimen for pregnant/postpartum women"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								]
-							},
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(artStartedAdult) && arrayContains(artStartedAdult, '98b0baf6-0b73-4429-9264-6233684b0969')",
-									"message": "DTG indication is required."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "isEmpty(artStartedAdult) || !arrayContains(artStartedAdult, '98b0baf6-0b73-4429-9264-6233684b0969')"
-							}
-						},
-						{
-							"label": "Other (specify):",
-							"id": "otherDtgIndications",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-								"rendering": "text"
-							},
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "dtgIndication !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
-							}
-						}
-					]
-				},
-				{
-					"label": "PCP Prophylaxis Plan",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"required": "true",
-							"id": "pcpProphylaxisPlan",
-							"label": "PCP prophylaxis plan:",
-							"questionOptions": {
-								"concept": "a89b7e12-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a89b7908-1350-11df-a1f1-0026b9348838",
-										"label": "Continue"
-									},
-									{
-										"concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
-										"label": "Change regimen"
-									},
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "Not on PCP prophylaxis"
-									},
-									{
-										"concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
-										"label": "Start"
-									},
-									{
-										"concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
-										"label": "Stop"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(pcpProphylaxisCurrent) && !isEmpty(myValue) && !arrayContains(['a899e0ac-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838'],myValue)&&(pcpProphylaxisCurrent==='a899e0ac-1350-11df-a1f1-0026b9348838')",
-									"message": "Patient marked as not on PCP prophylaxis. Therefore plan can only be none or start."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(pcpProphylaxisCurrent) && !isEmpty(myValue) && arrayContains(['a8989396-1350-11df-a1f1-0026b9348838','a890c9e0-1350-11df-a1f1-0026b9348838'],pcpProphylaxisCurrent)&&!(arrayContains(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838','a89b7908-1350-11df-a1f1-0026b9348838'], myValue))",
-									"message": "Patient marked as on PCP Prophylaxis. Therefore plan can only be change regimen,continue or stop."
-								}
-							]
-						},
-						{
-							"type": "obsGroup",
-							"label": "PCP prophylaxis change reason",
-							"questionOptions": {
-								"concept": "a8a07750-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "If change/stop, reason:",
-									"id": "pcpProphylaxisChangeReason",
-									"questionOptions": {
-										"concept": "a89b7eee-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a890d1ba-1350-11df-a1f1-0026b9348838",
-												"label": "Toxicity"
-											},
-											{
-												"concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
-												"label": "Pill burden"
-											},
-											{
-												"concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
-												"label": "Drug out of stock"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(pcpProphylaxisPlan) && isEmpty(myValue) && arrayContains(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan)",
-											"message": "Patient changed drugs, please select reason."
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(pcpProphylaxisPlan) && !isEmpty(myValue) && (!arrayContains(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan))",
-											"message": "Patient has not changed drugs, please do not select a reason."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "!arrayContains(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan)"
-									}
-								}
-							],
-							"id": "__rMyDpFrF8"
-						},
-						{
-							"id": "pcpToxicityCause",
-							"label": "If toxicity, please provide cause:",
-							"questionOptions": {
-								"concept": "a8a032fe-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
-										"label": "Anaemia"
-									},
-									{
-										"concept": "a8909060-1350-11df-a1f1-0026b9348838",
-										"label": "Hepatitis"
-									},
-									{
-										"concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
-										"label": "IRIS"
-									},
-									{
-										"concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
-										"label": "Lactic acidosis"
-									},
-									{
-										"concept": "a89cee50-1350-11df-a1f1-0026b9348838",
-										"label": "Lipo-dystrophy"
-									},
-									{
-										"concept": "a897fe86-1350-11df-a1f1-0026b9348838",
-										"label": "Neuropathy"
-									},
-									{
-										"concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
-										"label": "Persistent vomiting"
-									},
-									{
-										"concept": "a895776a-1350-11df-a1f1-0026b9348838",
-										"label": "Rash"
-									},
-									{
-										"concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
-										"label": "Steven-johnson syndrome"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(pcpProphylaxisChangeReason) && isEmpty(myValue) && (pcpProphylaxisChangeReason==='a890d1ba-1350-11df-a1f1-0026b9348838')",
-									"message": "You indicated patient is changing /changing dose/substituting/stopping PCP due to toxicity, cause should be selected."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(pcpProphylaxisChangeReason) && !isEmpty(myValue) && (pcpProphylaxisChangeReason!=='a890d1ba-1350-11df-a1f1-0026b9348838')",
-									"message": "You indicated patient is not changing/dose/substituting/stopping PCP due to toxicity, cause should not be selected."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "pcpProphylaxisChangeReason !== 'a890d1ba-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "If toxicity, please provide cause: Other (specify):",
-							"id": "q25OtherToxicity",
-							"questionOptions": {
-								"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-								"rendering": "text"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(pcpToxicityCause) && isEmpty(myValue) && pcpToxicityCause==='a8aaf3e2-1350-11df-a1f1-0026b9348838'",
-									"message": "You indicated patient is changing /changing dose/substituting/stopping PCP due to other toxicity, indicate the other cause."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "pcpToxicityCause !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "If Start/Change, regimen:",
-							"id": "pcpPlanMedication",
-							"questionOptions": {
-								"concept": "a89b82cc-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a8989396-1350-11df-a1f1-0026b9348838",
-										"label": "Septrin"
-									},
-									{
-										"concept": "a890c9e0-1350-11df-a1f1-0026b9348838",
-										"label": "Dapsone 100mg"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(pcpProphylaxisPlan) && isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838', 'a89b7c50-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan)",
-									"message": "You indicated patient is starting/continuing/changing PCP regimen. Please select regimen."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "!arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838', 'a89b7c50-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan)"
-							}
-						}
-					]
-				},
-				{
-					"label": "TB Prophylaxis Plan",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "TB prophylaxis plan:",
-							"required": "true",
-							"id": "tbpropplan",
-							"questionOptions": {
-								"concept": "a89c1cfa-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "Not on TB prophylaxis"
-									},
-									{
-										"concept": "a89b7908-1350-11df-a1f1-0026b9348838",
-										"label": "Continue"
-									},
-									{
-										"concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
-										"label": "Start"
-									},
-									{
-										"concept": "a8a00220-1350-11df-a1f1-0026b9348838",
-										"label": "Restart"
-									},
-									{
-										"concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
-										"label": "Stop"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onTbProphylaxis) && onTbProphylaxis === 'a899b35c-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838'], myValue)",
-									"message": "Patient marked as on TB prophylaxis in History section. Therefore plan can only be continue ,stop"
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(onTbProphylaxis) && onTbProphylaxis === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
-									"message": "Patient marked as not on TB prophylaxis in History section. Therefore plan can only be None,Start,Restart"
-								}
-							]
-						},
-						{
-							"type": "obsGroup",
-							"label": "stopping reason",
-							"questionOptions": {
-								"concept": "a8a0780e-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "If stopping, reason:",
-									"required": "true",
-									"id": "tbpropreasonstop",
-									"questionOptions": {
-										"concept": "a89c1e12-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a890a96a-1350-11df-a1f1-0026b9348838",
-												"label": "Active TB"
-											},
-											{
-												"concept": "a89c1ef8-1350-11df-a1f1-0026b9348838",
-												"label": "Completed"
-											},
-											{
-												"concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
-												"label": "Pill burden"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											},
-											{
-												"concept": "a890d1ba-1350-11df-a1f1-0026b9348838",
-												"label": "Toxicity"
-											},
-											{
-												"concept": "a89eb744-1350-11df-a1f1-0026b9348838",
-												"label": "Lack of drugs"
-											},
-											{
-												"concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
-												"label": "Poor adherence"
-											},
-											{
-												"concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
-												"label": "Side effects (Adverse drug reaction)"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "tbpropplan !== 'a89b7d36-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "If toxicity, please provide cause:",
-									"id": "toxCause",
-									"questionOptions": {
-										"concept": "a8a032fe-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
-												"label": "Anaemia"
-											},
-											{
-												"concept": "a8909060-1350-11df-a1f1-0026b9348838",
-												"label": "Hepatitis"
-											},
-											{
-												"concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
-												"label": "IRIS"
-											},
-											{
-												"concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
-												"label": "Lactic Acidosis"
-											},
-											{
-												"concept": "a89cee50-1350-11df-a1f1-0026b9348838",
-												"label": "Lipo-dystrophy"
-											},
-											{
-												"concept": "a897fe86-1350-11df-a1f1-0026b9348838",
-												"label": "Neuropathy"
-											},
-											{
-												"concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
-												"label": "Persistent vomiting"
-											},
-											{
-												"concept": "a895776a-1350-11df-a1f1-0026b9348838",
-												"label": "Rash"
-											},
-											{
-												"concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
-												"label": "Steven-Johnson syndrome"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "tbpropreasonstop !== 'a890d1ba-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "If toxicity, please provide cause: Other (specify):",
-									"id": "toxcauseOther",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "toxCause !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							],
-							"id": "__zrqKsvror"
-						},
-						{
-							"label": "TB prophylaxis regimen started:",
-							"questionOptions": {
-								"concept": "a89b83bc-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "162724df-5a66-4ae3-bbf6-5dc6dbba4ebb",
-										"label": "Isoniazid 100mg (6H)"
-									},
-									{
-										"concept": "b150ccdc-e7ec-4f99-b592-6f3fa73b3aea",
-										"label": "Isoniazid 300mg (6H)"
-									},
-									{
-										"concept": "aeaed1af-5b0d-401e-a32a-e96cf4072ab5",
-										"label": "Isoniazid 300mg and Rifapentine 300mg (3HP)"
-									},
-									{
-										"concept": "177635d0-793b-4a66-8324-976c46f795af",
-										"label": "Rifampicin 150mg and Isonaizid 75mg (3RH)"
-									},
-									{
-										"concept": "e5e24e6d-e6b0-4c81-8f7b-0e366df29426",
-										"label": "Rifampicin 70mg and Isonaizid 50mg (3RH)"
-									}
-								],
-								"rendering": "select"
-							},
-							"id": "prophyReg",
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "!arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], tbpropplan)"
-							}
-						}
-					]
-				},
-				{
-					"label": "TB Treatment Plan",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "TB Treatment Started, detailed",
-							"type": "obsGroup",
-							"questionOptions": {
-								"concept": "a89fe6f0-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "TB Treatment plan:",
-									"id": "tbTreatmentPlan",
-									"required": "true",
-									"questionOptions": {
-										"concept": "a89c1fd4-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-												"label": "Not on TB treatment"
-											},
-											{
-												"concept": "a89b7908-1350-11df-a1f1-0026b9348838",
-												"label": "Continue regimen"
-											},
-											{
-												"concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
-												"label": "Start induction"
-											},
-											{
-												"concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
-												"label": "Change to continuation"
-											},
-											{
-												"concept": "a898c938-1350-11df-a1f1-0026b9348838",
-												"label": "Re-dose"
-											},
-											{
-												"concept": "a8a00158-1350-11df-a1f1-0026b9348838",
-												"label": "Substitution"
-											},
-											{
-												"concept": "a8a00220-1350-11df-a1f1-0026b9348838",
-												"label": "Restart"
-											},
-											{
-												"concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
-												"label": "Stop"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(onTbTreatment) && onTbTreatment === 'a899b35c-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
-											"message": "Patient marked as on TB in TB History section. Therefore plan can only be drug substitution, continue regimen, change dose, change regimen"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(onTbTreatment) && onTbTreatment === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
-											"message": "Patient marked as not on TB in TB History section. Therefore plan can only be None, start"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(tbstatus) && tbstatus === 'a8af9046-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838'], myValue)",
-											"message": "Patient marked as confirmed for TB in TB Screening section. Therefore plan can only start"
-										}
-									]
-								}
-							],
-							"id": "__vIqMGy4uK"
-						},
-						{
-							"type": "obsGroup",
-							"label": "TB Plan Change Reason",
-							"questionOptions": {
-								"concept": "a8a078cc-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "If plan is to stop/change/re-dose/substitute, reason:",
-									"id": "tbPlanChangeReason",
-									"questionOptions": {
-										"concept": "a89c1fd4-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a89c1ef8-1350-11df-a1f1-0026b9348838",
-												"label": "Completed"
-											},
-											{
-												"concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
-												"label": "Drug out of stock"
-											},
-											{
-												"concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
-												"label": "Pill burden"
-											},
-											{
-												"concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
-												"label": "Changing to adult regimen"
-											},
-											{
-												"concept": "a8909e8e-1350-11df-a1f1-0026b9348838",
-												"label": "Pregnancy"
-											},
-											{
-												"concept": "e38b3e51-8a27-4bf6-b0c8-e0b285e4bb2f",
-												"label": "Risk of pregnancy"
-											},
-											{
-												"concept": "a890d1ba-1350-11df-a1f1-0026b9348838",
-												"label": "Toxicity"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(tbTreatmentPlan) && isEmpty(myValue) && arrayContains(['a898c938-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)",
-											"message": "You indicated patient is changing/changing dose/substituting/stopping TB, reason for changing should be selected."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "!arrayContains(['a898c938-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)"
-									}
-								},
-								{
-									"label": "If toxicity, please provide cause:",
-									"id": "tbToxicityCause",
-									"questionOptions": {
-										"concept": "a8a032fe-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
-												"label": "Anaemia"
-											},
-											{
-												"concept": "a8909060-1350-11df-a1f1-0026b9348838",
-												"label": "Hepatitis"
-											},
-											{
-												"concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
-												"label": "IRIS"
-											},
-											{
-												"concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
-												"label": "Lactic acidosis"
-											},
-											{
-												"concept": "a89cee50-1350-11df-a1f1-0026b9348838",
-												"label": "Lipo-dystrophy"
-											},
-											{
-												"concept": "a897fe86-1350-11df-a1f1-0026b9348838",
-												"label": "Neuropathy"
-											},
-											{
-												"concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
-												"label": "Persistent vomiting"
-											},
-											{
-												"concept": "a895776a-1350-11df-a1f1-0026b9348838",
-												"label": "Rash"
-											},
-											{
-												"concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
-												"label": "Steven-Johnson syndrome"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(tbPlanChangeReason)&&isEmpty(myValue) && (tbPlanChangeReason==='a890d1ba-1350-11df-a1f1-0026b9348838')",
-											"message": "You indicated patient is changing /changing dose/substituting/stopping arvs due to toxicity, cause should be selected."
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(tbPlanChangeReason) && !isEmpty(myValue) && (tbPlanChangeReason!=='a890d1ba-1350-11df-a1f1-0026b9348838')",
-											"message": "You indicated patient is not changing/dose/substituting/stopping arvs due to toxicity, cause should be selected."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "tbPlanChangeReason !== 'a890d1ba-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "If restarting, reason:",
-									"id": "tbRestart",
-									"type": "obs",
-									"questionOptions": {
-										"concept": "749d07cb-4994-4ce9-a39c-8a655a487fdd",
-										"answers": [
-											{
-												"concept": "15316528-adb9-4c33-b21f-2817f0cad769",
-												"label": "Defaulted"
-											},
-											{
-												"concept": "f6951199-560d-414a-bb5b-1150f07fcea7",
-												"label": "Failure"
-											},
-											{
-												"concept": "a8a3243c-1350-11df-a1f1-0026b9348838",
-												"label": "MDR TB regimen"
-											},
-											{
-												"concept": "769822b2-1f1f-4cbb-8371-0e3949e060cc",
-												"label": "New treatment"
-											},
-											{
-												"concept": "18ac99bf-0805-4929-8d0b-924455850a00",
-												"label": "Relapse/re-infection"
-											}
-										],
-										"rendering": "select"
-									},
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(tbTreatmentPlan) && arrayContains(['a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan) && isEmpty(myValue)",
-											"message": "You indicated patient is restarting tb medication, therefore reason should be selected."
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "(isEmpty(tbTreatmentPlan) || !arrayContains(['a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)) && !isEmpty(myValue)",
-											"message": "You did not indicate restart tb medication, therefore reason should not be selected."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "!arrayContains(['a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)"
-									}
-								}
-							],
-							"id": "__6wJyGLGuE"
-						},
-						{
-							"type": "obsGroup",
-							"label": "tbMedPickupSite",
-							"questionOptions": {
-								"concept": "b55a6d42-3189-4d4c-97bf-772dfe17b887",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Site of TB meds pick-up:",
-									"id": "tbMedPickupSite",
-									"questionOptions": {
-										"concept": "16db21cd-10cb-4c31-bb5a-b7619bfbea66",
-										"answers": [
-											{
-												"concept": "a89c2f42-1350-11df-a1f1-0026b9348838",
-												"label": "This AMPATH site"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "!arrayContains(['a89b7908-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)"
-									}
-								},
-								{
-									"label": "Other Specify:",
-									"id": "medspickOther",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "tbMedPickupSite !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							],
-							"id": "__vyqMwzsEx"
-						},
-						{
-							"label": "TB Treatment Started, detailed",
-							"type": "obsGroup",
-							"questionOptions": {
-								"concept": "a89fe6f0-1350-11df-a1f1-0026b9348838",
-								"rendering": "repeating"
-							},
-							"questions": [
-								{
-									"label": "TB regimen started:",
-									"questionOptions": {
-										"concept": "a89c218c-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a899f51a-1350-11df-a1f1-0026b9348838",
-												"label": "RHZE"
-											},
-											{
-												"concept": "a897d1a4-1350-11df-a1f1-0026b9348838",
-												"label": "RHZ"
-											},
-											{
-												"concept": "a8a382ba-1350-11df-a1f1-0026b9348838",
-												"label": "RHE"
-											},
-											{
-												"concept": "a89b1ca6-1350-11df-a1f1-0026b9348838",
-												"label": "RH"
-											},
-											{
-												"concept": "a899e19c-1350-11df-a1f1-0026b9348838",
-												"label": "EH"
-											},
-											{
-												"concept": "a8971c64-1350-11df-a1f1-0026b9348838",
-												"label": "Ethambutol"
-											},
-											{
-												"concept": "a8a3243c-1350-11df-a1f1-0026b9348838",
-												"label": "MDR drugs"
-											},
-											{
-												"concept": "a896cc00-1350-11df-a1f1-0026b9348838",
-												"label": "INH"
-											},
-											{
-												"concept": "a8ac5f2a-1350-11df-a1f1-0026b9348838",
-												"label": "Pyrazinamide"
-											},
-											{
-												"concept": "a8952e4a-1350-11df-a1f1-0026b9348838",
-												"label": "Streptomycin"
-											},
-											{
-												"concept": "b8aa06ca-93c6-40ea-b144-c74f841926f4",
-												"label": "Rifabutin"
-											},
-											{
-												"concept": "a897d0be-1350-11df-a1f1-0026b9348838",
-												"label": "Rifampicin"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "select"
-									},
-									"id": "q26f",
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "!arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)"
-									}
-								},
-								{
-									"label": "tabs/day:",
-									"questionOptions": {
-										"concept": "a8a07386-1350-11df-a1f1-0026b9348838",
-										"max": "30",
-										"min": "0",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"hide": {
-										"field": "q26f",
-										"value": [
-											"a899f51a-1350-11df-a1f1-0026b9348838",
-											"a897d1a4-1350-11df-a1f1-0026b9348838",
-											"a8a382ba-1350-11df-a1f1-0026b9348838"
-										]
-									},
-									"id": "__rqurICE08"
-								},
-								{
-									"label": "mg:",
-									"questionOptions": {
-										"concept": "a8a063c8-1350-11df-a1f1-0026b9348838",
-										"max": "2000",
-										"min": "0",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"hide": {
-										"field": "q26f",
-										"value": [
-											"a899e19c-1350-11df-a1f1-0026b9348838",
-											"a8ac5f2a-1350-11df-a1f1-0026b9348838",
-											"a8952e4a-1350-11df-a1f1-0026b9348838"
-										]
-									},
-									"id": "__18wrGus9M"
-								},
-								{
-									"label": "mg/day:",
-									"questionOptions": {
-										"concept": "a8a0744e-1350-11df-a1f1-0026b9348838",
-										"max": "2000",
-										"min": "0",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"hide": {
-										"field": "q26f",
-										"value": [
-											"a896cc00-1350-11df-a1f1-0026b9348838",
-											"a8971c64-1350-11df-a1f1-0026b9348838"
-										]
-									},
-									"id": "__xovtzvGwH"
-								},
-								{
-									"label": "tabs:",
-									"questionOptions": {
-										"concept": "a8a0630a-1350-11df-a1f1-0026b9348838",
-										"max": "180",
-										"min": "0",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"hide": {
-										"field": "q26f",
-										"value": [
-											"b8aa06ca-93c6-40ea-b144-c74f841926f4"
-										]
-									},
-									"id": "__Jywyp94Lw"
-								}
-							],
-							"id": "__LqprxvGCx"
-						}
-					]
-				},
-				{
-					"label": "Cryptococcal Treatment Plan",
-					"questions": [
-						{
-							"label": "Crag test:",
-							"id": "cragTest",
-							"questionOptions": {
-								"concept": "7243bed9-0bc7-4702-af28-a06ab1981e19",
-								"answers": [
-									{
-										"concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
-										"label": "Positive"
-									},
-									{
-										"concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
-										"label": "Negative"
-									},
-									{
-										"concept": "a89c3d8e-1350-11df-a1f1-0026b9348838",
-										"label": "Poor sample quality"
-									}
-								],
-								"showDate": "true",
-								"rendering": "select",
-								"shownDateOptions": {
-									"validators": [
-										{
-											"type": "date"
-										},
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "!isEmpty(cragTest) && isEmpty(myValue)",
-											"message": "Date is result is required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(cragTest)"
-									}
-								}
-							},
-							"type": "obs",
-							"validators": []
-						},
-						{
-							"label": "Cryptococcal treatment plan",
-							"type": "obs",
-							"questionOptions": {
-								"concept": "a89c2790-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a89b7908-1350-11df-a1f1-0026b9348838",
-										"label": "Continue"
-									},
-									{
-										"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-										"label": "None"
-									},
-									{
-										"concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
-										"label": "Start"
-									},
-									{
-										"concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
-										"label": "Stop"
-									}
-								],
-								"rendering": "select"
-							},
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(cryptCurrent) && !isEmpty(myValue) && !arrayContains(['a899e0ac-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838'],myValue)&&(cryptCurrent==='a899e0ac-1350-11df-a1f1-0026b9348838')",
-									"message": "Patient marked as not on Cryptococcus Treatment. Therefore plan can only be none or start."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(cryptCurrent) && cryptCurrent === 'a8971e12-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838'], myValue)",
-									"message": "Patient marked as on crypto in history section. Therefore plan can only be continue regimen and stop."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(cragTest) && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a89b7908-1350-11df-a1f1-0026b9348838'],myValue)&&(cragTest==='a896f3a6-1350-11df-a1f1-0026b9348838')",
-									"message": "Crag test is positive. Therefore patient should be on crypto."
-								}
-							],
-							"id": "__vxDFqIuGs"
-						}
-					]
-				},
-				{
-					"label": "Additional Medication Orders",
-					"questions": [
-						{
-							"type": "obsGroup",
-							"label": "Additional medication orders",
-							"questionOptions": {
-								"rendering": "repeating",
-								"concept": "a8a0654e-1350-11df-a1f1-0026b9348838"
-							},
-							"questions": [
-								{
-									"label": "Drug",
-									"questionOptions": {
-										"concept": "a8a060c6-1350-11df-a1f1-0026b9348838",
-										"rendering": "drug"
-									},
-									"type": "obs",
-									"validators": [],
-									"id": "__xFuGyGqwt"
-								},
-								{
-									"label": "Frequency",
-									"questionOptions": {
-										"concept": "a8a06184-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"label": "Once a day",
-												"concept": "a8a05dc4-1350-11df-a1f1-0026b9348838"
-											},
-											{
-												"label": "Twice a day",
-												"concept": "a8a05aea-1350-11df-a1f1-0026b9348838"
-											},
-											{
-												"label": "Three times a day",
-												"concept": "a8a05b9e-1350-11df-a1f1-0026b9348838"
-											},
-											{
-												"label": "Four times a day",
-												"concept": "a8a05cfc-1350-11df-a1f1-0026b9348838"
-											},
-											{
-												"label": "As needed",
-												"concept": "9c1dcb23-dc0c-46b2-a755-875ab6d78fc2"
-											},
-											{
-												"label": "Other",
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": [],
-									"id": "__ysvKpHHEI"
-								},
-								{
-									"label": "If tabs, number",
-									"questionOptions": {
-										"concept": "a8a0630a-1350-11df-a1f1-0026b9348838",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"id": "__w0txvvuII"
-								},
-								{
-									"label": "If caps, number",
-									"questionOptions": {
-										"concept": "ea404923-fe2b-4812-aec5-3be7fbe712f7",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"id": "__MMwGowJIo"
-								},
-								{
-									"label": "If mg, number",
-									"questionOptions": {
-										"concept": "a8a063c8-1350-11df-a1f1-0026b9348838",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"id": "__t3nHMD5EL"
-								},
-								{
-									"label": "If ml, number",
-									"questionOptions": {
-										"concept": "a8a08286-1350-11df-a1f1-0026b9348838",
-										"rendering": "number"
-									},
-									"type": "obs",
-									"id": "__EvyGDouC2"
-								}
-							],
-							"id": "__EyHsyzsFw"
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Plan",
-			"sections": [
-				{
-					"label": "Family Planning Plan",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Dispense condom today?",
-							"id": "condomDispensed",
-							"questionOptions": {
-								"concept": "a8b034d8-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','55c74fa8-c810-4b37-a918-14a851bba6f3','44032888-08e1-4900-b9dd-7d236d79276c'], visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Continue modern contraception method?",
-							"id": "contCurrentFP",
-							"questionOptions": {
-								"concept": "9bd08995-617e-407a-bf5d-79f29fbdb289",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "!isEmpty(fpMethod) && isEmpty(myValue) && arrayContains(['a8a713f8-1350-11df-a1f1-0026b9348838', 'a123d949-31f3-4abf-98e3-8504e17ebc00', 'feb48308-a56f-4754-8e8f-8c1698e570cb', 'f8c66a32-3660-4233-ae51-d3a4a1eac44e', '236dba53-1062-46b4-8067-ec8711897dbf', 'a8988b44-1350-11df-a1f1-0026b9348838', 'a897dbd6-1350-11df-a1f1-0026b9348838', 'eaa5796d-0b1c-478b-8c9d-d23cf4c3bddc'], fpMethod)",
-									"message": "Based on modern contraception method selected, you must answer this question."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "sex !== 'F' || fpMethod === 'a899e0ac-1350-11df-a1f1-0026b9348838' || arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','44032888-08e1-4900-b9dd-7d236d79276c','55c74fa8-c810-4b37-a918-14a851bba6f3'],visitTypeUuid)"
-							}
-						},
-						{
-							"label": "Does patient wish to start modern contraception method?",
-							"id": "famPlanningPlan",
-							"questionOptions": {
-								"concept": "d1d7056f-42ed-4948-b04f-ef6146c789be",
-								"answers": [
-									{
-										"concept": "a899b35c-1350-11df-a1f1-0026b9348838",
-										"label": "Yes"
-									},
-									{
-										"concept": "a899b42e-1350-11df-a1f1-0026b9348838",
-										"label": "No"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(contCurrentFP) && contCurrentFP !== 'a899b35c-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient does not wish to continue with modern contraception method. Please indicate if they wish to start."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "isEmpty(contCurrentFP) && fpMethod !== 'a899e0ac-1350-11df-a1f1-0026b9348838' || contCurrentFP === 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						},
-						{
-							"label": "If yes, modern contraception method chosen:",
-							"id": "famPlanChosen",
-							"questionOptions": {
-								"concept": "2d55cabe-a778-40a3-9b85-613889037a11",
-								"answers": [
-									{
-										"concept": "a8a713f8-1350-11df-a1f1-0026b9348838",
-										"label": "Bilateral tubal ligation"
-									},
-									{
-										"concept": "a123d949-31f3-4abf-98e3-8504e17ebc00",
-										"label": "3-year implant"
-									},
-									{
-										"concept": "feb48308-a56f-4754-8e8f-8c1698e570cb",
-										"label": "5-year implant"
-									},
-									{
-										"concept": "f8c66a32-3660-4233-ae51-d3a4a1eac44e",
-										"label": "IUCD copper"
-									},
-									{
-										"concept": "236dba53-1062-46b4-8067-ec8711897dbf",
-										"label": "IUCD hormonal"
-									},
-									{
-										"concept": "a8988b44-1350-11df-a1f1-0026b9348838",
-										"label": "Injectables (Depo)"
-									},
-									{
-										"concept": "a8aff1b2-1350-11df-a1f1-0026b9348838",
-										"label": "Combined hormone oral contraceptive pills"
-									},
-									{
-										"concept": "a8afeb54-1350-11df-a1f1-0026b9348838",
-										"label": "Projestin only pills"
-									},
-									{
-										"concept": "eaa5796d-0b1c-478b-8c9d-d23cf4c3bddc",
-										"label": "Vasectomy"
-									},
-									{
-										"concept": "4a740e33-fee5-4a2b-b679-1904722e3d9e",
-										"label": "Lactational amenohhrea method"
-									},
-									{
-										"concept": "a8a71588-1350-11df-a1f1-0026b9348838",
-										"label": "Diaphram/Cervical cap"
-									},
-									{
-										"concept": "b75702a6-908d-491b-9399-6495712c81cc",
-										"label": "Emergency contraceptive pills"
-									},
-									{
-										"concept": "a8aff284-1350-11df-a1f1-0026b9348838",
-										"label": "Periodic abstinence"
-									},
-									{
-										"concept": "856a7f0d-8359-4316-97c1-2d37813414f0",
-										"label": "Undecided"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && !isEmpty(famPlanningPlan) && famPlanningPlan === 'a899b35c-1350-11df-a1f1-0026b9348838'",
-									"message": "Patient wishes to start modern contraception method. Please choose method."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "famPlanningPlan!== 'a899b35c-1350-11df-a1f1-0026b9348838'"
-							}
-						}
-					]
-				},
-				{
-					"label": "DC Outcome",
-					"questions": [
-						{
-							"label": "Differentiated care plan:",
-							"required": "true",
-							"id": "dcCarePlan",
-							"questionOptions": {
-								"concept": "59f21b48-ccf9-40b8-9fcb-92bdbf90a4dd",
-								"answers": [
-									{
-										"concept": "a8af5018-1350-11df-a1f1-0026b9348838",
-										"label": "Continue in DC"
-									},
-									{
-										"concept": "a8af50f4-1350-11df-a1f1-0026b9348838",
-										"label": "Exit from DC"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "!arrayContains(['380d79a7-6fb0-41bf-be3d-aa3d25da187c','d4e28d0f-ae28-4eec-8cfc-449b4c5a9f5f'],visitTypeUuid)"
-							}
-						},
-						{
-							"type": "obsGroup",
-							"label": "Reason for exit",
-							"questionOptions": {
-								"concept": "3665d0ef-3718-47b2-9091-8b685bda412d",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Reason for exit:",
-									"id": "dcExit",
-									"questionOptions": {
-										"concept": "a89e3f94-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "6daff4ce-bce7-41f5-9141-17e694155180",
-												"label": "Self transfer out of facility"
-											},
-											{
-												"concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
-												"label": "Adherence concerns"
-											},
-											{
-												"concept": "a8ce0d44-8cd4-4eb0-9441-dd27cc328caf",
-												"label": "High VL"
-											},
-											{
-												"concept": "a89ac184-1350-11df-a1f1-0026b9348838",
-												"label": "New OI/new chronic illness"
-											},
-											{
-												"concept": "a8909e8e-1350-11df-a1f1-0026b9348838",
-												"label": "Pregnancy"
-											},
-											{
-												"concept": "5be50fc2-9e50-4d64-8a0c-f08ed7a34bb9",
-												"label": "Voluntary request to exit"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "multiCheckbox"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "isEmpty(dcCarePlan) || dcCarePlan !== 'a8af50f4-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"label": "Other specify:",
-									"id": "dcOther",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "isEmpty(dcExit) || !arrayContains(dcExit, 'a8aaf3e2-1350-11df-a1f1-0026b9348838')"
-									}
-								}
-							],
-							"id": "__xG3qDqIpq"
-						}
-					]
-				},
-				{
-					"label": "Test Orders",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"type": "obsGroup",
-							"label": "Test orders",
-							"questionOptions": {
-								"concept": "af46861e-597a-48a3-b3d4-a134d0b1c5fa",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Tests Ordered",
-									"id": "order1",
-									"type": "testOrder",
-									"questionOptions": {
-										"rendering": "repeating",
-										"orderSettingUuid": "6f0c9a92-6f24-11e3-af88-005056821db0",
-										"orderType": "testorder",
-										"selectableOrders": [
-											{
-												"concept": "a8982474-1350-11df-a1f1-0026b9348838",
-												"label": "Viral load"
-											},
-											{
-												"concept": "a896cce6-1350-11df-a1f1-0026b9348838",
-												"label": "CD4"
-											},
-											{
-												"concept": "7243bed9-0bc7-4702-af28-a06ab1981e19",
-												"label": "Crag test"
-											},
-											{
-												"concept": "57677735-4310-4841-8902-dae4bac24d20",
-												"label": "DST"
-											},
-											{
-												"concept": "a898fe80-1350-11df-a1f1-0026b9348838",
-												"label": "HIV DNA PCR "
-											},
-											{
-												"concept": "a8908192-1350-11df-a1f1-0026b9348838",
-												"label": "CXR"
-											},
-											{
-												"concept": "a8945d4e-1350-11df-a1f1-0026b9348838",
-												"label": "Sputum AFB"
-											},
-											{
-												"concept": "a897e450-1350-11df-a1f1-0026b9348838",
-												"label": "Creatinine"
-											},
-											{
-												"concept": "a898f50c-1350-11df-a1f1-0026b9348838",
-												"label": "CBC"
-											},
-											{
-												"concept": "a896ca48-1350-11df-a1f1-0026b9348838",
-												"label": "SGPT(ALT)"
-											},
-											{
-												"concept": "a896c8ae-1350-11df-a1f1-0026b9348838",
-												"label": "AST"
-											},
-											{
-												"concept": "a8970a26-1350-11df-a1f1-0026b9348838",
-												"label": " CD4 %"
-											},
-											{
-												"concept": "a8999fb6-1350-11df-a1f1-0026b9348838",
-												"label": "Elisa"
-											},
-											{
-												"concept": "a8999dfe-1350-11df-a1f1-0026b9348838",
-												"label": "Rapid HIV "
-											},
-											{
-												"concept": "a8a47094-1350-11df-a1f1-0026b9348838",
-												"label": "TB PCR "
-											},
-											{
-												"concept": "741517cf-8bac-4755-b289-8dd2a2df7962",
-												"label": "Gene Xpert"
-											},
-											{
-												"concept": "a8908a16-1350-11df-a1f1-0026b9348838",
-												"label": "Hgb"
-											},
-											{
-												"concept": "a8a462a2-1350-11df-a1f1-0026b9348838",
-												"label": "TB Culture"
-											},
-											{
-												"concept": "a8945678-1350-11df-a1f1-0026b9348838",
-												"label": "VDRL"
-											},
-											{
-												"concept": "a894590c-1350-11df-a1f1-0026b9348838",
-												"label": "Urinalysis"
-											},
-											{
-												"concept": "a8af7520-1350-11df-a1f1-0026b9348838",
-												"label": "HbA1C"
-											},
-											{
-												"concept": "7129af13-e39a-43b0-9923-6d1de22c9c5e",
-												"label": "Microalbumin"
-											},
-											{
-												"concept": "a89a7418-1350-11df-a1f1-0026b9348838",
-												"label": "Potassium"
-											},
-											{
-												"concept": "a89dda72-1350-11df-a1f1-0026b9348838",
-												"label": "ECGn"
-											},
-											{
-												"concept": "a89dd9aa-1350-11df-a1f1-0026b9348838",
-												"label": "Echo"
-											}
-										]
-									}
-								},
-								{
-									"label": "Test ordered: Other (specify):",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"validators": [],
-									"id": "__wKIqwxMvx"
-								},
-								{
-									"label": "Viral load justification:",
-									"type": "obs",
-									"id": "vljust",
-									"questionOptions": {
-										"concept": "0a98f01f-57f1-44b7-aacf-e1121650a967",
-										"rendering": "select",
-										"answers": [
-											{
-												"concept": "5931c4d4-4406-4d71-b75d-2205d905cc24",
-												"label": "Routine VL"
-											},
-											{
-												"concept": "e43ddeb6-3984-499c-a280-3bade1039608",
-												"label": "Confirmation of treatment failure (repeat VL)"
-											},
-											{
-												"concept": "a8981934-1350-11df-a1f1-0026b9348838",
-												"label": "Clinical failure"
-											},
-											{
-												"concept": "a8a00158-1350-11df-a1f1-0026b9348838",
-												"label": "Single drug substitution"
-											},
-											{
-												"concept": "3966e139-ca69-47c6-aad3-ebd41bb45e28",
-												"label": "Baseline VL (for infants diagnsed through EID)"
-											},
-											{
-												"concept": "42cdefa2-c306-4d10-a819-c04131c4934e",
-												"label": "Confirmation of persistent low level viremia (PLLV)"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										]
-									},
-									"validators": [
-										{
-											"type": "js_expression",
-											"failsWhenExpression": "isEmpty(myValue) && !(isEmpty(order1) || !arrayContains(order1, 'a8982474-1350-11df-a1f1-0026b9348838'))",
-											"message": "Viral load required."
-										}
-									],
-									"hide": {
-										"hideWhenExpression": "isEmpty(order1) || !arrayContains(order1, 'a8982474-1350-11df-a1f1-0026b9348838')"
-									}
-								},
-								{
-									"label": "PMTCT patient category:",
-									"required": "true",
-									"type": "obs",
-									"id": "patCategory1",
-									"questionOptions": {
-										"concept": "a89eea66-1350-11df-a1f1-0026b9348838",
-										"rendering": "select",
-										"answers": [
-											{
-												"concept": "a89d109c-1350-11df-a1f1-0026b9348838",
-												"label": "Pregnant"
-											},
-											{
-												"concept": "a8a18208-1350-11df-a1f1-0026b9348838",
-												"label": "Breastfeeding"
-											},
-											{
-												"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-												"label": "None of the above"
-											}
-										]
-									},
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "(!arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','0b1b6194-d2d5-4e4b-9f7c-c3b778ccc354','42de8e7e-24b2-4c16-b62b-137eb2c55ede','b1a978ca-9315-4ba2-ac2b-84efb9a68c5c','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)) || (isEmpty(order1) || !arrayContains(order1, 'a8982474-1350-11df-a1f1-0026b9348838'))"
-									}
-								}
-							],
-							"id": "__uJHpvsG95"
-						}
-					]
-				},
-				{
-					"label": "Positive Health Diginity & Prevention Services",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "PHDP:",
-							"required": "true",
-							"questionOptions": {
-								"concept": "e7819751-a5b0-485d-a2bc-9d4aa69aa1e4",
-								"answers": [
-									{
-										"concept": "a8a8b352-1350-11df-a1f1-0026b9348838",
-										"label": "Adherence counselling"
-									},
-									{
-										"concept": "b76021d2-38c7-42ff-b2eb-0bd558396ef7",
-										"label": "STI screening"
-									},
-									{
-										"concept": "a2c49302-edb4-4baa-8440-2448eafd0ec1",
-										"label": "Substance use"
-									},
-									{
-										"concept": "a89accc4-1350-11df-a1f1-0026b9348838",
-										"label": "Disclosure to sex partner"
-									},
-									{
-										"concept": "a8a4636a-1350-11df-a1f1-0026b9348838",
-										"label": "Partner testing"
-									},
-									{
-										"concept": "f0a280e8-eb88-41a8-837a-f9949ed1b9cd",
-										"label": "Condom distribution"
-									},
-									{
-										"concept": "91f43249-73c7-427c-8300-2038fc0d6be8",
-										"label": "Needle exchange"
-									},
-									{
-										"concept": "05656545-86be-4605-9527-34fb580534b1",
-										"label": "Targeted risk reduction"
-									},
-									{
-										"concept": "a89adc46-1350-11df-a1f1-0026b9348838",
-										"label": "Treatment of GBV injuries"
-									},
-									{
-										"concept": "717c50e1-48da-4148-aeee-c49fdd957b64",
-										"label": "First line support (LIVES)"
-									},
-									{
-										"concept": "b75702a6-908d-491b-9399-6495712c81cc",
-										"label": "Emergency contraceptives"
-									},
-									{
-										"concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
-										"label": "N/A"
-									}
-								],
-								"rendering": "multiCheckbox"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": " !arrayContains(['d164c76c-cc91-4ac2-89e9-ab7c29152ee0','824cf3e6-dd16-4767-ba41-2e04dede349e'], visitType.uuid)"
-							},
-							"id": "__FHtz9nGGy"
-						}
-					]
-				},
-				{
-					"label": "Referrals",
-					"questions": [
-						{
-							"type": "obsGroup",
-							"label": "Referrals",
-							"questionOptions": {
-								"concept": "a8a07c8c-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Referrals made to the patient:",
-									"id": "referrals",
-									"questionOptions": {
-										"concept": "a89c2344-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
-												"label": "None"
-											},
-											{
-												"concept": "a89fbb12-1350-11df-a1f1-0026b9348838",
-												"label": "OVC"
-											},
-											{
-												"concept": "a8a066ca-1350-11df-a1f1-0026b9348838",
-												"label": "ENT"
-											},
-											{
-												"concept": "a8a8b352-1350-11df-a1f1-0026b9348838",
-												"label": "Adherence counselling"
-											},
-											{
-												"concept": "a2187952-59e0-449b-895f-5102b7aed49c",
-												"label": "Cardiology"
-											},
-											{
-												"concept": "0fa18f9a-95c8-4ab3-81ed-a1bac69063fa",
-												"label": "Diabetes"
-											},
-											{
-												"concept": "a89accc4-1350-11df-a1f1-0026b9348838",
-												"label": "Disclosure counselling"
-											},
-											{
-												"concept": "057dae68-3d6f-4d79-926c-ed75a0ce7fd5",
-												"label": "Hospitalization"
-											},
-											{
-												"concept": "073ea366-834b-49bd-b4db-ce4e6c61bbc3",
-												"label": "Oncology"
-											},
-											{
-												"concept": "a8a8b42e-1350-11df-a1f1-0026b9348838",
-												"label": "Mental health services"
-											},
-											{
-												"concept": "a8a8afd8-1350-11df-a1f1-0026b9348838",
-												"label": "Nutritional support"
-											},
-											{
-												"concept": "a89e2df6-1350-11df-a1f1-0026b9348838",
-												"label": "Psychosocial support"
-											},
-											{
-												"concept": "a8a8b26c-1350-11df-a1f1-0026b9348838",
-												"label": "TB/DOT program"
-											},
-											{
-												"concept": "c65fcd72-1f3f-4450-b93f-90a87ae64d55",
-												"label": "Surgery"
-											},
-											{
-												"concept": "0d516ea7-218f-43d4-b5c0-58d126529271",
-												"label": "Dermatology"
-											},
-											{
-												"concept": "a89e2d1a-1350-11df-a1f1-0026b9348838",
-												"label": "Social work"
-											},
-											{
-												"concept": "7c6f0599-3e3e-4f42-87a2-2ce66f1e96d0",
-												"label": "Differentiated care program"
-											},
-											{
-												"concept": "a8a06788-1350-11df-a1f1-0026b9348838",
-												"label": "Ophthalmology "
-											},
-											{
-												"concept": "a8a002e8-1350-11df-a1f1-0026b9348838",
-												"label": "Reproductive health "
-											},
-											{
-												"concept": "a9431295-9862-405b-b694-534f093ca0ad",
-												"label": "MDT Program"
-											},
-											{
-												"concept": "7c941f38-ede1-4a94-938f-6c4083339673",
-												"label": "Resistant clinic"
-											},
-											{
-												"concept": "355b199f-c9c7-4e91-831f-2be17d2c67bd",
-												"label": "Legal counsel"
-											},
-											{
-												"concept": "5fc2555b-cae1-4bb8-9cd8-e19c2c04fc37",
-												"label": "Police department"
-											},
-											{
-												"concept": "5a089407-22df-4242-99d8-0b4d4da56b75",
-												"label": "Child protection services"
-											},
-											{
-												"concept": "a8b02e16-1350-11df-a1f1-0026b9348838",
-												"label": "Emergency shelter"
-											},
-											{
-												"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-												"label": "Other"
-											}
-										],
-										"rendering": "multiCheckbox"
-									},
-									"type": "obs",
-									"validators": []
-								},
-								{
-									"label": "Referrals made to the patient: Other (specify):",
-									"questionOptions": {
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-										"rendering": "text"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "referrals !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
-									},
-									"id": "__sut7DsFDD"
-								}
-							],
-							"id": "__npuq2nDsH"
-						},
-						{
-							"label": "If referred for hospitalization, choose location:",
-							"questionOptions": {
-								"concept": "a89c2420-1350-11df-a1f1-0026b9348838",
-								"answers": [
-									{
-										"concept": "a89c25d8-1350-11df-a1f1-0026b9348838",
-										"label": "Local health centre/hospital"
-									},
-									{
-										"concept": "a89c24fc-1350-11df-a1f1-0026b9348838",
-										"label": "MTRH"
-									},
-									{
-										"concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
-										"label": "Other"
-									}
-								],
-								"rendering": "select"
-							},
-							"type": "obs",
-							"validators": [],
-							"hide": {
-								"hideWhenExpression": "isEmpty(referrals) || !arrayContains(referrals, '057dae68-3d6f-4d79-926c-ed75a0ce7fd5')"
-							},
-							"id": "__ynFwE4KwM"
-						},
-						{
-							"label": "Reason  for hospitalization",
-							"type": "obsGroup",
-							"questionOptions": {
-								"concept": "a8a07c8c-1350-11df-a1f1-0026b9348838",
-								"rendering": "repeating"
-							},
-							"questions": [
-								{
-									"label": "Reason for hospitalization:",
-									"questionOptions": {
-										"concept": "a8a07a48-1350-11df-a1f1-0026b9348838",
-										"rendering": "problem"
-									},
-									"type": "obs",
-									"validators": [],
-									"hide": {
-										"hideWhenExpression": "isEmpty(referrals) || !arrayContains(referrals, '057dae68-3d6f-4d79-926c-ed75a0ce7fd5')"
-									},
-									"id": "__t2tMtxDtD"
-								}
-							],
-							"id": "__IJyILurpI"
-						}
-					]
-				},
-				{
-					"label": "Transfer Out",
-					"questions": [
-						{
-							"type": "obsGroup",
-							"label": "Transfer care to other centre",
-							"questionOptions": {
-								"concept": "a8a170e2-1350-11df-a1f1-0026b9348838",
-								"rendering": "group"
-							},
-							"questions": [
-								{
-									"label": "Transfer care to other centre:",
-									"id": "transferOut",
-									"questionOptions": {
-										"concept": "a89c2e5c-1350-11df-a1f1-0026b9348838",
-										"answers": [
-											{
-												"concept": "a89c2f42-1350-11df-a1f1-0026b9348838",
-												"label": "AMPATH"
-											},
-											{
-												"concept": "a89c301e-1350-11df-a1f1-0026b9348838",
-												"label": "Non-AMPATH"
-											},
-											{
-												"concept": "a8a17d80-1350-11df-a1f1-0026b9348838",
-												"label": "MCH"
-											}
-										],
-										"rendering": "select"
-									},
-									"type": "obs",
-									"validators": []
-								},
-								{
-									"type": "personAttribute",
-									"label": "Specify name of AMPATH clinic to which patient is being referred:",
-									"id": "transfered_out_to_ampath",
-									"required": "false",
-									"questionOptions": {
-										"rendering": "ui-select-extended",
-										"attributeType": "8d87236c-c2cc-11de-8d13-0010c6dffd0f"
-									},
-									"hide": {
-										"hideWhenExpression": "transferOut !== 'a89c2f42-1350-11df-a1f1-0026b9348838'"
-									}
-								},
-								{
-									"type": "obs",
-									"label": "If Non-AMPATH specify where the patient is being referred:",
-									"id": "transfered_out_to_non_ampath",
-									"required": "false",
-									"default": "",
-									"questionOptions": {
-										"rendering": "text",
-										"concept": "a8a06fc6-1350-11df-a1f1-0026b9348838"
-									},
-									"hide": {
-										"hideWhenExpression": "transferOut !== 'a89c301e-1350-11df-a1f1-0026b9348838'"
-									}
-								}
-							],
-							"id": "__IvyopxLnJ"
-						}
-					]
-				},
-				{
-					"label": "Next Appointment",
-					"isExpanded": "true",
-					"questions": [
-						{
-							"label": "Medication pick up date:",
-							"type": "obs",
-							"id": "medDate",
-							"questionOptions": {
-								"concept": "318a5e8b-218c-4f66-9106-cd581dec1f95",
-								"rendering": "date",
-								"weeksList": [
-									2,
-									4,
-									6,
-									8,
-									12,
-									16,
-									24,
-									36
-								]
-							},
-							"validators": [
-								{
-									"type": "date",
-									"allowFutureDates": "true"
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "(new moment(encDate)).isAfter((new moment(myValue)), 'day') || (new moment(encDate)).isSame((new moment(myValue)), 'day')",
-									"message": "Medication pick up date should be greater than the encounter date."
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "isEmpty(myValue) && arrayContains (['7c6f0599-3e3e-4f42-87a2-2ce66f1e96d0'],referrals)",
-									"message": "Patient referred for DC, medication pick up date should be required."
-								}
-							],
-							"hide": {
-								"hideWhenExpression": "!((arrayContains( ['d4ac2aa5-2899-42fb-b08a-d40161815b48'], visitTypeUuid) && arrayContains (['7c6f0599-3e3e-4f42-87a2-2ce66f1e96d0'],referrals)) || (arrayContains( ['380d79a7-6fb0-41bf-be3d-aa3d25da187c','d4e28d0f-ae28-4eec-8cfc-449b4c5a9f5f'], visitTypeUuid)))"
-							}
-						},
-						{
-							"label": "Return to clinic date:",
-							"type": "obs",
-							"required": "true",
-							"id": "rtc",
-							"questionOptions": {
-								"concept": "a8a666ba-1350-11df-a1f1-0026b9348838",
-								"rendering": "date",
-								"weeksList": [
-									2,
-									4,
-									6,
-									8,
-									12,
-									16,
-									20,
-									24,
-									36
-								]
-							},
-							"validators": [
-								{
-									"type": "date",
-									"allowFutureDates": "true"
-								},
-								{
-									"type": "js_expression",
-									"failsWhenExpression": "(new moment(encDate)).isAfter((new moment(myValue)), 'day') || (new moment(encDate)).isSame((new moment(myValue)), 'day')",
-									"message": "Return to clinic date should be greater than the encounter date."
-								}
-							]
-						}
-					]
-				}
-			]
-		}
-	]
+  "name": "ampath_poc_adult_return_visit_form_v1.6",
+  "uuid": "xxxx",
+  "processor": "EncounterFormProcessor",
+  "referencedForms": [
+    {
+      "formName": "component_hospitalization",
+      "alias": "hosp",
+      "ref": {
+        "uuid": "77d6652f-4653-4434-af6b-6dab84117044",
+        "display": "Hospitalization Component"
+      }
+    },
+    {
+      "formName": "component_immunization-v1.0",
+      "alias": "immn1",
+      "ref": {
+        "uuid": "11b15110-e325-4d0d-bd54-5f55b21301f5",
+        "display": "Immunization v1.0 Component"
+      }
+    },
+    {
+      "formName": "component_art-v1.2",
+      "alias": "art12",
+      "ref": {
+        "uuid": "49eb4af7-7e05-4b3f-aeb0-d1931e27909b",
+        "display": "Art v1.2 Component"
+      }
+    },
+    {
+      "formName": "component_art-v1.4",
+      "alias": "art14",
+      "ref": {
+        "uuid": "fe2cc2aa-ea65-42a1-a1fc-560fff8d5480",
+        "display": "Art v1.4 DTG Component"
+      }
+    },
+    {
+      "formName": "component_pcp-prophy-v1.2",
+      "alias": "pcp12",
+      "ref": {
+        "uuid": "6493a2dd-d3c3-4ff5-9b2d-02ac6c30fe39",
+        "display": "Pcp v1.2 Prophy Component"
+      }
+    },
+    {
+      "formName": "component_tb-prophy-v1.2",
+      "alias": "tbp12",
+      "ref": {
+        "uuid": "f48291ac-40c5-466b-83ee-62758e804b32",
+        "display": "Tb Prophy Component"
+      }
+    },
+    {
+      "formName": "component_tb-treatment-v1.3",
+      "alias": "tbt13",
+      "ref": {
+        "uuid": "e04b6b46-1682-4804-aa3c-895347c8f402",
+        "display": "Tb Treatment Component"
+      }
+    },
+    {
+      "formName": "component_other-medication",
+      "alias": "omed",
+      "ref": {
+        "uuid": "46205439-ccbf-4f60-80e1-d765861f6257",
+        "display": "Other Medication Component"
+      }
+    },
+    {
+      "formName": "component_side-effect-v1.1",
+      "alias": "se11",
+      "ref": {
+        "uuid": "c45f02b4-12bb-4611-9920-aa2df3b6bd3d",
+        "display": "Side Effect v 1.1 Component"
+      }
+    },
+    {
+      "formName": "component_nutrition",
+      "alias": "nut",
+      "ref": {
+        "uuid": "e421b750-e7fc-4194-b55e-6f2c978e1af5",
+        "display": "Nutrition Component"
+      }
+    },
+    {
+      "formName": "component_vitals",
+      "alias": "vt",
+      "ref": {
+        "uuid": "7f5e06a4-92d1-4fc9-9e05-03b414457d69",
+        "display": "Vitals Component"
+      }
+    },
+    {
+      "formName": "component_hpi",
+      "alias": "hpi",
+      "ref": {
+        "uuid": "b91aef27-cd94-4934-94ac-c168ce539cb3",
+        "display": "Hpi Component"
+      }
+    },
+    {
+      "formName": "component_who-staging",
+      "alias": "who",
+      "ref": {
+        "uuid": "fdf950e0-ff0a-4d7d-a52b-33a8d5b98fb7",
+        "display": "Who Staging Component"
+      }
+    },
+    {
+      "formName": "component_assessment",
+      "alias": "ass",
+      "ref": {
+        "uuid": "98e061d2-4a16-4665-b0dc-fc0266ee689c",
+        "display": "Assessment Component"
+      }
+    },
+    {
+      "formName": "component_sti-v1.0",
+      "alias": "sti1",
+      "ref": {
+        "uuid": "6515b019-5264-4a61-a7fd-e891ea03b5f4",
+        "display": "STI v1.0 Component"
+      }
+    },
+    {
+      "formName": "component_lab-orders-v1.0",
+      "alias": "to",
+      "ref": {
+        "uuid": "61a262b6-3238-4187-9740-dea29ea4f7e4",
+        "display": "Lab Orders v1.0 Component"
+      }
+    },
+    {
+      "formName": "component_referral",
+      "alias": "ref",
+      "ref": {
+        "uuid": "f18a6b65-f55b-4d53-afe2-b929bbb66a70",
+        "display": "Referral Component"
+      }
+    },
+    {
+      "formName": "component_positive-health-dignity-&-prevention-services-v1.0",
+      "alias": "phdp",
+      "ref": {
+        "uuid": "4da1548d-e098-4658-a847-8d42f45059f4",
+        "display": "PHDP Component"
+      }
+    },
+    {
+      "formName": "component_vl-justification",
+      "alias": "vljust",
+      "ref": {
+        "uuid": "c47dd152-9996-4ec9-94bb-434f85a6a2b5",
+        "display": "VL Justification Component"
+      }
+    },
+    {
+      "formName": "component_family-planning-v1.0",
+      "alias": "fp1",
+      "ref": {
+        "uuid": "68363308-0a91-4541-9934-c3e770416d51",
+        "display": "Family Planning v1.0 Component"
+      }
+    },
+    {
+      "ref": {
+        "uuid": "a472864e-ddb4-4741-be6f-20d1b2a9be2b",
+        "display": "component_morisky-adherence-score-v1.0"
+      },
+      "formName": "component_morisky-adherence-score-v1.0",
+      "alias": "mmas1"
+    },
+    {
+      "ref": {
+        "uuid": "10fb1c84-84d8-43b3-8683-2fbe2bc9962a",
+        "display": "Feeding v1.1 Compent"
+      },
+      "formName": "component_feeding-v1.1",
+      "alias": "feed11"
+    },
+    {
+      "ref": {
+        "uuid": "df2529c9-3679-4dc1-b747-d753cdb8b774",
+        "display": "Vitals v1.3 Component"
+      },
+      "formName": "component_vitals-v1.3",
+      "alias": "vt13"
+    },
+    {
+      "ref": {
+        "uuid": "4491d2dc-abc7-45f5-b724-ef534f00d144",
+        "display": "Preclinic v1.4"
+      },
+      "formName": "component_preclinic-review-v1.4",
+      "alias": "pcr14"
+    },
+    {
+      "ref": {
+        "uuid": "68cb1748-94ea-48b2-bfd0-cda5c1a7b7d1",
+        "display": "Reproductive history v1.5"
+      },
+      "formName": "component_reproductive-history-v1.5",
+      "alias": "repro15"
+    },
+    {
+      "ref": {
+        "uuid": "64d07d7c-b82b-4245-ae0a-9e4af907eab7",
+        "display": "Crypto v1.1"
+      },
+      "formName": "component_crypto-v1.1",
+      "alias": "crypto11"
+    },
+    {
+      "ref": {
+        "uuid": "b9e18c55-6547-49ed-8025-f18bacb22e7c",
+        "display": "Lab Results v1.5"
+      },
+      "formName": "component_lab-results-v1.5",
+      "alias": "lr5"
+    },
+    {
+      "ref": {
+        "uuid": "4caf221a-1451-4331-8256-50d37f0d02c6",
+        "display": "OB-History v1.5"
+      },
+      "formName": "component_ob-history-1.5",
+      "alias": "obgynhist15"
+    },
+    {
+      "ref": {
+        "uuid": "c297210f-a151-49a5-bf51-d2d726fe459d",
+        "display": "Enhanced Adherence 1.0"
+      },
+      "formName": "component_enhanced-adherence-v1.0",
+      "alias": "enhadhere1"
+    },
+    {
+      "ref": {
+        "uuid": "83eaa418-9d70-4a27-b5cd-f7eed9e11f6f",
+        "display": "DC Plan"
+      },
+      "formName": "component_dc-plan",
+      "alias": "dcPlan"
+    },
+    {
+      "ref": {
+        "uuid": "ad50a94d-4edb-463d-b6e6-ac83eecffa7c",
+        "display": "component_gender-based-violence"
+      },
+      "formName": "component_gender-based-violence-v1.0",
+      "alias": "gbv10"
+    },
+    {
+      "ref": {
+        "uuid": "1d265294-3a62-4ab4-bc64-038cbd4a8a14",
+        "display": "component_positive-health-dignity-&-prevention-services-v12"
+      },
+      "formName": "component_positive-health-dignity-&-prevention-services-v1.2",
+      "alias": "phdp12"
+    },
+    {
+      "ref": {
+        "uuid": "3b56db77-167f-49ee-b52f-7511ac71294f",
+        "display": "component_referral-v1.4"
+      },
+      "formName": "component_referral-v1.4",
+      "alias": "ref14"
+    }
+  ],
+  "pages": [
+    {
+      "label": "Encounter Details",
+      "componentConfigs": [
+        {
+          "tag": "afe-content-display",
+          "url": "http://localhost:4200/lib/web-components.bundled.js?module",
+          "module": "true",
+          "detail": "This is custom component within a page it is displayed at the top of the page"
+        }
+      ],
+      "sections": [
+        {
+          "label": "Encounter Details",
+          "componentConfigs": [
+            {
+              "tag": "afe-content-display",
+              "url": "http://localhost:4200/lib/web-components.bundled.js?module",
+              "module": "true",
+              "detail": "This is custom component within a section it is displayed at the top of the section"
+            }
+          ],
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Visit date:",
+              "type": "encounterDatetime",
+              "datePickerFormat": "both",
+              "required": "true",
+              "default": "",
+              "id": "encDate",
+              "questionOptions": {
+                "rendering": "date"
+              },
+              "validators": [
+                {
+                  "type": "date"
+                }
+              ]
+            },
+            {
+              "type": "encounterProvider",
+              "label": "Provider:",
+              "id": "provider",
+              "required": "true",
+              "default": "",
+              "questionOptions": {
+                "rendering": "ui-select-extended"
+              }
+            },
+            {
+              "type": "encounterLocation",
+              "label": "Facility name (site/satellite clinic required):",
+              "id": "location",
+              "required": "true",
+              "questionOptions": {
+                "rendering": "ui-select-extended"
+              }
+            },
+            {
+              "type": "obs",
+              "label": "Custom Control Test:",
+              "id": "customCon",
+              "default": "",
+              "questionOptions": {
+                "rendering": "select",
+                "customControl": true,
+                "answers": [
+                  {
+                    "concept": "8b715fed-97f6-4e38-8f6a-c167a42f8923",
+                    "label": "yes"
+                  },
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ]
+              },
+              "customControlConfig": {
+                "tag": "afe-content-switcher",
+                "url": "http://localhost:4200/lib/web-components.bundled.js?module",
+                "module": "true"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Pre-Clinic Review",
+      "sections": [
+        {
+          "label": "Pre-clinic Review",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "id": "scheduledVisit",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "a89ff9a6-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a89b6440-1350-11df-a1f1-0026b9348838"
+                  },
+                  {
+                    "concept": "a89ff816-1350-11df-a1f1-0026b9348838"
+                  },
+                  {
+                    "concept": "a89ff8de-1350-11df-a1f1-0026b9348838"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "If unscheduled, actual scheduled date",
+              "id": "actualDate",
+              "type": "obs",
+              "required": {
+                "type": "conditionalRequired",
+                "message": "Patient visit marked as unscheduled. Please provide the scheduled date.",
+                "referenceQuestionId": "scheduledVisit",
+                "referenceQuestionAnswers": [
+                  "a89ff816-1350-11df-a1f1-0026b9348838",
+                  "a89ff8de-1350-11df-a1f1-0026b9348838"
+                ]
+              },
+              "questionOptions": {
+                "rendering": "date",
+                "concept": "dc1942b2-5e50-4adc-949d-ad6c905f054e"
+              },
+              "validators": [
+                {
+                  "type": "date",
+                  "allowFutureDates": "true"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(scheduledVisit) && arrayContains(['a89ff816-1350-11df-a1f1-0026b9348838','a89ff8de-1350-11df-a1f1-0026b9348838'], scheduledVisit) && isEmpty(myValue)",
+                  "message": "Patient visit marked as unscheduled. Please provide the scheduled date."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "!arrayContains(['a89ff816-1350-11df-a1f1-0026b9348838','a89ff8de-1350-11df-a1f1-0026b9348838'], scheduledVisit)"
+              }
+            },
+            {
+              "label": "Patient covered by NHIF:",
+              "id": "nhif",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('0b49e3e6-55df-4096-93ca-59edadb74b3f')) ? undefined : HD.getObject('prevEnc').getValue('0b49e3e6-55df-4096-93ca-59edadb74b3f')",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "0b49e3e6-55df-4096-93ca-59edadb74b3f",
+                "answers": [
+                  {
+                    "concept": "8b715fed-97f6-4e38-8f6a-c167a42f8923",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "What is the patient's NHIF status?",
+              "id": "nhifStatus",
+              "questionInfo": "Indicate if the patient has been remitting monthly contributions towards the NHIF medical cover.",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "548e6743-67c0-4a6b-bb07-b5f799f63bc1",
+                "answers": [
+                  {
+                    "concept": "b058a9ad-a0e4-4b37-9214-75b8aed1eaa4",
+                    "label": "Active"
+                  },
+                  {
+                    "concept": "dd373348-1a7f-4625-9e69-9904fa1cc9c7",
+                    "label": "Inactive"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "nhif !== '8b715fed-97f6-4e38-8f6a-c167a42f8923'"
+              }
+            },
+            {
+              "label": "What other insurance do you have?",
+              "id": "healthInsurance",
+              "questionInfo": "Indicate if the patient has another medical cover.",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "a8b02524-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "0bfb0150-949b-4625-98b8-b9d8275bcf44",
+                    "label": "Employer based health insurance"
+                  },
+                  {
+                    "concept": "6fac74c3-fe25-4170-92a4-3ecb8859152e",
+                    "label": "Individual private health insurance"
+                  },
+                  {
+                    "concept": "cb0b7a67-961b-485d-8dde-4fa65cec476b",
+                    "label": "Linda mama services"
+                  },
+                  {
+                    "concept": "21eb8488-76ae-47ce-a542-bb3038ab05de",
+                    "label": "Zuri health insurance"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "nhif !== 'a899e0ac-1350-11df-a1f1-0026b9348838'"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Clinical History",
+      "sections": [
+        {
+          "label": "Social History",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Civil status:",
+              "type": "obs",
+              "historicalExpression": "HD.getObject('prevEnc').getValue('a899a9f2-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "a899a9f2-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899af10-1350-11df-a1f1-0026b9348838",
+                    "label": "Cohabitating"
+                  },
+                  {
+                    "concept": "a899ad58-1350-11df-a1f1-0026b9348838",
+                    "label": "Divorced"
+                  },
+                  {
+                    "concept": "a8aa76b0-1350-11df-a1f1-0026b9348838",
+                    "label": "Married monogamous"
+                  },
+                  {
+                    "concept": "a8b03712-1350-11df-a1f1-0026b9348838",
+                    "label": "Married polygamous"
+                  },
+                  {
+                    "concept": "a899aba0-1350-11df-a1f1-0026b9348838",
+                    "label": "Separated"
+                  },
+                  {
+                    "concept": "a899ac7c-1350-11df-a1f1-0026b9348838",
+                    "label": "Single"
+                  },
+                  {
+                    "concept": "a899ae34-1350-11df-a1f1-0026b9348838",
+                    "label": "Widowed"
+                  }
+                ]
+              },
+              "validators": [],
+              "disable": {
+                "disableWhenExpression": "pregOutcome == 'a890a1b8-1350-11df-a1f1-0026b9348838'"
+              },
+              "resetValueOnDisable": false,
+              "id": "__pDtIu3KJK"
+            },
+            {
+              "label": "Discordant couple:",
+              "required": "true",
+              "questionOptions": {
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  },
+                  {
+                    "concept": "a899b50a-1350-11df-a1f1-0026b9348838",
+                    "label": "Unknown"
+                  },
+                  {
+                    "concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
+                    "label": "N/A"
+                  }
+                ],
+                "concept": "a8af49d8-1350-11df-a1f1-0026b9348838",
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "id": "__HtF2FGyLo"
+            }
+          ]
+        },
+        {
+          "label": "Partner Notification Service",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Partner notification",
+              "id": "pns",
+              "questionOptions": {
+                "concept": "8767734c-0f98-4084-b960-6453f8679600",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Sexual partner tested?",
+                  "id": "sexPartnerTested",
+                  "questionOptions": {
+                    "answers": [
+                      {
+                        "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                        "label": "Yes"
+                      },
+                      {
+                        "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                        "label": "No"
+                      }
+                    ],
+                    "concept": "a8a4636a-1350-11df-a1f1-0026b9348838",
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": []
+                },
+                {
+                  "label": "Do you have a new sexual partner?",
+                  "id": "newSexPartner",
+                  "questionOptions": {
+                    "answers": [
+                      {
+                        "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                        "label": "Yes"
+                      },
+                      {
+                        "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                        "label": "No"
+                      }
+                    ],
+                    "concept": "79f74b25-3f97-4367-a57d-7571bba1d7b4",
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "disable": {
+                    "disableWhenExpression": "pregOutcome == 'a890a1b8-1350-11df-a1f1-0026b9348838'"
+                  },
+                  "resetValueOnDisable": false
+                },
+                {
+                  "label": "Name of new sexual partner:",
+                  "id": "nameSexPartner",
+                  "questionOptions": {
+                    "answers": [],
+                    "concept": "dcb0f31c-d070-4f03-8e6e-5d07367e1500",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "disable": {
+                    "disableWhenExpression": "pregOutcome == 'a890a1b8-1350-11df-a1f1-0026b9348838'"
+                  },
+                  "resetValueOnDisable": false,
+                  "hide": {
+                    "hideWhenExpression": "newSexPartner !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Prevention With Positives",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Prevention with positives: At risk population:",
+              "required": "true",
+              "historicalExpression": "HD.getObject('prevEnc').getValue('93aa3f1d-1c39-4196-b5e6-8adc916cd5d6')",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "93aa3f1d-1c39-4196-b5e6-8adc916cd5d6",
+                "answers": [
+                  {
+                    "concept": "5da55301-e28e-4fdf-8b64-02622dedc8b0",
+                    "label": "Client of sex worker"
+                  },
+                  {
+                    "concept": "a89ff438-1350-11df-a1f1-0026b9348838",
+                    "label": "Commercial sex worker"
+                  },
+                  {
+                    "concept": "a8af49d8-1350-11df-a1f1-0026b9348838",
+                    "label": "Discordant couple"
+                  },
+                  {
+                    "concept": "a890d57a-1350-11df-a1f1-0026b9348838",
+                    "label": "IV drug use"
+                  },
+                  {
+                    "concept": "e19c35f0-12f0-46c2-94ea-97050f37b811",
+                    "label": "MSM"
+                  },
+                  {
+                    "concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
+                    "label": "N/A"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [],
+              "id": "__vnK5zxMFx"
+            },
+            {
+              "label": "Prevention with positives: PWP services:",
+              "id": "pwpServices",
+              "required": "true",
+              "historicalExpression": "HD.getObject('prevEnc').getValue('9ce5dbf0-a141-4ad8-8c9d-cd2bf84fe72b')",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "9ce5dbf0-a141-4ad8-8c9d-cd2bf84fe72b",
+                "answers": [
+                  {
+                    "concept": "f0a280e8-eb88-41a8-837a-f9949ed1b9cd",
+                    "label": "Condom promotion/provision"
+                  },
+                  {
+                    "concept": "bf51f71e-937c-4da5-ae07-654acf59f5bb",
+                    "label": "Couple counseling"
+                  },
+                  {
+                    "concept": "91f43249-73c7-427c-8300-2038fc0d6be8",
+                    "label": "Needle exchange"
+                  },
+                  {
+                    "concept": "05656545-86be-4605-9527-34fb580534b1",
+                    "label": "Targeted risk reduction"
+                  },
+                  {
+                    "concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
+                    "label": "N/A"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "Hospitalization History",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Recent hospitalizations",
+              "questionOptions": {
+                "rendering": "group",
+                "concept": "a8a003a6-1350-11df-a1f1-0026b9348838"
+              },
+              "questions": [
+                {
+                  "label": "Was the patient hospitalized since last visit?",
+                  "id": "wasHospitalized",
+                  "questionOptions": {
+                    "concept": "a898c56e-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                        "label": "Yes"
+                      },
+                      {
+                        "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                        "label": "No"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": []
+                }
+              ],
+              "id": "__ty3FIrHrq"
+            },
+            {
+              "type": "obsGroup",
+              "label": "If yes reason for hospitalization:",
+              "questionOptions": {
+                "concept": "a8a003a6-1350-11df-a1f1-0026b9348838",
+                "rendering": "repeating"
+              },
+              "questions": [
+                {
+                  "label": "Reason for hospitalization:",
+                  "id": "hospReason",
+                  "questionOptions": {
+                    "concept": "a8a07a48-1350-11df-a1f1-0026b9348838",
+                    "rendering": "problem"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "conditionalAnswered",
+                      "message": "Providing diagnosis but didn't answer that patient was hospitalized in question",
+                      "referenceQuestionId": "wasHospitalized",
+                      "referenceQuestionAnswers": [
+                        "a899b35c-1350-11df-a1f1-0026b9348838"
+                      ]
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "isEmpty(myValue) && !isEmpty(wasHospitalized) && wasHospitalized === 'a899b35c-1350-11df-a1f1-0026b9348838'",
+                      "message": "Patient previously marked as hospitalized. Please provide hospitalization reason."
+                    }
+                  ],
+                  "disable": {
+                    "disableWhenExpression": "pregOutcome == 'a890a1b8-1350-11df-a1f1-0026b9348838'"
+                  },
+                  "resetValueOnDisable": false,
+                  "hide": {
+                    "hideWhenExpression": "wasHospitalized !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ],
+              "id": "__y5xuGIE2H"
+            }
+          ]
+        },
+        {
+          "label": "Reproductive History",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "How many pregnancies have you had?",
+              "type": "obs",
+              "id": "noPregnancy",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8aaf59a-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8aaf59a-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a8aaf59a-1350-11df-a1f1-0026b9348838",
+                "rendering": "number",
+                "max": "50",
+                "min": "0"
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F'"
+              }
+            },
+            {
+              "label": "How many pregnancies have you delivered (more than 24 weeks)?",
+              "type": "obs",
+              "id": "noDelivery",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a899a920-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a899a920-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a899a920-1350-11df-a1f1-0026b9348838",
+                "rendering": "number",
+                "min": "0",
+                "max": "50"
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F'"
+              }
+            },
+            {
+              "label": "Reproductive age status:",
+              "id": "menStatus",
+              "required": "true",
+              "questionOptions": {
+                "concept": "a8a185d2-1350-11df-a1f1-0026b9348838",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "label": "Menstruating",
+                    "concept": "a8ad2b4e-1350-11df-a1f1-0026b9348838"
+                  },
+                  {
+                    "label": "Postmenopausal",
+                    "concept": "5cc1c1a7-dfcc-47dc-ad73-c386c188fad8"
+                  },
+                  {
+                    "label": "Amenorrhea",
+                    "concept": "a8a18514-1350-11df-a1f1-0026b9348838"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F'"
+              }
+            },
+            {
+              "label": "LMP:",
+              "id": "lmpDate1",
+              "questionOptions": {
+                "concept": "a89ff758-1350-11df-a1f1-0026b9348838",
+                "rendering": "date"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "date"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(pattype1) && pattype1 === '375e6d4a-ba94-41ac-8ac3-5a56015c4d92'",
+                  "message": "Patient is antenatal. Please provide LMP."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(menStatus) && menStatus === 'a8ad2b4e-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient is menstruating. Please provide LMP."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": " sex !== 'F' || menStatus !== 'a8ad2b4e-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Is the patient pregnant?",
+              "id": "pregnant",
+              "questionOptions": {
+                "concept": "6b4f1d00-0a27-41dd-a299-fb7dc730819c",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && moment(encDate).diff(moment(lmpDate1), 'days') >= 35",
+                  "message": "Last LMP is greater than 35 days. Please indicate patient's pregnancy status."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || menStatus === '5cc1c1a7-dfcc-47dc-ad73-c386c188fad8' || visitTypeUuid === 'b1a978ca-9315-4ba2-ac2b-84efb9a68c5c'"
+              }
+            },
+            {
+              "label": "EDD:",
+              "id": "delDate",
+              "required": "true",
+              "questionOptions": {
+                "concept": "a8aaddbc-1350-11df-a1f1-0026b9348838",
+                "rendering": "date",
+                "calculate": {
+                  "calculateExpression": "moment(lmpDate1).isValid() ? moment(lmpDate1).add(280, 'days').toDate():''"
+                }
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "(new moment(lmpDate1)).isAfter((new moment(myValue)), 'day') || (new moment(lmpDate1)).isSame((new moment(myValue)), 'day')",
+                  "message": "EDD should be greater than the encounter date."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(pregnant) && pregnant === 'a899b35c-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient is pregnant. Please provide EDD."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "pregnant !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Reason patient not pregnant?",
+              "id": "reasonNotPreg",
+              "questionOptions": {
+                "concept": "f701166d-9820-420d-b0bc-c98ad4747dec",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "5bafcbc0-e499-4741-85e3-52e93f68f08c",
+                    "label": "Pregnancy not suspected"
+                  },
+                  {
+                    "concept": "6cb93e09-cd9a-4333-994a-9cd65dfa8c12",
+                    "label": "Pregnancy test is negative"
+                  },
+                  {
+                    "concept": "c662737e-d529-4b49-9ad3-2d72eeb56b45",
+                    "label": "Using hormonal contraceptive"
+                  },
+                  {
+                    "concept": "3bca6c9c-333c-433e-ac07-7e44e0501b49",
+                    "label": "postpartum < 6 weeks"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(pregnant) && pregnant === 'a899b42e-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient is not pregnant. Please provide reasons."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "pregnant !== 'a899b42e-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Actual date of delivery:",
+              "id": "actualDelDate",
+              "questionOptions": {
+                "concept": "a8aae050-1350-11df-a1f1-0026b9348838",
+                "rendering": "date"
+              },
+              "type": "obs",
+              "validators": [],
+              "disable": {
+                "disableWhenExpression": "pregOutcome == 'a890a1b8-1350-11df-a1f1-0026b9348838'"
+              },
+              "resetValueOnDisable": true,
+              "hide": {
+                "hideWhenExpression": "!arrayContains (['0b1b6194-d2d5-4e4b-9f7c-c3b778ccc354','53954785-4d53-4012-8f30-1c37fa870906','0d4512f1-47b5-44e6-8035-feec9be25b4b','161f3383-65d8-4c19-9554-52ee5c3d43ff'],visitTypeUuid )"
+              }
+            },
+            {
+              "label": "Gestation in weeks:",
+              "id": "gestationWeeks",
+              "questionOptions": {
+                "concept": "0670d3d9-950c-4836-b147-0dc8e6b013aa",
+                "rendering": "number"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "pregnant !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','55c74fa8-c810-4b37-a918-14a851bba6f3','44032888-08e1-4900-b9dd-7d236d79276c'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Pregnancy outcome:",
+              "id": "pregOutcome",
+              "questionOptions": {
+                "concept": "a8aff7e8-1350-11df-a1f1-0026b9348838",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "a890a1b8-1350-11df-a1f1-0026b9348838",
+                    "label": "Abortion/Miscarriage/Terminated"
+                  },
+                  {
+                    "concept": "e8074110-b989-45e3-b89c-d6092d1a2fd7",
+                    "label": "Live birth (Preterm)"
+                  },
+                  {
+                    "concept": "bdde6796-fc68-4a84-b569-56cbeb7e5101",
+                    "label": "Live birth (Term)"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "!arrayContains (['0b1b6194-d2d5-4e4b-9f7c-c3b778ccc354','53954785-4d53-4012-8f30-1c37fa870906','0d4512f1-47b5-44e6-8035-feec9be25b4b','161f3383-65d8-4c19-9554-52ee5c3d43ff'],visitTypeUuid)"
+              }
+            }
+          ]
+        },
+        {
+          "label": "Family Planning Profile",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Is the client using condoms?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8a00090-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8a00090-1350-11df-a1f1-0026b9348838')",
+              "id": "condomUse",
+              "questionOptions": {
+                "concept": "a8a00090-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','55c74fa8-c810-4b37-a918-14a851bba6f3','44032888-08e1-4900-b9dd-7d236d79276c'], visitTypeUuid)"
+              }
+            },
+            {
+              "type": "obsGroup",
+              "label": "Family planning, detailed",
+              "questionOptions": {
+                "concept": "767e8060-5272-4927-ab78-97534a4499ef",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Select modern contraception method:",
+                  "required": "true",
+                  "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('767e8060-5272-4927-ab78-97534a4499ef.a894b1cc-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('767e8060-5272-4927-ab78-97534a4499ef.a894b1cc-1350-11df-a1f1-0026b9348838')",
+                  "id": "fpMethod",
+                  "questionOptions": {
+                    "concept": "a894b1cc-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                        "label": "None"
+                      },
+                      {
+                        "concept": "a8a713f8-1350-11df-a1f1-0026b9348838",
+                        "label": "Bilateral tubal ligation"
+                      },
+                      {
+                        "concept": "a123d949-31f3-4abf-98e3-8504e17ebc00",
+                        "label": "3-year implant"
+                      },
+                      {
+                        "concept": "feb48308-a56f-4754-8e8f-8c1698e570cb",
+                        "label": "5-year implant"
+                      },
+                      {
+                        "concept": "f8c66a32-3660-4233-ae51-d3a4a1eac44e",
+                        "label": "IUCD copper"
+                      },
+                      {
+                        "concept": "236dba53-1062-46b4-8067-ec8711897dbf",
+                        "label": "IUCD hormonal"
+                      },
+                      {
+                        "concept": "a8988b44-1350-11df-a1f1-0026b9348838",
+                        "label": "Injectables (Depo)"
+                      },
+                      {
+                        "concept": "a8aff1b2-1350-11df-a1f1-0026b9348838",
+                        "label": "Combined hormone oral contraceptive pills"
+                      },
+                      {
+                        "concept": "a8afeb54-1350-11df-a1f1-0026b9348838",
+                        "label": "Projestin only pills"
+                      },
+                      {
+                        "concept": "eaa5796d-0b1c-478b-8c9d-d23cf4c3bddc",
+                        "label": "Vasectomy"
+                      },
+                      {
+                        "concept": "4a740e33-fee5-4a2b-b679-1904722e3d9e",
+                        "label": "Lactational amenohhrea method"
+                      },
+                      {
+                        "concept": "a8a71588-1350-11df-a1f1-0026b9348838",
+                        "label": "Diaphram/Cervical cap"
+                      },
+                      {
+                        "concept": "b75702a6-908d-491b-9399-6495712c81cc",
+                        "label": "Emergency contraceptive pills"
+                      },
+                      {
+                        "concept": "a8aff284-1350-11df-a1f1-0026b9348838",
+                        "label": "Periodic abstinence"
+                      },
+                      {
+                        "concept": "856a7f0d-8359-4316-97c1-2d37813414f0",
+                        "label": "Undecided"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "sex !== 'F' || menStatus === '5cc1c1a7-dfcc-47dc-ad73-c386c188fad8' || arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','55c74fa8-c810-4b37-a918-14a851bba6f3','44032888-08e1-4900-b9dd-7d236d79276c'], visitTypeUuid)"
+                  }
+                },
+                {
+                  "type": "obs",
+                  "label": "Approximate start date (If FP is 3-year implant/5-year implant/Injectables/Vasectomy/IUCD Copper/IUCD Hormonal/Bilateral tubal ligation)",
+                  "id": "appStartDate",
+                  "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('767e8060-5272-4927-ab78-97534a4499ef.a89ae092-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('767e8060-5272-4927-ab78-97534a4499ef.a89ae092-1350-11df-a1f1-0026b9348838')",
+                  "questionOptions": {
+                    "concept": "a89ae092-1350-11df-a1f1-0026b9348838",
+                    "rendering": "date"
+                  },
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "(new moment(encDate)).isBefore((new moment(myValue)), 'day') || (new moment(encDate)).isSame((new moment(myValue)), 'day')",
+                      "message": "Start date should be before the encounter date."
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "isEmpty(myValue) && !(isEmpty(fpMethod) || !arrayContainsAny(fpMethod,['a123d949-31f3-4abf-98e3-8504e17ebc00','feb48308-a56f-4754-8e8f-8c1698e570cb','eaa5796d-0b1c-478b-8c9d-d23cf4c3bddc','a8988b44-1350-11df-a1f1-0026b9348838','a8a713f8-1350-11df-a1f1-0026b9348838','f8c66a32-3660-4233-ae51-d3a4a1eac44e','236dba53-1062-46b4-8067-ec8711897dbf']))",
+                      "message": "Start date is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(fpMethod) || arrayContains(['a899e0ac-1350-11df-a1f1-0026b9348838','a897dbd6-1350-11df-a1f1-0026b9348838'],fpMethod) && visitTypeUuid !== 'b1a978ca-9315-4ba2-ac2b-84efb9a68c5c'"
+                  }
+                }
+              ],
+              "id": "__zuFzDwJn4"
+            }
+          ]
+        },
+        {
+          "label": "Cancer Screening",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Cervical cancer screening done:",
+              "required": "true",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('3086a740-face-4fcd-825b-1e627a66c93a')) ? undefined : HD.getObject('prevEnc').getValue('3086a740-face-4fcd-825b-1e627a66c93a')",
+              "id": "cervCanScreen",
+              "questionOptions": {
+                "concept": "3086a740-face-4fcd-825b-1e627a66c93a",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  },
+                  {
+                    "concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
+                    "label": "N/A"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F'"
+              }
+            },
+            {
+              "label": "Cervical cancer screening test result:",
+              "type": "obs",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('6bad2971-c776-4f0e-ae15-a3fc0cbd7d0f')) ? undefined : HD.getObject('prevEnc').getValue('6bad2971-c776-4f0e-ae15-a3fc0cbd7d0f')",
+              "id": "caTestResult",
+              "questionOptions": {
+                "concept": "6bad2971-c776-4f0e-ae15-a3fc0cbd7d0f",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                    "label": "Negative"
+                  }
+                ]
+              },
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' ||cervCanScreen !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Cervical cancer result date:",
+              "type": "obs",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('958b9055-88be-4bf1-9a2c-f209424a03ac')) ? undefined : HD.getObject('prevEnc').getValue('958b9055-88be-4bf1-9a2c-f209424a03ac')",
+              "default": "",
+              "id": "cercanDate",
+              "questionOptions": {
+                "rendering": "date",
+                "concept": "958b9055-88be-4bf1-9a2c-f209424a03ac"
+              },
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(caTestResult) && caTestResult !== 'a89ad3a4-1350-11df-a1f1-0026b9348838' ",
+                  "message": "Date is result is required."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "isEmpty(caTestResult)"
+              }
+            },
+            {
+              "label": "If cervical cancer is positive, is patient on treatment?",
+              "id": "caTreatment",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('3e4943b5-8499-43fb-b254-e1bb1dacfdb7')) ? undefined : HD.getObject('prevEnc').getValue('3e4943b5-8499-43fb-b254-e1bb1dacfdb7')",
+              "questionOptions": {
+                "concept": "3e4943b5-8499-43fb-b254-e1bb1dacfdb7",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  },
+                  {
+                    "concept": "a89c1ef8-1350-11df-a1f1-0026b9348838",
+                    "label": "Completed"
+                  },
+                  {
+                    "concept": "a899b50a-1350-11df-a1f1-0026b9348838",
+                    "label": "Unknown"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "caTestResult !== 'a896f3a6-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "If patient on treatment, indicate below:",
+              "type": "obs",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('94f54710-6ee0-45cd-ad5f-a990fcb47bc1')) ? undefined : HD.getObject('prevEnc').getValue('94f54710-6ee0-45cd-ad5f-a990fcb47bc1')",
+              "id": "caTreatmentMode",
+              "questionOptions": {
+                "concept": "94f54710-6ee0-45cd-ad5f-a990fcb47bc1",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "dcb72b0b-c1cb-4f32-aa82-e8f7b74cc16e",
+                    "label": "Cryotherapy"
+                  },
+                  {
+                    "concept": "ca10f28c-586a-427a-8bcc-816f0835ab18",
+                    "label": "Chemotherapy"
+                  },
+                  {
+                    "concept": "a8a713f8-1350-11df-a1f1-0026b9348838",
+                    "label": "Hysterectomy"
+                  },
+                  {
+                    "concept": "12afc118-5acd-48c6-89a0-1b6156c33d10",
+                    "label": "Radiotherapy"
+                  },
+                  {
+                    "concept": "b6fccd82-c622-4c3e-9563-39899e709b3b",
+                    "label": "Thermo-coagulation/Loop Electrosurgical Excision Procedure"
+                  }
+                ]
+              },
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "caTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            }
+          ]
+        },
+        {
+          "label": "GBV Screening",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Within the past 3 months, have you been hit, slapped, kicked or physically hurt by someone in any way?",
+              "required": "true",
+              "id": "physical",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "8fca5b8a-0674-49e5-8111-003db067ee22",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "label": "Yes",
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838"
+                  },
+                  {
+                    "label": "No",
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838"
+                  }
+                ]
+              }
+            },
+            {
+              "label": "Are you in a relationship with a person who physically hit you?",
+              "required": "true",
+              "id": "domestic",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "4045cb6c-793c-4784-bea5-6e2b7bfd8467",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "label": "Yes",
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838"
+                  },
+                  {
+                    "label": "No",
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838"
+                  }
+                ]
+              }
+            },
+            {
+              "label": "Are you in a relationship with a person who threatens, frightens or insults you or treats you badly?",
+              "required": "true",
+              "id": "emotional",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "374a34e2-71a0-4221-b59e-8d50721330ee",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "label": "Yes",
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838"
+                  },
+                  {
+                    "label": "No",
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838"
+                  }
+                ]
+              }
+            },
+            {
+              "label": "Are you in relationship with a person who forces you to participate in sexual activities that make you feel uncomfortable?",
+              "required": "true",
+              "id": "sexual",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "920709bc-dde6-4d21-863e-851e63c084e4",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "label": "Yes",
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838"
+                  },
+                  {
+                    "label": "No",
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838"
+                  }
+                ]
+              }
+            },
+            {
+              "label": "Have you ever experienced any of the above with someone you do not have a relationship with?",
+              "required": "true",
+              "id": "nonfamily",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "588b29de-2200-4dc5-ba38-9992771aa535",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "label": "Yes",
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838"
+                  },
+                  {
+                    "label": "No",
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "label": "Adult Vaccination",
+          "questions": [
+            {
+              "label": "Immunization history:",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "multiCheckbox",
+                "concept": "b29b512f-cd46-41ee-a568-bdaafa0bb874",
+                "answers": [
+                  {
+                    "concept": "a897dd84-1350-11df-a1f1-0026b9348838",
+                    "label": "Hepatitis B"
+                  },
+                  {
+                    "concept": "a8a70746-1350-11df-a1f1-0026b9348838",
+                    "label": "Flu"
+                  },
+                  {
+                    "concept": "a890a654-1350-11df-a1f1-0026b9348838",
+                    "label": "Tetanus booster"
+                  }
+                ]
+              },
+              "validators": [],
+              "id": "__yKrIpr8pC"
+            }
+          ]
+        },
+        {
+          "label": "Breastfeeding",
+          "questions": [
+            {
+              "label": "Child breastfeeding?",
+              "required": "true",
+              "id": "childBreFeeding",
+              "questionOptions": {
+                "concept": "a8aafc70-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": " !arrayContainsAny(['0b1b6194-d2d5-4e4b-9f7c-c3b778ccc354','53954785-4d53-4012-8f30-1c37fa870906','0d4512f1-47b5-44e6-8035-feec9be25b4b','161f3383-65d8-4c19-9554-52ee5c3d43ff'], visitTypeUuid)"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Medication History",
+      "sections": [
+        {
+          "label": "ART History",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Is the patient on ART?",
+              "required": "true",
+              "id": "onArt",
+              "historicalExpression": "arrayContainsAny(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838'], HD.getObject('prevEnc').getValue('a89b75d4-1350-11df-a1f1-0026b9348838')) ? 'a899b35c-1350-11df-a1f1-0026b9348838' : HD.getObject('prevEnc').getValue('a89ae254-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a89ae254-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(transferInControl) && transferInControl === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], myValue)",
+                  "message": "In the enrollment section, patient not marked as transfer in. Kindly confirm."
+                }
+              ]
+            },
+            {
+              "label": "Is the patient on ART 2?",
+              "required": "true",
+              "id": "onArt2",
+              "historicalExpression": "arrayContainsAny(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838'], HD.getObject('prevEnc').getValue('a89b75d4-1350-11df-a1f1-0026b9348838')) ? 'a899b35c-1350-11df-a1f1-0026b9348838' : HD.getObject('prevEnc').getValue('a89ae254-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a89ae254-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(transferInControl) && transferInControl === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], myValue)",
+                  "message": "In the enrollment section, patient not marked as transfer in. Kindly confirm."
+                }
+              ]
+            },
+            {
+              "label": "Reason for use:",
+              "id": "reasonUse",
+              "type": "obs",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8a30d1c-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8a30d1c-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a8a30d1c-1350-11df-a1f1-0026b9348838",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "a89adc46-1350-11df-a1f1-0026b9348838",
+                    "label": "Treatment"
+                  },
+                  {
+                    "concept": "a8a19c20-1350-11df-a1f1-0026b9348838",
+                    "label": "PEP"
+                  },
+                  {
+                    "concept": "27ac429d-8a42-476e-b2f6-65bde0b8c935",
+                    "label": "Prep"
+                  },
+                  {
+                    "concept": "a89fbedc-1350-11df-a1f1-0026b9348838",
+                    "label": "PMTCT"
+                  }
+                ]
+              },
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "If patient started ART since last visit, enter start date:",
+              "id": "startDate",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a89d200a-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a89d200a-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a89d200a-1350-11df-a1f1-0026b9348838",
+                "rendering": "date"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "date"
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Line of ART patient is taking:",
+              "id": "current_arv_line",
+              "historicalExpression": "!_.isEmpty(HD.getObject('prevEnc').getValue('a89b6a62-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('04616f5d-b961-4f41-bbd7-bcc0dd235577')",
+              "questionOptions": {
+                "concept": "04616f5d-b961-4f41-bbd7-bcc0dd235577",
+                "answers": [
+                  {
+                    "concept": "034047bd-3fa1-4b2a-b0f0-2787e9b9f7b3",
+                    "label": "First line regimen"
+                  },
+                  {
+                    "concept": "8f8a715d-e49a-4b2c-aa3a-83fa9d7a4254",
+                    "label": "Second line regimen"
+                  },
+                  {
+                    "concept": "a90ebdd2-351f-485a-b850-4938fcca2729",
+                    "label": "Third line regimen"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient previously marked as on ART. Please provide the treatment category."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Patient's ART regimen, adults:",
+              "id": "current_art_regimen_adult",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a89b6a62-1350-11df-a1f1-0026b9348838')) ? (_.isEmpty(HD.getObject('prevEnc').getValue('a8a08344-1350-11df-a1f1-0026b9348838'))? HD.getObject('prevEnc').getValue('a899cf5e-1350-11df-a1f1-0026b9348838') : HD.getObject('prevEnc').getValue('a899cf5e-1350-11df-a1f1-0026b9348838')) : HD.getObject('prevEnc').getValue('a89b6a62-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a899cf5e-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "18e86e1f-92b8-40cd-8266-0df0ab0a4a50",
+                    "label": "DTG50mg/3TC300mg/TDF300mg"
+                  },
+                  {
+                    "concept": "1c4a75d0-cc91-4752-b0a5-4b833326ff7a",
+                    "label": "TDF300mg/3TC300mg/EFV600mg"
+                  },
+                  {
+                    "concept": "ea501f4e-cbc5-4942-b9c8-0ac415929f08",
+                    "label": "TDF300mg/3TC300mg/EFV400mg"
+                  },
+                  {
+                    "concept": "6a73f32d-1870-4527-af6e-74443251ded2",
+                    "label": "NVP200/ZDV300/3TC150"
+                  },
+                  {
+                    "concept": "e78843da-fdb6-446d-8e99-873c278b3540",
+                    "label": "ABC600mg/3TC300mg"
+                  },
+                  {
+                    "concept": "a89cc876-1350-11df-a1f1-0026b9348838",
+                    "label": "3TC300mg/TDF300mg"
+                  },
+                  {
+                    "concept": "a896758e-1350-11df-a1f1-0026b9348838",
+                    "label": "3TC150mg/ZDV300mg"
+                  },
+                  {
+                    "concept": "a8afcf84-1350-11df-a1f1-0026b9348838",
+                    "label": "Emtri200mg/TDF300(Truvada)"
+                  },
+                  {
+                    "concept": "a897e7c0-1350-11df-a1f1-0026b9348838",
+                    "label": "Aluvia(Kaletra)200mg/LPV50mg"
+                  },
+                  {
+                    "concept": "a8afc066-1350-11df-a1f1-0026b9348838",
+                    "label": "Atazanavir300/Ritonavir100"
+                  },
+                  {
+                    "concept": "dabf36cb-dd9a-4542-a8ef-874c1ee5be4a",
+                    "label": "FTC200mg/RPV25mg/TDF245mg(Eviplera)"
+                  },
+                  {
+                    "concept": "98b0baf6-0b73-4429-9264-6233684b0969",
+                    "label": "Dolutegravir 50mg"
+                  },
+                  {
+                    "concept": "a897f8a0-1350-11df-a1f1-0026b9348838",
+                    "label": "Abacavir300mg"
+                  },
+                  {
+                    "concept": "db3c194b-3e1b-4001-9a1c-a5df1728fc28",
+                    "label": "Efavirenz 200mg"
+                  },
+                  {
+                    "concept": "a89673f4-1350-11df-a1f1-0026b9348838",
+                    "label": "Lamivudine150mg"
+                  },
+                  {
+                    "concept": "a8afbd64-1350-11df-a1f1-0026b9348838",
+                    "label": "Raltegravir 400mg"
+                  },
+                  {
+                    "concept": "a897ea4a-1350-11df-a1f1-0026b9348838",
+                    "label": "Zidovudine300mg"
+                  },
+                  {
+                    "concept": "68a0a5dd-1e91-43a2-8dce-c6e84a14de04",
+                    "label": "Darunavir 600mg"
+                  },
+                  {
+                    "concept": "1baf254e-1429-4fd9-8db1-edf6523cea13",
+                    "label": " Ritonavir 100mg"
+                  },
+                  {
+                    "concept": "42ef7c4d-d6fb-49c0-a46e-019c42dea203",
+                    "label": " Ritonavir 80mg"
+                  },
+                  {
+                    "concept": "38fbba9c-4b26-412d-9659-8dd649514d66",
+                    "label": "Etravirine 100mg"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient  marked as on ART. Please provide the Regimen."
+                }
+              ],
+              "disable": {
+                "disableWhenExpression": "pregOutcome == 'a890a1b8-1350-11df-a1f1-0026b9348838'"
+              },
+              "resetValueOnDisable": false,
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "type": "obsGroup",
+              "label": "ART adherence",
+              "questionOptions": {
+                "concept": "bc3834dd-ef07-4027-be30-729baa069291",
+                "rendering": "group"
+              },
+              "questions": [],
+              "id": "__x8EsJHxFJ"
+            }
+          ]
+        },
+        {
+          "label": "Morisky Adherence",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Do you ever forget to take your medicines? (0=No, 1=Yes)",
+              "id": "forget",
+              "questionOptions": {
+                "concept": "99a99956-90b0-431e-a453-bf8efffeb7d3",
+                "rendering": "number",
+                "max": "1",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Patient on ARVs. Please provide morisky adherence history."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Are you sometimes not keen about taking your medications? (0=No, 1=Yes)",
+              "id": "notKeen",
+              "questionOptions": {
+                "concept": "26b3c8c9-20be-4585-98f7-c8b8bf2c9207",
+                "rendering": "number",
+                "max": "1",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Patient on ARVs. Please provide morisky adherence history."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Do you stop taking medicine at times when you feel worse? (0=No, 1=Yes)",
+              "id": "feelWorse",
+              "questionOptions": {
+                "concept": "ccffa130-12c6-45e8-a24a-b16c0395abd5",
+                "rendering": "number",
+                "max": "1",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Patient on ARVs. Please provide morisky adherence history."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "If you feel better, do you sometimes stop taking your medicine? (0=No, 1=Yes)",
+              "id": "feelBetter",
+              "questionOptions": {
+                "concept": "f9eb1023-4cd7-47a7-87cd-b3353824c2c7",
+                "rendering": "number",
+                "max": "1",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Patient on ARVs. Please provide morisky adherence history."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Morisky 4 total score:",
+              "id": "moriskyScore4",
+              "questionOptions": {
+                "concept": "315472dc-2b5e-4add-b3b7-bbcf21a8959b",
+                "rendering": "number",
+                "max": "4",
+                "min": "0",
+                "calculate": {
+                  "calculateExpression": "isNaN(parseFloat(feelBetter)+ parseFloat(feelWorse)+ parseFloat(notKeen)+ parseFloat(forget)) ? undefined: (parseFloat(feelBetter)+ parseFloat(feelWorse)+ parseFloat(notKeen)+ parseFloat(forget))"
+                }
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Morisky score rating:",
+              "id": "scoreMo4",
+              "questionOptions": {
+                "concept": "",
+                "rendering": "text",
+                "calculate": {
+                  "calculateExpression": "parseInt(moriskyScore4) === 0 && parseInt(moriskyScore4) < 1 ? 'Good' : parseInt(moriskyScore4) >=1 && parseInt(moriskyScore4) <= 2 ? 'Inadequate' : parseInt(moriskyScore4) >= 3 && parseInt(moriskyScore4) <= 4 ? 'Poor' : 'Unknown'"
+                }
+              },
+              "type": "control",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Did you forget to take your medicine yesterday? (0=No, 1=Yes)",
+              "id": "medicineYesterday",
+              "questionOptions": {
+                "concept": "2860acd4-2391-4467-9e69-e848d1672f96",
+                "rendering": "number",
+                "max": "1",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(moriskyScore4) && moriskyScore4 >=3 && isEmpty(myValue)",
+                  "message": "Patient on ARVs. Please provide morisky adherence history."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
+              }
+            },
+            {
+              "label": "Do you sometimes stop taking medicine if you feel like your symptoms are under control? (0=No, 1=Yes)",
+              "id": "symptomControl",
+              "questionOptions": {
+                "concept": "8fcb3ada-2188-4e0a-8c68-18c26fd123b2",
+                "rendering": "number",
+                "max": "1",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(moriskyScore4) && moriskyScore4 >=3 && isEmpty(myValue)",
+                  "message": "Patient on ARVs. Please provide morisky adherence history."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
+              }
+            },
+            {
+              "label": "Do you ever feel under pressure about sticking to your treatment plan? (0=No, 1=Yes)",
+              "id": "underPressure",
+              "questionOptions": {
+                "concept": "87ba16a0-6f57-4b0b-a76e-753977f1ef7f",
+                "rendering": "number",
+                "max": "1",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(moriskyScore4) && moriskyScore4 >=3 && isEmpty(myValue)",
+                  "message": "Patient on ARVs. Please provide morisky adherence history."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
+              }
+            },
+            {
+              "label": "How often do you have difficulty remembering to take all your medication? (0=Never/Rarely, 1/4=Once in a while, 1/2=Sometimes, 3/4=Usually,1=All the time)",
+              "id": "difficultyRemembering",
+              "questionOptions": {
+                "concept": "658523c7-77d2-4419-9633-eba789a7d64d",
+                "rendering": "number",
+                "max": "1",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(moriskyScore4) && moriskyScore4 >=3 && isEmpty(myValue)",
+                  "message": "Patient on ARVs. Please provide morisky adherence history."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
+              }
+            },
+            {
+              "label": "Morisky 8 total score:",
+              "id": "moriskyScore",
+              "questionOptions": {
+                "concept": "857caa4e-b566-4a43-ab78-f911c1a8a727",
+                "rendering": "number",
+                "max": "8",
+                "min": "0",
+                "calculate": {
+                  "calculateExpression": "isNaN(parseFloat(difficultyRemembering) + parseFloat(underPressure) + parseFloat(symptomControl)+ parseFloat(medicineYesterday)+ parseFloat(feelBetter)+ parseFloat(feelWorse)+ parseFloat(notKeen)+ parseFloat(forget)) ? undefined: (parseFloat(difficultyRemembering) + parseFloat(underPressure) + parseFloat(symptomControl)+ parseFloat(medicineYesterday)+ parseFloat(feelBetter)+ parseFloat(feelWorse)+ parseFloat(notKeen)+ parseFloat(forget))"
+                }
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
+              }
+            },
+            {
+              "label": "Morisky score rating:",
+              "id": "scoreMo",
+              "questionOptions": {
+                "concept": "",
+                "rendering": "text",
+                "calculate": {
+                  "calculateExpression": "parseInt(moriskyScore) === 0 && parseFloat(moriskyScore) <= 0.25 ? 'Good' : parseFloat(moriskyScore) >=0.5 && parseInt(moriskyScore) <= 2 ? 'Inadequate' : parseInt(moriskyScore) >= 3 && parseInt(moriskyScore) <= 8 ? 'Poor' : 'Unknown'"
+                }
+              },
+              "type": "control",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "isEmpty(moriskyScore4) || moriskyScore4 <3"
+              }
+            }
+          ]
+        },
+        {
+          "label": "Enhanced Adherence",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Has a home visit been done?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('fe6800a2-76f1-42a4-a1c8-553e1fec18e9')) ? undefined : HD.getObject('prevEnc').getValue('fe6800a2-76f1-42a4-a1c8-553e1fec18e9')",
+              "id": "homeVisit",
+              "questionOptions": {
+                "concept": "fe6800a2-76f1-42a4-a1c8-553e1fec18e9",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If yes, number of visits:",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('7458141a-2cb6-4425-8e51-1d4f0a858683')) ? undefined : HD.getObject('prevEnc').getValue('7458141a-2cb6-4425-8e51-1d4f0a858683')",
+              "id": "noVisits",
+              "questionOptions": {
+                "concept": "7458141a-2cb6-4425-8e51-1d4f0a858683",
+                "answers": [],
+                "rendering": "number",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(homeVisit) && homeVisit === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Home visit was done. Please indicate number of visits."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "homeVisit !== 'a899b35c-1350-11df-a1f1-0026b9348838' ||  onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If yes, what were the findings:",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('743bee17-bb4d-4bf5-bbfe-a58a7cca5a3f')) ? undefined : HD.getObject('prevEnc').getValue('743bee17-bb4d-4bf5-bbfe-a58a7cca5a3f')",
+              "id": "homeVisitFinindgs",
+              "questionOptions": {
+                "concept": "743bee17-bb4d-4bf5-bbfe-a58a7cca5a3f",
+                "answers": [],
+                "rendering": "text"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(homeVisit) && homeVisit === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Home visit was done. Please indicate findings."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "homeVisit !== 'a899b35c-1350-11df-a1f1-0026b9348838' ||  onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If no, wish to refer to the social worker:",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('6ada1724-aab2-4b78-af41-91498d211ca2')) ? undefined : HD.getObject('prevEnc').getValue('6ada1724-aab2-4b78-af41-91498d211ca2')",
+              "id": "socialworkRef",
+              "questionOptions": {
+                "concept": "6ada1724-aab2-4b78-af41-91498d211ca2",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(homeVisit) && homeVisit === 'a899b42e-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Home visit was not done. Please refer client to social work."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "homeVisit !== 'a899b42e-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "What are the support structures in place?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a7958e13-c78c-4085-9fdf-b475d602b2b8')) ? undefined : HD.getObject('prevEnc').getValue('a7958e13-c78c-4085-9fdf-b475d602b2b8')",
+              "id": "supportStructures",
+              "questionOptions": {
+                "concept": "a7958e13-c78c-4085-9fdf-b475d602b2b8",
+                "answers": [
+                  {
+                    "concept": "01b957da-23bb-4862-819d-036364fe3faf",
+                    "label": "Treatment supporter"
+                  },
+                  {
+                    "concept": "a89e2df6-1350-11df-a1f1-0026b9348838",
+                    "label": "Support group"
+                  },
+                  {
+                    "concept": "a89cd280-1350-11df-a1f1-0026b9348838",
+                    "label": "Caregiver"
+                  },
+                  {
+                    "concept": "a8b03bb8-1350-11df-a1f1-0026b9348838",
+                    "label": "Family"
+                  },
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Has directly observed treatment (DOT) been done?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('4b3c4263-9f86-4f3c-985b-1a71e2a57495')) ? undefined : HD.getObject('prevEnc').getValue('4b3c4263-9f86-4f3c-985b-1a71e2a57495')",
+              "id": "priorDotDone",
+              "questionOptions": {
+                "concept": "4b3c4263-9f86-4f3c-985b-1a71e2a57495",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Number of directly observed treatment (DOT) done (days):",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('438c22e0-fcb9-4737-b3a6-55cc1f391e0c')) ? undefined : HD.getObject('prevEnc').getValue('438c22e0-fcb9-4737-b3a6-55cc1f391e0c')",
+              "id": "dotDone",
+              "questionOptions": {
+                "concept": "438c22e0-fcb9-4737-b3a6-55cc1f391e0c",
+                "answers": [],
+                "rendering": "number",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(priorDotDone) && priorDotDone === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "DOT was done. Please indicate number of DOTs done."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "priorDotDone !== 'a899b35c-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Likely causes of poor adherence: (Choose all that apply)",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a89ebbc2-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a89ebbc2-1350-11df-a1f1-0026b9348838')",
+              "id": "poorAdherence",
+              "questionOptions": {
+                "concept": "a89ebbc2-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a89eba46-1350-11df-a1f1-0026b9348838",
+                    "label": "Stigma"
+                  },
+                  {
+                    "concept": "945f0a33-dd89-4ca4-9eb3-d74128a2adc8",
+                    "label": "School related stigma"
+                  },
+                  {
+                    "concept": "b858568f-c722-411d-85ca-97d46bc98b3c",
+                    "label": "Home related stigma"
+                  },
+                  {
+                    "concept": "24ff3f30-b7ff-4464-b1b3-fda5ed5714a3",
+                    "label": "Improper disclosure to child"
+                  },
+                  {
+                    "concept": "e91a0b75-133d-4aae-81c9-2b4423e48379",
+                    "label": "Inadequate supervision"
+                  },
+                  {
+                    "concept": "a89d25fa-1350-11df-a1f1-0026b9348838",
+                    "label": "Child refusing to take drugs"
+                  },
+                  {
+                    "concept": "6a377e01-fa40-4ac2-98a9-0cb09cfbea36",
+                    "label": "Pill related size"
+                  },
+                  {
+                    "concept": "1c811199-3cc1-4495-8e05-980bebb045ab",
+                    "label": "Pill taste"
+                  },
+                  {
+                    "concept": "53956fb4-d7d9-438c-addf-c5f67b2a3866",
+                    "label": "Pill color"
+                  },
+                  {
+                    "concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
+                    "label": "Pill burden"
+                  },
+                  {
+                    "concept": "a89ecaa4-1350-11df-a1f1-0026b9348838",
+                    "label": "Disclosure"
+                  },
+                  {
+                    "concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
+                    "label": "Side effects"
+                  },
+                  {
+                    "concept": "a89ced88-1350-11df-a1f1-0026b9348838",
+                    "label": "Alcohol"
+                  },
+                  {
+                    "concept": "a89ebb04-1350-11df-a1f1-0026b9348838",
+                    "label": "Other drugs"
+                  },
+                  {
+                    "concept": "a890b810-1350-11df-a1f1-0026b9348838",
+                    "label": "Mental health issues"
+                  },
+                  {
+                    "concept": "a8935fde-1350-11df-a1f1-0026b9348838",
+                    "label": "Depression"
+                  },
+                  {
+                    "concept": "abf95bf2-c481-490f-9e9f-84fa2d7b2f8c",
+                    "label": "Caregiver changes"
+                  },
+                  {
+                    "concept": "a89e3396-1350-11df-a1f1-0026b9348838",
+                    "label": "Religious beliefs"
+                  },
+                  {
+                    "concept": "b5c3006f-97fd-466f-b4ab-596e23ddc4d9",
+                    "label": "Inadequate treatment preparation"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'|| !arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "type": "obsGroup",
+              "label": "Poor adherence",
+              "questionOptions": {
+                "concept": "04edb08f-d1fd-43ac-98b1-adc5e7d73ba1",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "If other causes of poor adherence, explain:",
+                  "id": "otherCausesSpecify",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "answers": [],
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(poorAdherence) && arrayContainsAny(['a8aaf3e2-1350-11df-a1f1-0026b9348838'], poorAdherence) && isEmpty(myValue)",
+                      "message": "Other selected as cause of poor adherence. Please indicate the cause."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(poorAdherence) || !arrayContainsAny(['a8aaf3e2-1350-11df-a1f1-0026b9348838'], poorAdherence)"
+                  }
+                }
+              ],
+              "id": "__srpHHtMnD"
+            },
+            {
+              "label": "Is patient enrolled in support group?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('ed1e7a5d-a9f4-4adf-a033-4e895409fafe')) ? undefined : HD.getObject('prevEnc').getValue('ed1e7a5d-a9f4-4adf-a033-4e895409fafe')",
+              "id": "supportGroupEnroll",
+              "questionOptions": {
+                "concept": "ed1e7a5d-a9f4-4adf-a033-4e895409fafe",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If no, wishes to enroll?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('c796c49d-2e33-40c4-aadd-c5508e733c30')) ? undefined : HD.getObject('prevEnc').getValue('c796c49d-2e33-40c4-aadd-c5508e733c30')",
+              "id": "wishesToEnroll",
+              "questionOptions": {
+                "concept": "c796c49d-2e33-40c4-aadd-c5508e733c30",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(supportGroupEnroll) && supportGroupEnroll === 'a899b42e-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Patient is not enrolled in any group. Please indicate if they wish to enroll in any group."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "supportGroupEnroll !== 'a899b42e-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If yes, name of support group:",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('aab3dcc5-f984-45d2-b0c4-7a3ba746951b')) ? undefined : HD.getObject('prevEnc').getValue('aab3dcc5-f984-45d2-b0c4-7a3ba746951b')",
+              "id": "supportGroupName",
+              "questionOptions": {
+                "concept": "aab3dcc5-f984-45d2-b0c4-7a3ba746951b",
+                "answers": [],
+                "rendering": "text"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(supportGroupEnroll) && supportGroupEnroll === 'a8aaf3e2-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Patient is enrolled in a group. Please indicate name of the group."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "supportGroupEnroll !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Has age appropriate disclosure been completed?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('6a40a88b-555e-4d7e-b7ce-db677a02609f')) ? undefined : HD.getObject('prevEnc').getValue('6a40a88b-555e-4d7e-b7ce-db677a02609f')",
+              "id": "childDisclosure",
+              "questionOptions": {
+                "concept": "6a40a88b-555e-4d7e-b7ce-db677a02609f",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "age>=18 || !arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Has a pill count been done?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('067e6d30-4962-46eb-9090-be55478d4afd')) ? undefined : HD.getObject('prevEnc').getValue('067e6d30-4962-46eb-9090-be55478d4afd')",
+              "id": "pillCountDone",
+              "questionOptions": {
+                "concept": "067e6d30-4962-46eb-9090-be55478d4afd",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If yes, what are the findings:",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('9bf98c27-1821-407f-9c06-5609357f3698')) ? undefined : HD.getObject('prevEnc').getValue('9bf98c27-1821-407f-9c06-5609357f3698')",
+              "id": "pillCountFindings",
+              "questionOptions": {
+                "concept": "9bf98c27-1821-407f-9c06-5609357f3698",
+                "answers": [
+                  {
+                    "concept": "5b1bf823-da30-4e23-a777-0d8ef93a6211",
+                    "label": "Accurate"
+                  },
+                  {
+                    "concept": "64433aeb-81fb-43a5-be42-3efce1692063",
+                    "label": "Missed doses"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(pillCountDone) && pillCountDone === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "Pill count done. Indicate the findings."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "pillCountDone !== 'a899b35c-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Other possible causes of treatment failure:",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('bc764345-2e57-42f5-aee9-c7d5bd012c97')) ? undefined : HD.getObject('prevEnc').getValue('bc764345-2e57-42f5-aee9-c7d5bd012c97')",
+              "id": "treatmentFailure",
+              "questionOptions": {
+                "concept": "bc764345-2e57-42f5-aee9-c7d5bd012c97",
+                "answers": [
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "4a98eaa4-e5df-4e76-9b58-5191d61666eb",
+                    "label": "Inadequate dosing/dose adjustments"
+                  },
+                  {
+                    "concept": "01eedbcc-ea21-40cc-b150-fcaca5eef501",
+                    "label": "Drug-drug interaction"
+                  },
+                  {
+                    "concept": "c6f38251-5b52-489c-854e-ec2d3994a6cd",
+                    "label": "Drug-food interaction"
+                  },
+                  {
+                    "concept": "cfef32f6-2807-427e-9607-1397e8d7e347",
+                    "label": "Impaired absorption (such as chronic severe diarrhea)"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If drug causes treatment failure, indicate drug:",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('1682a920-c93d-4aad-b9cb-4a2b2c41ff1a')) ? undefined : HD.getObject('prevEnc').getValue('1682a920-c93d-4aad-b9cb-4a2b2c41ff1a')",
+              "id": "drugCausingFailure",
+              "questionOptions": {
+                "concept": "1682a920-c93d-4aad-b9cb-4a2b2c41ff1a",
+                "rendering": "drug"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "treatmentFailure !== '01eedbcc-ea21-40cc-b150-fcaca5eef501' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'|| !arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Does this patient have other co morbidities?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8b010e8-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8b010e8-1350-11df-a1f1-0026b9348838')",
+              "id": "coMorbidities",
+              "questionOptions": {
+                "concept": "a8b010e8-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a8935f0c-1350-11df-a1f1-0026b9348838",
+                    "label": "Convulsive disease"
+                  },
+                  {
+                    "concept": "a890b810-1350-11df-a1f1-0026b9348838",
+                    "label": "Mental health disorders"
+                  },
+                  {
+                    "concept": "a893436e-1350-11df-a1f1-0026b9348838",
+                    "label": "Diabetes"
+                  },
+                  {
+                    "concept": "a8ad5254-1350-11df-a1f1-0026b9348838",
+                    "label": "Renal disease"
+                  },
+                  {
+                    "concept": "a8ad516e-1350-11df-a1f1-0026b9348838",
+                    "label": "Liver disease"
+                  },
+                  {
+                    "concept": "a8986880-1350-11df-a1f1-0026b9348838",
+                    "label": "Hypertention"
+                  },
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Has drug resistance test (DRT) been done?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('2ae99396-0e12-463f-8968-1cba7cf24bc0')) ? undefined : HD.getObject('prevEnc').getValue('2ae99396-0e12-463f-8968-1cba7cf24bc0')",
+              "id": "dstDone",
+              "questionOptions": {
+                "concept": "2ae99396-0e12-463f-8968-1cba7cf24bc0",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If DRT result available, upload image:",
+              "type": "obs",
+              "default": "",
+              "id": "dstImage",
+              "questionOptions": {
+                "concept": "8ec7c519-502e-46ea-8a98-181ed5a088be",
+                "rendering": "file"
+              },
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(dstDone) && dstDone === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                  "message": "DST was done.Please upload the image for the results."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "dstDone !== 'a899b35c-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Has an MDT been done?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('946dabee-3079-4dd1-9f84-1a1ab5507a26')) ? undefined : HD.getObject('prevEnc').getValue('946dabee-3079-4dd1-9f84-1a1ab5507a26')",
+              "id": "mdtDone",
+              "questionOptions": {
+                "concept": "946dabee-3079-4dd1-9f84-1a1ab5507a26",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31','161f3383-65d8-4c19-9554-52ee5c3d43ff','44032888-08e1-4900-b9dd-7d236d79276c','1d7cc708-11cd-4c9c-b51d-ca7eecfe7c7e'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "If No, wish to refer?",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('88a8c7d1-95ac-4aa4-8058-df99a3598390')) ? undefined : HD.getObject('prevEnc').getValue('88a8c7d1-95ac-4aa4-8058-df99a3598390')",
+              "id": "wishRefertoMDT",
+              "questionOptions": {
+                "concept": "88a8c7d1-95ac-4aa4-8058-df99a3598390",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "mdtDone !== 'a899b42e-1350-11df-a1f1-0026b9348838' || onArt!== 'a899b35c-1350-11df-a1f1-0026b9348838'||!arrayContains(['6c5d74f4-943f-489a-b1c4-b2accfae92fb','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)"
+              }
+            }
+          ]
+        },
+        {
+          "label": "PCP Prophylaxis History",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Is the patient on any PCP prophylaxis?",
+              "id": "pcpProphylaxisCurrent",
+              "historicalExpression": "HD.getObject('prevEnc').getValue('a899e282-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a899e282-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "a8989396-1350-11df-a1f1-0026b9348838",
+                    "label": "Septrin"
+                  },
+                  {
+                    "concept": "a890c9e0-1350-11df-a1f1-0026b9348838",
+                    "label": "Dapsone 100mg"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "required": "true",
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "type": "obsGroup",
+              "label": "PCP prophylaxis adherence:",
+              "questionOptions": {
+                "concept": "275eee16-c358-4f3a-ac16-e8f24659df87",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Patient's adherence on PCP prophylaxis:",
+                  "id": "pcpProphylaxisAdherence",
+                  "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('115c744a-cf54-469f-bd5f-820352ffe9be')) ? undefined : HD.getObject('prevEnc').getValue('115c744a-cf54-469f-bd5f-820352ffe9be')",
+                  "questionOptions": {
+                    "concept": "115c744a-cf54-469f-bd5f-820352ffe9be",
+                    "answers": [
+                      {
+                        "concept": "a8b0f882-1350-11df-a1f1-0026b9348838",
+                        "label": "Good"
+                      },
+                      {
+                        "concept": "a73d20b3-d721-4763-a362-14a0c41a6b5e",
+                        "label": "Fair"
+                      },
+                      {
+                        "concept": "fdaf8b47-ea14-4d28-80fa-e1da58a30e8b",
+                        "label": "Poor"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(pcpProphylaxisCurrent) && arrayContains(['a8989396-1350-11df-a1f1-0026b9348838', 'a890c9e0-1350-11df-a1f1-0026b9348838'], pcpProphylaxisCurrent) && isEmpty(myValue)",
+                      "message": "Patient on PCP Prophylaxis. Please provide adherence history"
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(pcpProphylaxisCurrent) || pcpProphylaxisCurrent === 'a899e0ac-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "Adherence (PCP) reasons for poor/fair:",
+                  "id": "pcpAdherence",
+                  "questionOptions": {
+                    "concept": "a89ebbc2-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a89ced88-1350-11df-a1f1-0026b9348838",
+                        "label": "Alcohol"
+                      },
+                      {
+                        "concept": "a8935fde-1350-11df-a1f1-0026b9348838",
+                        "label": "Depression"
+                      },
+                      {
+                        "concept": "a89eac04-1350-11df-a1f1-0026b9348838",
+                        "label": "Felt well"
+                      },
+                      {
+                        "concept": "a89eacc2-1350-11df-a1f1-0026b9348838",
+                        "label": "Forgot"
+                      },
+                      {
+                        "concept": "7211031b-0685-44bc-a5e9-5a018d0173ea",
+                        "label": "Gave away"
+                      },
+                      {
+                        "concept": "a8af4cee-1350-11df-a1f1-0026b9348838",
+                        "label": "Lost/ran out of pills"
+                      },
+                      {
+                        "concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
+                        "label": "Pill burden"
+                      },
+                      {
+                        "concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
+                        "label": "Side effects"
+                      },
+                      {
+                        "concept": "a89eba46-1350-11df-a1f1-0026b9348838",
+                        "label": "Stigma"
+                      },
+                      {
+                        "concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
+                        "label": "Stock out"
+                      },
+                      {
+                        "concept": "a89de2d8-1350-11df-a1f1-0026b9348838",
+                        "label": "Too ill"
+                      },
+                      {
+                        "concept": "a897fdaa-1350-11df-a1f1-0026b9348838",
+                        "label": "Travel problems"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "multiCheckbox"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(pcpProphylaxisCurrent) || pcpProphylaxisCurrent === 'a899e0ac-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], pcpProphylaxisAdherence)"
+                  }
+                },
+                {
+                  "label": "Adherence (PCP): Other (specify):",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "id": "pcpOtherAdherence",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(pcpProphylaxisCurrent) || pcpProphylaxisCurrent === 'a899e0ac-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], pcpProphylaxisAdherence)"
+                  }
+                }
+              ],
+              "id": "__twvv36Kuq"
+            }
+          ]
+        },
+        {
+          "label": "TB Prophylaxis History",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Is the patient on any TB prophylaxis?",
+              "type": "obs",
+              "required": "true",
+              "id": "onTbProphylaxis",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('163784d2-6c55-4ceb-abf0-df8cebb385f1')) ? undefined : HD.getObject('prevEnc').getValue('163784d2-6c55-4ceb-abf0-df8cebb385f1')",
+              "questionOptions": {
+                "concept": "163784d2-6c55-4ceb-abf0-df8cebb385f1",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "validators": []
+            },
+            {
+              "label": "If yes select drug",
+              "type": "obs",
+              "id": "onTbProphylaxisDrug",
+              "historicalExpression": "HD.getObject('prevEnc').getValue('a899e35e-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a899e35e-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "162724df-5a66-4ae3-bbf6-5dc6dbba4ebb",
+                    "label": "Isoniazid 100mg (6H)"
+                  },
+                  {
+                    "concept": "b150ccdc-e7ec-4f99-b592-6f3fa73b3aea",
+                    "label": "Isoniazid 300mg (6H)"
+                  },
+                  {
+                    "concept": "aeaed1af-5b0d-401e-a32a-e96cf4072ab5",
+                    "label": "Isoniazid 300mg and Rifapentine 300mg (3HP)"
+                  },
+                  {
+                    "concept": "177635d0-793b-4a66-8324-976c46f795af",
+                    "label": "Rifampicin 150mg and Isonaizid 75mg (3RH)"
+                  },
+                  {
+                    "concept": "e5e24e6d-e6b0-4c81-8f7b-0e366df29426",
+                    "label": "Rifampicin 70mg and Isonaizid 50mg (3RH)"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(onTbProphylaxis) && onTbProphylaxis === 'a899b35c-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient  marked as on TB Prophylaxis. Please provide the drug."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "onTbProphylaxis !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "type": "obsGroup",
+              "label": "TB prophylaxis ever",
+              "questionOptions": {
+                "concept": "d86c36dc-c523-42e3-b07d-eb4c3c4fbf99",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "If no, have you ever used the drugs in the past?",
+                  "type": "obs",
+                  "id": "pastTbProphylaxisDrug",
+                  "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('59077bc1-7ef7-4b27-a33b-113e2841bd4f')) ? undefined : HD.getObject('prevEnc').getValue('59077bc1-7ef7-4b27-a33b-113e2841bd4f')",
+                  "questionOptions": {
+                    "concept": "59077bc1-7ef7-4b27-a33b-113e2841bd4f",
+                    "answers": [
+                      {
+                        "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                        "label": "Yes"
+                      },
+                      {
+                        "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                        "label": "No"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "onTbProphylaxis !== 'a899b42e-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "Start date of past TB prophylaxis treatment:",
+                  "id": "pastStartTbProphTreatment",
+                  "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('67785e82-c2f7-4417-8ada-cc8e85abbfc1')) ? undefined : HD.getObject('prevEnc').getValue('67785e82-c2f7-4417-8ada-cc8e85abbfc1')",
+                  "questionOptions": {
+                    "concept": "67785e82-c2f7-4417-8ada-cc8e85abbfc1",
+                    "rendering": "date"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "date"
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "pastTbProphylaxisDrug !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "End date of past TB prophylaxis treatment:",
+                  "id": "pastEndTbProphTreatment",
+                  "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('d4f18a59-9bb4-4089-8cd6-1410491569a0')) ? undefined : HD.getObject('prevEnc').getValue('d4f18a59-9bb4-4089-8cd6-1410491569a0')",
+                  "questionOptions": {
+                    "concept": "d4f18a59-9bb4-4089-8cd6-1410491569a0",
+                    "rendering": "date"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "date"
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "pastTbProphylaxisDrug !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ],
+              "id": "__IvxxM4zxt"
+            },
+            {
+              "label": "TB prophylaxis adherence",
+              "type": "obsGroup",
+              "questionOptions": {
+                "concept": "3a69cfcf-f129-4702-a8dd-d061d2a16b9d",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Patient's adherence on TB prophylaxis:",
+                  "id": "adherenceOnTbProphy",
+                  "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('3a69cfcf-f129-4702-a8dd-d061d2a16b9d','ebfdb93a-9292-4245-9a27-0faf49545720')) ? undefined : HD.getObject('prevEnc').getValue('3a69cfcf-f129-4702-a8dd-d061d2a16b9d','ebfdb93a-9292-4245-9a27-0faf49545720')",
+                  "questionOptions": {
+                    "concept": "ebfdb93a-9292-4245-9a27-0faf49545720",
+                    "answers": [
+                      {
+                        "concept": "a8b0f882-1350-11df-a1f1-0026b9348838",
+                        "label": "Good"
+                      },
+                      {
+                        "concept": "a73d20b3-d721-4763-a362-14a0c41a6b5e",
+                        "label": "Fair"
+                      },
+                      {
+                        "concept": "fdaf8b47-ea14-4d28-80fa-e1da58a30e8b",
+                        "label": "Poor"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(onTbProphylaxis) && arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], onTbProphylaxis) && isEmpty(myValue)",
+                      "message": "Patient on TB Prophylaxis. Please provide adherence history."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(onTbProphylaxis)|| onTbProphylaxis !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "Adherence (TB Prophylaxis) reasons for poor/fair:",
+                  "id": "tbProphylaxisAdherence",
+                  "questionOptions": {
+                    "concept": "a89ebbc2-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a89ced88-1350-11df-a1f1-0026b9348838",
+                        "label": "Alcohol"
+                      },
+                      {
+                        "concept": "a8935fde-1350-11df-a1f1-0026b9348838",
+                        "label": "Depression"
+                      },
+                      {
+                        "concept": "a89eac04-1350-11df-a1f1-0026b9348838",
+                        "label": "Felt well"
+                      },
+                      {
+                        "concept": "a89eacc2-1350-11df-a1f1-0026b9348838",
+                        "label": "Forgot"
+                      },
+                      {
+                        "concept": "7211031b-0685-44bc-a5e9-5a018d0173ea",
+                        "label": "Gave away"
+                      },
+                      {
+                        "concept": "a8af4cee-1350-11df-a1f1-0026b9348838",
+                        "label": "Lost/Ran out of pills"
+                      },
+                      {
+                        "concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
+                        "label": "Pill burden"
+                      },
+                      {
+                        "concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
+                        "label": "Side effects"
+                      },
+                      {
+                        "concept": "a89eba46-1350-11df-a1f1-0026b9348838",
+                        "label": "Stigma"
+                      },
+                      {
+                        "concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
+                        "label": "Stock out"
+                      },
+                      {
+                        "concept": "a89de2d8-1350-11df-a1f1-0026b9348838",
+                        "label": "Too ill"
+                      },
+                      {
+                        "concept": "a897fdaa-1350-11df-a1f1-0026b9348838",
+                        "label": "Travel problems"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "multiCheckbox"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(onTbProphylaxis) || onTbProphylaxis !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], adherenceOnTbProphy)"
+                  }
+                },
+                {
+                  "label": "Adherence (TB Prophylaxis): Other (specify):",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "id": "tbProphylaxisOtherAdherence",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(onTbProphylaxis) || onTbProphylaxis !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], adherenceOnTbProphy)"
+                  }
+                }
+              ],
+              "id": "__Dwx8svpyL"
+            }
+          ]
+        },
+        {
+          "label": "Tuberculosis History",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "id": "onTbTreatment",
+              "required": "true",
+              "label": "Is patient on TB treatment?",
+              "historicalExpression": "HD.getObject('prevEnc').getValue('a8afcc82-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a8afcc82-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs"
+            },
+            {
+              "label": "Start date of TB treatment:",
+              "id": "startDateOfTbTreatment",
+              "historicalExpression": "HD.getObject('prevEnc').getValue('a899e5f2-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a899e5f2-1350-11df-a1f1-0026b9348838",
+                "rendering": "date"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "date"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onTbTreatment) && arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], onTbTreatment) && isEmpty(myValue)",
+                  "message": "You indicated patient on tb treatment, indicate start date."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "(isEmpty(onTbTreatment) || !arrayContains(['a899b35c-1350-11df-a1f1-0026b9348838'], onTbTreatment)) && !isEmpty(myValue)",
+                  "message": "You indicated patient is not on tb treatment, therefore start date should not be indicated."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "Tuberculosis treatment phase:",
+              "type": "obs",
+              "id": "tbPhase",
+              "questionOptions": {
+                "concept": "a8afdf4c-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a8afdd08-1350-11df-a1f1-0026b9348838",
+                    "label": "Continuation phase"
+                  },
+                  {
+                    "concept": "a8afddc6-1350-11df-a1f1-0026b9348838",
+                    "label": "Retreatment phase"
+                  },
+                  {
+                    "concept": "a8afdc4a-1350-11df-a1f1-0026b9348838",
+                    "label": "Induction phase"
+                  },
+                  {
+                    "concept": "a8afde8e-1350-11df-a1f1-0026b9348838",
+                    "label": "Retreated phase"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "hide": {
+                "hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "type": "obsGroup",
+              "label": "Current TB regimen",
+              "questionOptions": {
+                "concept": "a8afdb8c-1350-11df-a1f1-0026b9348838",
+                "rendering": "repeating"
+              },
+              "questions": [
+                {
+                  "label": "Current TB regimen:",
+                  "type": "obs",
+                  "id": "tb_current",
+                  "questionOptions": {
+                    "concept": "a899e444-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a899f51a-1350-11df-a1f1-0026b9348838",
+                        "label": "RHZE"
+                      },
+                      {
+                        "concept": "a897d1a4-1350-11df-a1f1-0026b9348838",
+                        "label": "RHZ"
+                      },
+                      {
+                        "concept": "a8a382ba-1350-11df-a1f1-0026b9348838",
+                        "label": "RHE"
+                      },
+                      {
+                        "concept": "a89b1ca6-1350-11df-a1f1-0026b9348838",
+                        "label": "RH"
+                      },
+                      {
+                        "concept": "a899e19c-1350-11df-a1f1-0026b9348838",
+                        "label": "EH"
+                      },
+                      {
+                        "concept": "a8971c64-1350-11df-a1f1-0026b9348838",
+                        "label": "Ethambutol"
+                      },
+                      {
+                        "concept": "a8a3243c-1350-11df-a1f1-0026b9348838",
+                        "label": "MDR drugs"
+                      },
+                      {
+                        "concept": "a896cc00-1350-11df-a1f1-0026b9348838",
+                        "label": "INH"
+                      },
+                      {
+                        "concept": "a8ac5f2a-1350-11df-a1f1-0026b9348838",
+                        "label": "Pyrazinamide"
+                      },
+                      {
+                        "concept": "a8952e4a-1350-11df-a1f1-0026b9348838",
+                        "label": "Streptomycin"
+                      },
+                      {
+                        "concept": "b8aa06ca-93c6-40ea-b144-c74f841926f4",
+                        "label": "Rifabutin"
+                      },
+                      {
+                        "concept": "a897d0be-1350-11df-a1f1-0026b9348838",
+                        "label": "Rifampicin"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "validators": [],
+                  "disable": {
+                    "disableWhenExpression": "pregOutcome == 'a890a1b8-1350-11df-a1f1-0026b9348838'"
+                  },
+                  "resetValueOnDisable": false,
+                  "hide": {
+                    "hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "tabs/day:",
+                  "questionOptions": {
+                    "concept": "a8a07386-1350-11df-a1f1-0026b9348838",
+                    "max": "30",
+                    "min": "0",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "hide": {
+                    "field": "tb_current",
+                    "value": [
+                      "a899f51a-1350-11df-a1f1-0026b9348838",
+                      "a897d1a4-1350-11df-a1f1-0026b9348838",
+                      "a8a382ba-1350-11df-a1f1-0026b9348838"
+                    ]
+                  },
+                  "id": "__uoEvFzpJ3"
+                },
+                {
+                  "label": "mg:",
+                  "questionOptions": {
+                    "concept": "a8a063c8-1350-11df-a1f1-0026b9348838",
+                    "max": "2000",
+                    "min": "0",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "hide": {
+                    "field": "tb_current",
+                    "value": [
+                      "a899e19c-1350-11df-a1f1-0026b9348838",
+                      "a8ac5f2a-1350-11df-a1f1-0026b9348838",
+                      "a8952e4a-1350-11df-a1f1-0026b9348838"
+                    ]
+                  },
+                  "id": "__K0sIqqpLx"
+                },
+                {
+                  "label": "mg/day:",
+                  "questionOptions": {
+                    "concept": "a8a0744e-1350-11df-a1f1-0026b9348838",
+                    "max": "2000",
+                    "min": "0",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "hide": {
+                    "field": "tb_current",
+                    "value": [
+                      "a896cc00-1350-11df-a1f1-0026b9348838",
+                      "a8971c64-1350-11df-a1f1-0026b9348838"
+                    ]
+                  },
+                  "id": "__GLnzrzFDx"
+                },
+                {
+                  "label": "tabs:",
+                  "questionOptions": {
+                    "concept": "a8a0630a-1350-11df-a1f1-0026b9348838",
+                    "max": "180",
+                    "min": "0",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "hide": {
+                    "field": "tb_current",
+                    "value": ["b8aa06ca-93c6-40ea-b144-c74f841926f4"]
+                  },
+                  "id": "__ptxCzFD2s"
+                }
+              ],
+              "id": "__F7qwFJrHF"
+            },
+            {
+              "label": "TB treatment completion date:",
+              "type": "obs",
+              "id": "tbComplDate",
+              "questionOptions": {
+                "concept": "a8a176b4-1350-11df-a1f1-0026b9348838",
+                "rendering": "date"
+              },
+              "hide": {
+                "hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "TB treatment defaulted year:",
+              "type": "obs",
+              "id": "tbDefaultDate",
+              "questionOptions": {
+                "concept": "a8a18758-1350-11df-a1f1-0026b9348838",
+                "rendering": "number"
+              },
+              "hide": {
+                "hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "type": "obsGroup",
+              "id": "tbadhere",
+              "label": "Patient adherence to TB medications",
+              "questionOptions": {
+                "concept": "2a4b87dd-977d-4ce8-a321-1f13df4a31b2",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Patient adherence to TB medications:",
+                  "id": "tb_adherence",
+                  "questionOptions": {
+                    "concept": "479decbd-e964-41c3-9576-98b39089ebd3",
+                    "answers": [
+                      {
+                        "concept": "a8b0f882-1350-11df-a1f1-0026b9348838",
+                        "label": "Good"
+                      },
+                      {
+                        "concept": "a73d20b3-d721-4763-a362-14a0c41a6b5e",
+                        "label": "Fair"
+                      },
+                      {
+                        "concept": "fdaf8b47-ea14-4d28-80fa-e1da58a30e8b",
+                        "label": "Poor"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(onTbTreatment) && onTbTreatment === 'a899b35c-1350-11df-a1f1-0026b9348838' && isEmpty(myValue)",
+                      "message": "Patient on TB Treament. Please provide adherence history."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "Adherence (TB Treatment) reasons for poor/fair:",
+                  "id": "adherenceTbTreatment",
+                  "questionOptions": {
+                    "concept": "a89ebbc2-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a89ced88-1350-11df-a1f1-0026b9348838",
+                        "label": "Alcohol"
+                      },
+                      {
+                        "concept": "a8935fde-1350-11df-a1f1-0026b9348838",
+                        "label": "Depression"
+                      },
+                      {
+                        "concept": "a89eac04-1350-11df-a1f1-0026b9348838",
+                        "label": "Felt well"
+                      },
+                      {
+                        "concept": "a89eacc2-1350-11df-a1f1-0026b9348838",
+                        "label": "Forgot"
+                      },
+                      {
+                        "concept": "7211031b-0685-44bc-a5e9-5a018d0173ea",
+                        "label": "Gave away"
+                      },
+                      {
+                        "concept": "a8af4cee-1350-11df-a1f1-0026b9348838",
+                        "label": "Lost/Ran out of pills"
+                      },
+                      {
+                        "concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
+                        "label": "Pill burden"
+                      },
+                      {
+                        "concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
+                        "label": "Side effects"
+                      },
+                      {
+                        "concept": "a89eba46-1350-11df-a1f1-0026b9348838",
+                        "label": "Stigma"
+                      },
+                      {
+                        "concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
+                        "label": "Stock out"
+                      },
+                      {
+                        "concept": "a89de2d8-1350-11df-a1f1-0026b9348838",
+                        "label": "Too ill"
+                      },
+                      {
+                        "concept": "a897fdaa-1350-11df-a1f1-0026b9348838",
+                        "label": "Travel problems"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "multiCheckbox"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], tb_adherence)"
+                  }
+                },
+                {
+                  "label": "Adherence (TB Treatment): Other (specify):",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "id": "adherenceTbOther",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "onTbTreatment !== 'a899b35c-1350-11df-a1f1-0026b9348838' || !arrayContains(['a73d20b3-d721-4763-a362-14a0c41a6b5e','fdaf8b47-ea14-4d28-80fa-e1da58a30e8b'], tb_adherence)"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Cryptococcal Secondary Prevention",
+          "questions": [
+            {
+              "label": "Cryptococcus Tx:",
+              "id": "cryptCurrent",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a899e516-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a899e516-1350-11df-a1f1-0026b9348838')",
+              "questionOptions": {
+                "concept": "a899e516-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "a8971e12-1350-11df-a1f1-0026b9348838",
+                    "label": "Fluconazole 400mg"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "Other Medications",
+          "questions": [
+            {
+              "label": "Please add any other medications the patient is taking",
+              "type": "obsGroup",
+              "questionOptions": {
+                "concept": "a8a072c8-1350-11df-a1f1-0026b9348838",
+                "rendering": "repeating"
+              },
+              "questions": [
+                {
+                  "label": "Other drugs:",
+                  "questionOptions": {
+                    "concept": "a8a060c6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "drug"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "id": "__qnIztHtsp"
+                }
+              ],
+              "id": "__yKMrLn68C"
+            }
+          ]
+        },
+        {
+          "label": "Side Effects/Toxicity",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Side effects",
+              "id": "sideEff",
+              "questionOptions": {
+                "concept": "a8a072c8-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Any side effects attributable to any drug that the patient is currently taking:",
+                  "id": "currSideEffect",
+                  "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('30fc0cea-b6c7-48cc-bbfb-4eb53170ce41')) ? undefined : HD.getObject('prevEnc').getValue('30fc0cea-b6c7-48cc-bbfb-4eb53170ce41')",
+                  "questionOptions": {
+                    "concept": "30fc0cea-b6c7-48cc-bbfb-4eb53170ce41",
+                    "answers": [
+                      {
+                        "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                        "label": "Yes"
+                      },
+                      {
+                        "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                        "label": "No"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(current_art_regimen_adult) && isEmpty(myValue) && arrayContains(current_art_regimen_adult, '98b0baf6-0b73-4429-9264-6233684b0969')",
+                      "message": "Patient is on DTG. Kindly fill the side effects."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "obsGroup",
+              "questionOptions": {
+                "rendering": "repeating",
+                "concept": "a8a072c8-1350-11df-a1f1-0026b9348838"
+              },
+              "label": "If yes drugs suspected to be causing side effects",
+              "questions": [
+                {
+                  "label": "Drug:",
+                  "id": "sideEffectDrug",
+                  "questionOptions": {
+                    "concept": "1682a920-c93d-4aad-b9cb-4a2b2c41ff1a",
+                    "rendering": "drug"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ],
+              "id": "__GsJpvoqnG"
+            },
+            {
+              "label": "If yes, tick all that apply:",
+              "id": "sideEffectype",
+              "questionOptions": {
+                "concept": "c2ecd5f7-4b47-47ae-b706-3dc5ed98b4db",
+                "answers": [
+                  {
+                    "concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
+                    "label": "Anaemia"
+                  },
+                  {
+                    "concept": "a8909060-1350-11df-a1f1-0026b9348838",
+                    "label": "Hepatitis"
+                  },
+                  {
+                    "concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
+                    "label": "IRIS"
+                  },
+                  {
+                    "concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
+                    "label": "Lactic acidosis"
+                  },
+                  {
+                    "concept": "a89cee50-1350-11df-a1f1-0026b9348838",
+                    "label": "Lipo-dystrophy"
+                  },
+                  {
+                    "concept": "a897fe86-1350-11df-a1f1-0026b9348838",
+                    "label": "Neuropathy"
+                  },
+                  {
+                    "concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
+                    "label": "Persistent vomiting"
+                  },
+                  {
+                    "concept": "a895776a-1350-11df-a1f1-0026b9348838",
+                    "label": "Rash"
+                  },
+                  {
+                    "concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
+                    "label": "Steven-Johnson syndrome"
+                  },
+                  {
+                    "concept": "a8ad21e4-1350-11df-a1f1-0026b9348838",
+                    "label": "Nausea"
+                  },
+                  {
+                    "concept": "a894b604-1350-11df-a1f1-0026b9348838",
+                    "label": "Burning sensation"
+                  },
+                  {
+                    "concept": "a890861a-1350-11df-a1f1-0026b9348838",
+                    "label": "Diarrhea"
+                  },
+                  {
+                    "concept": "a8966d1e-1350-11df-a1f1-0026b9348838",
+                    "label": "Headache"
+                  },
+                  {
+                    "concept": "a8ad042a-1350-11df-a1f1-0026b9348838",
+                    "label": "Fatigue"
+                  },
+                  {
+                    "concept": "a89366a0-1350-11df-a1f1-0026b9348838",
+                    "label": "Jaundice"
+                  },
+                  {
+                    "concept": "a89836ee-1350-11df-a1f1-0026b9348838",
+                    "label": "Dizzy"
+                  },
+                  {
+                    "concept": "a8932f00-1350-11df-a1f1-0026b9348838",
+                    "label": "Abdominal pain"
+                  },
+                  {
+                    "concept": "a89cec02-1350-11df-a1f1-0026b9348838",
+                    "label": "Anxiety"
+                  },
+                  {
+                    "concept": "c80dcaad-ea61-4b88-b1f7-c091d706c7de",
+                    "label": "Nightmare"
+                  },
+                  {
+                    "concept": "a8935fde-1350-11df-a1f1-0026b9348838",
+                    "label": "Depression"
+                  },
+                  {
+                    "concept": "a8ad3b02-1350-11df-a1f1-0026b9348838",
+                    "label": "Confusion/abnormal thinking"
+                  },
+                  {
+                    "concept": "a8982de8-1350-11df-a1f1-0026b9348838",
+                    "label": "Insomnia"
+                  },
+                  {
+                    "concept": "a8ae7ecc-1350-11df-a1f1-0026b9348838",
+                    "label": "Poor concentration/ memory problems"
+                  },
+                  {
+                    "concept": "a8ad392c-1350-11df-a1f1-0026b9348838",
+                    "label": "Paresthesia/painful neuropathy"
+                  },
+                  {
+                    "concept": "f5b8f79a-5460-49a5-983e-78cc203673da",
+                    "label": "Suicide ideation"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(currSideEffect) && currSideEffect === 'a899b35c-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient  marked as having side effects. Please provide list."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "id": "reaction",
+              "label": "Severity of the reaction:",
+              "questionOptions": {
+                "concept": "6c1b293c-4d8c-470f-9991-93cdde1274ff",
+                "answers": [
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "a89efccc-1350-11df-a1f1-0026b9348838",
+                    "label": "Mild"
+                  },
+                  {
+                    "concept": "a89efdee-1350-11df-a1f1-0026b9348838",
+                    "label": "Moderate"
+                  },
+                  {
+                    "concept": "a89eff1a-1350-11df-a1f1-0026b9348838",
+                    "label": "Severe"
+                  },
+                  {
+                    "concept": "a899b50a-1350-11df-a1f1-0026b9348838",
+                    "label": "Unknown"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "id": "action",
+              "label": "Action plan:",
+              "questionOptions": {
+                "concept": "01fb96f5-8dc5-4481-8a11-240994b3b795",
+                "answers": [
+                  {
+                    "concept": "b5b9663c-9568-4f48-b70f-34c63b21bce4",
+                    "label": "Stopped drugs"
+                  },
+                  {
+                    "concept": "a8a00158-1350-11df-a1f1-0026b9348838",
+                    "label": "Substitute drugs"
+                  },
+                  {
+                    "concept": "a8a07bce-1350-11df-a1f1-0026b9348838",
+                    "label": "Change drugs"
+                  },
+                  {
+                    "concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
+                    "label": "Switched drugs"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "How certain are you the drug(s) is/are the cause of the reaction?",
+              "id": "certainityOfReaction",
+              "questionOptions": {
+                "concept": "d0efbf5b-cbfc-48fc-a857-c0ca4d70f077",
+                "answers": [
+                  {
+                    "concept": "45eb8953-dc14-4c2e-8ce6-12cdf7da280a",
+                    "label": "Certain"
+                  },
+                  {
+                    "concept": "07e9e14e-a718-4a9e-9479-1de79e1f614a",
+                    "label": "Probable/likely"
+                  },
+                  {
+                    "concept": "260e6d24-1634-4467-a070-e8359f6827f7",
+                    "label": "Possible"
+                  },
+                  {
+                    "concept": "66b46c63-7e75-4b1d-918a-1e17348c62f7",
+                    "label": "Unlikely"
+                  },
+                  {
+                    "concept": "b1055e84-0e97-483a-ae8a-3f2dee84a623",
+                    "label": "Conditional/unclassified"
+                  },
+                  {
+                    "concept": "80d03d9f-2510-4a95-b9d6-2613aaeebd21",
+                    "label": "Unassessable/unclassified"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "currSideEffect !== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Vitals",
+      "sections": [
+        {
+          "label": "Vital Signs",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "BP systolic:",
+              "id": "syst",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a65d5a-1350-11df-a1f1-0026b9348838",
+                "max": "250",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "BP diastolic:",
+              "id": "dias",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a65e36-1350-11df-a1f1-0026b9348838",
+                "max": "200",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "Pulse (Rate/min):",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a65f12-1350-11df-a1f1-0026b9348838",
+                "max": "230",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [],
+              "id": "__uIC58G0rw"
+            },
+            {
+              "label": "Temp (C):",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a65fee-1350-11df-a1f1-0026b9348838",
+                "max": "43",
+                "min": "25"
+              },
+              "type": "obs",
+              "validators": [],
+              "id": "__yuHJFKyxE"
+            },
+            {
+              "label": "Historical Calculation",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "max": "",
+                "min": "",
+                "showDate": "",
+                "useMostRecentValue": true,
+                "calculate": {
+                  "calculateExpression": "parseFloat(extractObsValue(rawPrevObs,'5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',height))"
+                }
+              },
+              "id": "Ht"
+            },
+            {
+              "label": "Weight (Kg):",
+              "id": "weight",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a660ca-1350-11df-a1f1-0026b9348838",
+                "max": "250",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "Height (Cm):",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8a6619c-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8a6619c-1350-11df-a1f1-0026b9348838')",
+              "id": "height",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a6619c-1350-11df-a1f1-0026b9348838",
+                "max": "228",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "Sp02:",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a66354-1350-11df-a1f1-0026b9348838",
+                "max": "100",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [],
+              "id": "__y2oEz0ytE"
+            },
+            {
+              "label": "BMI (Kg/m2):",
+              "id": "bmi",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a89c60c0-1350-11df-a1f1-0026b9348838",
+                "max": "100",
+                "min": "0",
+                "calculate": {
+                  "calculateExpression": "calcBMI(height,weight)"
+                }
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "MUAC:",
+              "id": "muac",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a89c6188-1350-11df-a1f1-0026b9348838",
+                "max": "450",
+                "min": "60"
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "Foetal heart rate:",
+              "id": "fhr",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a007a2-1350-11df-a1f1-0026b9348838",
+                "max": "230",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": " !arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966', '42de8e7e-24b2-4c16-b62b-137eb2c55ede','53b856ad-21ef-4745-9acd-81aca01bba31'], visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Fundal height:",
+              "id": "fundalHeight",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "a8a005fe-1350-11df-a1f1-0026b9348838",
+                "max": "48",
+                "min": "0"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": " !arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966', '42de8e7e-24b2-4c16-b62b-137eb2c55ede','53b856ad-21ef-4745-9acd-81aca01bba31'], visitTypeUuid)"
+              }
+            }
+          ]
+        },
+        {
+          "label": "Nutrition Assessment and Diagnosis",
+          "questions": [
+            {
+              "label": "Nutrition status:",
+              "id": "nutritionStatus",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "ac5f7974-3a71-4867-af59-0c30d68ce9d8",
+                "answers": [
+                  {
+                    "concept": "a899e7b4-1350-11df-a1f1-0026b9348838",
+                    "label": "Normal"
+                  },
+                  {
+                    "concept": "1505faef-c8aa-422c-b356-da065b88ec9c",
+                    "label": "Overweight"
+                  },
+                  {
+                    "concept": "2a60e784-1314-4454-91ba-7ea4cc2c3b15",
+                    "label": "Obese"
+                  },
+                  {
+                    "concept": "0306539c-f24f-49f5-b059-b646adbec47c",
+                    "label": "Severe acute malnutrition"
+                  },
+                  {
+                    "concept": "f0dd06d5-6174-447f-9a9c-f8635b4a6a6d",
+                    "label": "Moderate  acute malnutrition"
+                  }
+                ]
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Current Symptoms",
+      "sections": [
+        {
+          "label": "TB Screening Questions",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "TB Symptoms:",
+              "required": "true",
+              "questionOptions": {
+                "concept": "a8afcafc-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "a8ad1276-1350-11df-a1f1-0026b9348838",
+                    "label": "Breathlessness"
+                  },
+                  {
+                    "concept": "a892e4b4-1350-11df-a1f1-0026b9348838",
+                    "label": "Chest pain"
+                  },
+                  {
+                    "concept": "a8afc8b8-1350-11df-a1f1-0026b9348838",
+                    "label": "Cough of any duration"
+                  },
+                  {
+                    "concept": "d7adae14-c386-49cc-8f7c-765d8ceec566",
+                    "label": "Fever for = 2 weeks"
+                  },
+                  {
+                    "concept": "3f57aafc-7162-41da-a51b-6a804cb6f5e8",
+                    "label": "New exposure to household contact with TB"
+                  },
+                  {
+                    "concept": "a89807f0-1350-11df-a1f1-0026b9348838",
+                    "label": "Noticeable weight loss"
+                  },
+                  {
+                    "concept": "e1862fef-68ed-4df4-90dd-a00152f719aa",
+                    "label": "Night sweats = 2 weeks"
+                  },
+                  {
+                    "concept": "a8ad462e-1350-11df-a1f1-0026b9348838",
+                    "label": "Abdomen swelling"
+                  },
+                  {
+                    "concept": "f218c60e-4b54-475a-a4fa-facab9216da8",
+                    "label": "Groin swelling"
+                  },
+                  {
+                    "concept": "a8a774b0-1350-11df-a1f1-0026b9348838",
+                    "label": "Joints swelling"
+                  },
+                  {
+                    "concept": "4639388c-ee31-4dcf-abb4-ad71253493bb",
+                    "label": "Neck swelling"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [],
+              "disable": {
+                "disableWhenExpression": "pregOutcome == 'a890a1b8-1350-11df-a1f1-0026b9348838'"
+              },
+              "id": "__sKDEGEEyv"
+            },
+            {
+              "label": "TB Status:",
+              "id": "tbstatus",
+              "required": "true",
+              "questionOptions": {
+                "concept": "02ad9357-b996-4530-b1a4-aff91a105383",
+                "answers": [
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "No signs"
+                  },
+                  {
+                    "concept": "a8afcc82-1350-11df-a1f1-0026b9348838",
+                    "label": "On TB treatment"
+                  },
+                  {
+                    "concept": "260e6d24-1634-4467-a070-e8359f6827f7",
+                    "label": "Suspect"
+                  },
+                  {
+                    "concept": "a8af9046-1350-11df-a1f1-0026b9348838",
+                    "label": "Confirmed"
+                  },
+                  {
+                    "concept": "a899ea48-1350-11df-a1f1-0026b9348838",
+                    "label": "Not assessed"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "STI",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Do you have any of the following:",
+              "required": "true",
+              "questionOptions": {
+                "concept": "a8b00562-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a8982b54-1350-11df-a1f1-0026b9348838",
+                    "label": "Genital ulcers"
+                  },
+                  {
+                    "concept": "a8ad3062-1350-11df-a1f1-0026b9348838",
+                    "label": "Urethral discharge"
+                  },
+                  {
+                    "concept": "a8ad2eb4-1350-11df-a1f1-0026b9348838",
+                    "label": "Vaginal discharge"
+                  },
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [],
+              "id": "__pnnryvrpL"
+            },
+            {
+              "label": "STI partner notification:",
+              "questionOptions": {
+                "concept": "7d7e1c44-a0d5-44ca-8481-8569b38c7e9b",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  },
+                  {
+                    "concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
+                    "label": "N/A"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [],
+              "id": "__LEDCquGKJ"
+            }
+          ]
+        },
+        {
+          "label": "Adult WHO Staging",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "If you are assigning a new WHO stage to patient today, select new WHO stage:",
+              "type": "obs",
+              "id": "adultWhoStage",
+              "questionOptions": {
+                "concept": "a8a8331e-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a89b2606-1350-11df-a1f1-0026b9348838",
+                    "label": "1"
+                  },
+                  {
+                    "concept": "a89b26d8-1350-11df-a1f1-0026b9348838",
+                    "label": "2"
+                  },
+                  {
+                    "concept": "a89b27be-1350-11df-a1f1-0026b9348838",
+                    "label": "3"
+                  },
+                  {
+                    "concept": "a89b289a-1350-11df-a1f1-0026b9348838",
+                    "label": "4"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && arrayContains (['33d13ffb-5f0e-427e-ab80-637491fb6526'], visitTypeUuid)",
+                  "message": "Required."
+                }
+              ]
+            },
+            {
+              "label": "Select criteria for new WHO stage:",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a8ae88a4-1350-11df-a1f1-0026b9348838",
+                "rendering": "select-concept-answers"
+              },
+              "required": {
+                "type": "conditionalRequired",
+                "message": "Patient marked as receiving new WHO stage. Please select stage.",
+                "referenceQuestionId": "adultWhoStage",
+                "referenceQuestionAnswers": [
+                  "a89b2606-1350-11df-a1f1-0026b9348838, a89b26d8-1350-11df-a1f1-0026b9348838, a89b27be-1350-11df-a1f1-0026b9348838, a89b289a-1350-11df-a1f1-0026b9348838"
+                ]
+              },
+              "validators": [],
+              "id": "__KLGqFrorn"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Test Results",
+      "sections": [
+        {
+          "label": "Chemistry Lab Tests",
+          "questions": [
+            {
+              "type": "obs",
+              "label": "Creatinine mmol/L:",
+              "id": "creatinine_test",
+              "questionOptions": {
+                "concept": "a897e450-1350-11df-a1f1-0026b9348838",
+                "rendering": "number",
+                "showDate": "true",
+                "max": "11050",
+                "min": "0",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(creatinine_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(creatinine_test)"
+                  }
+                }
+              },
+              "validators": []
+            },
+            {
+              "type": "obs",
+              "label": "SGPT(ALT):",
+              "id": "sgptalt_test",
+              "questionOptions": {
+                "concept": "a896ca48-1350-11df-a1f1-0026b9348838",
+                "rendering": "number",
+                "max": "3500",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(sgptalt_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(sgptalt_test)"
+                  }
+                }
+              },
+              "validators": []
+            },
+            {
+              "type": "obs",
+              "label": "AST:",
+              "id": "ast_test",
+              "questionOptions": {
+                "concept": "a896c8ae-1350-11df-a1f1-0026b9348838",
+                "rendering": "number",
+                "max": "3500",
+                "min": "0",
+                "showDate": "true"
+              },
+              "shownDateOptions": {
+                "validators": [
+                  {
+                    "type": "date"
+                  },
+                  {
+                    "type": "js_expression",
+                    "failsWhenExpression": "!isEmpty(ast_test) && isEmpty(myValue)",
+                    "message": "Date is result is required."
+                  }
+                ],
+                "hide": {
+                  "hideWhenExpression": "isEmpty(ast_test)"
+                }
+              }
+            },
+            {
+              "label": "RBS mmol/L:",
+              "id": "rbs_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a898418e-1350-11df-a1f1-0026b9348838",
+                "answers": [],
+                "rendering": "number",
+                "max": "50",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(rbs_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(rbs_test)"
+                  }
+                }
+              }
+            },
+            {
+              "label": "FBS mmol/L:",
+              "id": "fbs_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a8b018fe-1350-11df-a1f1-0026b9348838",
+                "answers": [],
+                "rendering": "number",
+                "max": "50",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(fbs_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(fbs_test)"
+                  }
+                }
+              }
+            },
+            {
+              "label": "HbA1C %:",
+              "id": "a1c_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a8af7520-1350-11df-a1f1-0026b9348838",
+                "answers": [],
+                "rendering": "number",
+                "max": "20",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(a1c_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(a1c_test)"
+                  }
+                }
+              }
+            },
+            {
+              "label": "LDL mmol/L:",
+              "id": "ldl_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a898e74c-1350-11df-a1f1-0026b9348838",
+                "answers": [],
+                "rendering": "number",
+                "max": "75",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(ldl_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(ldl_test)"
+                  }
+                }
+              }
+            },
+            {
+              "label": "HDL mmol/L:",
+              "id": "hdl_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a898e602-1350-11df-a1f1-0026b9348838",
+                "answers": [],
+                "rendering": "number",
+                "max": "15",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(hdl_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(hdl_test)"
+                  }
+                }
+              }
+            },
+            {
+              "label": "TG mmol/L:",
+              "id": "tg_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a898e8a0-1350-11df-a1f1-0026b9348838",
+                "answers": [],
+                "rendering": "number",
+                "max": "55",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(tg_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(tg_test)"
+                  }
+                }
+              }
+            },
+            {
+              "label": "Cholesterol mmol/L:",
+              "id": "chol_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a898e4b8-1350-11df-a1f1-0026b9348838",
+                "answers": [],
+                "rendering": "number",
+                "max": "100",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(chol_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(chol_test)"
+                  }
+                }
+              }
+            },
+            {
+              "label": "Microalbumin test, urine mg/L:",
+              "id": "microAlb_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "7129af13-e39a-43b0-9923-6d1de22c9c5e",
+                "answers": [],
+                "rendering": "number",
+                "max": "300",
+                "min": "30",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(microAlb_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(microAlb_test)"
+                  }
+                }
+              }
+            },
+            {
+              "label": "Urea mmol/L:",
+              "id": "urea_test",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a8982550-1350-11df-a1f1-0026b9348838",
+                "answers": [],
+                "rendering": "number",
+                "max": "330",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(urea_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hde": {
+                    "hideWhenExpression": "isEmpty(urea_test)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "label": "CBC",
+          "questions": [
+            {
+              "label": "Hgb g/dL:",
+              "id": "hgbgdl_test",
+              "questionOptions": {
+                "concept": "a8908a16-1350-11df-a1f1-0026b9348838",
+                "max": "50",
+                "min": "0",
+                "showDate": "true",
+                "rendering": "number",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(hgbgdl_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(hgbgdl_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "WBC/mm3:",
+              "id": "testWBCmm",
+              "questionOptions": {
+                "concept": "a896dea2-1350-11df-a1f1-0026b9348838",
+                "max": "500",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(testWBCmm) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(testWBCmm)"
+                  }
+                },
+                "rendering": "number"
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "type": "obs",
+              "label": "Platelets:",
+              "id": "platelets_test",
+              "questionOptions": {
+                "concept": "a8970954-1350-11df-a1f1-0026b9348838",
+                "rendering": "number",
+                "max": "450000",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(platelets_test) && isEmpty(myValue)",
+                      "message": "Date result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(platelets_test)"
+                  }
+                }
+              },
+              "validators": []
+            },
+            {
+              "label": "ALC/ mm3:",
+              "id": "alcmm_test",
+              "questionOptions": {
+                "concept": "a898b20e-1350-11df-a1f1-0026b9348838",
+                "max": "500",
+                "min": "0",
+                "showDate": "true",
+                "rendering": "number",
+                "shownDateOptions": {
+                  "historicalExpression": "HD.getObject('prevEnc').getValue('a8afdb8c-1350-11df-a1f1-0026b9348838.a898b20e-1350-11df-a1f1-0026b9348838')",
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(alcmm_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(alcmm_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "MCV:",
+              "id": "mcv_test",
+              "questionOptions": {
+                "concept": "a898201e-1350-11df-a1f1-0026b9348838",
+                "max": "500",
+                "min": "0",
+                "showDate": "true",
+                "rendering": "number",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(mcv_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(mcv_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "CD4",
+          "questions": [
+            {
+              "type": "obs",
+              "id": "cd4_test",
+              "questionOptions": {
+                "concept": "a8a8bb18-1350-11df-a1f1-0026b9348838",
+                "showDate": "true",
+                "rendering": "number",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(cd4_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(cd4_test)"
+                  }
+                }
+              },
+              "label": "CD4 Count:",
+              "validators": []
+            },
+            {
+              "type": "obs",
+              "label": "CD4 %:",
+              "id": "cd4percent_test",
+              "questionOptions": {
+                "rendering": "number",
+                "max": "100",
+                "min": "0",
+                "showDate": "true",
+                "concept": "a8970a26-1350-11df-a1f1-0026b9348838",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(cd4percent_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(cd4percent_test)"
+                  }
+                }
+              },
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "ART Drug Sensitivity Test",
+          "questions": [
+            {
+              "label": "ART drug sensitivity test (Upload image of the result):",
+              "id": "drugSensitivity_test",
+              "questionOptions": {
+                "concept": "8ec7c519-502e-46ea-8a98-181ed5a088be",
+                "showDate": "true",
+                "rendering": "file",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(drugSensitivity_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(drugSensitivity_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "Viral Load",
+          "questions": [
+            {
+              "type": "obs",
+              "label": "Viral load:",
+              "id": "viralLoad_test",
+              "questionOptions": {
+                "concept": "a8982474-1350-11df-a1f1-0026b9348838",
+                "rendering": "number",
+                "max": "10000000",
+                "min": "0",
+                "showDate": "true",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(viralLoad_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(viralLoad_test)"
+                  }
+                }
+              },
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "Urinalysis",
+          "questions": [
+            {
+              "label": "Urinalysis:",
+              "type": "obsGroup",
+              "questionOptions": {
+                "id": "urinalysis",
+                "concept": "a8a0aa9a-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Pus cells:",
+                  "id": "puscells_test",
+                  "type": "obs",
+                  "questionOptions": {
+                    "concept": "a8a0a91e-1350-11df-a1f1-0026b9348838",
+                    "rendering": "select",
+                    "answers": [
+                      {
+                        "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                        "label": "Negative"
+                      },
+                      {
+                        "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                        "label": "Positive (+)"
+                      },
+                      {
+                        "concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
+                        "label": "Strong positive (++)"
+                      },
+                      {
+                        "concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
+                        "label": "Stronger positive (+++)"
+                      }
+                    ]
+                  },
+                  "hide": {
+                    "hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
+                  }
+                },
+                {
+                  "label": "Protein:",
+                  "type": "obs",
+                  "id": "protein_test",
+                  "questionOptions": {
+                    "concept": "a8a47ca6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "select",
+                    "answers": [
+                      {
+                        "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                        "label": "Negative"
+                      },
+                      {
+                        "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                        "label": "Positive (+)"
+                      },
+                      {
+                        "concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
+                        "label": "Strong positive (++)"
+                      },
+                      {
+                        "concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
+                        "label": "Stronger positive (+++)"
+                      }
+                    ]
+                  },
+                  "hide": {
+                    "hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
+                  }
+                },
+                {
+                  "label": "Leucocytes:",
+                  "type": "obs",
+                  "id": "leucocytes_test",
+                  "questionOptions": {
+                    "concept": "a8b0f3e6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "select",
+                    "answers": [
+                      {
+                        "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                        "label": "Negative"
+                      },
+                      {
+                        "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                        "label": "Positive (+)"
+                      },
+                      {
+                        "concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
+                        "label": "Strong positive (++)"
+                      },
+                      {
+                        "concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
+                        "label": "Stronger positive (+++)"
+                      }
+                    ]
+                  },
+                  "hide": {
+                    "hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
+                  }
+                },
+                {
+                  "label": "Ketone:",
+                  "type": "obs",
+                  "id": "ketone_test",
+                  "questionOptions": {
+                    "concept": "b72fa772-19a9-4386-8185-6491ab97e97e",
+                    "rendering": "select",
+                    "answers": [
+                      {
+                        "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                        "label": "Negative"
+                      },
+                      {
+                        "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                        "label": "Positive (+)"
+                      },
+                      {
+                        "concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
+                        "label": "Strong positive (++)"
+                      },
+                      {
+                        "concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
+                        "label": "Stronger positive (+++)"
+                      }
+                    ]
+                  },
+                  "hide": {
+                    "hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
+                  }
+                },
+                {
+                  "label": "Glucose:",
+                  "id": "sugar_test",
+                  "type": "obs",
+                  "questionOptions": {
+                    "concept": "a8a47d5a-1350-11df-a1f1-0026b9348838",
+                    "rendering": "select",
+                    "answers": [
+                      {
+                        "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                        "label": "Negative"
+                      },
+                      {
+                        "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                        "label": "Positive (+)"
+                      },
+                      {
+                        "concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
+                        "label": "Strong positive (++)"
+                      },
+                      {
+                        "concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
+                        "label": "Stronger positive (+++)"
+                      }
+                    ]
+                  },
+                  "hide": {
+                    "hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
+                  }
+                },
+                {
+                  "label": "Nitrites:",
+                  "id": "nitrites_test",
+                  "type": "obs",
+                  "questionOptions": {
+                    "concept": "6ab44394-80a5-40cd-9649-32f1839e94cd",
+                    "rendering": "select",
+                    "answers": [
+                      {
+                        "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                        "label": "Negative"
+                      },
+                      {
+                        "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                        "label": "Positive (+)"
+                      },
+                      {
+                        "concept": "a8a18fdc-1350-11df-a1f1-0026b9348838",
+                        "label": "Strong positive (++)"
+                      },
+                      {
+                        "concept": "a8a1909a-1350-11df-a1f1-0026b9348838",
+                        "label": "Stronger positive (+++)"
+                      }
+                    ]
+                  },
+                  "hide": {
+                    "hideWhenExpression": "visitTypeUuid !== '02e3ce61-fa24-445e-a1f0-6e3299142966'"
+                  }
+                }
+              ],
+              "id": "__IvovCqnzL"
+            }
+          ]
+        },
+        {
+          "label": "Blood Grouping",
+          "questions": [
+            {
+              "label": "Blood type:",
+              "id": "bloodGroup_test",
+              "questionOptions": {
+                "concept": "a8945754-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a896e8c0-1350-11df-a1f1-0026b9348838",
+                    "label": "A positive"
+                  },
+                  {
+                    "concept": "a896ea6e-1350-11df-a1f1-0026b9348838",
+                    "label": "A negative"
+                  },
+                  {
+                    "concept": "a896ec1c-1350-11df-a1f1-0026b9348838",
+                    "label": "B positive"
+                  },
+                  {
+                    "concept": "a896edca-1350-11df-a1f1-0026b9348838",
+                    "label": "B negative"
+                  },
+                  {
+                    "concept": "a896f04a-1350-11df-a1f1-0026b9348838",
+                    "label": "O positive"
+                  },
+                  {
+                    "concept": "a896f1f8-1350-11df-a1f1-0026b9348838",
+                    "label": "O negative"
+                  },
+                  {
+                    "concept": "a89b47a8-1350-11df-a1f1-0026b9348838",
+                    "label": "AB positive"
+                  },
+                  {
+                    "concept": "a89b48de-1350-11df-a1f1-0026b9348838",
+                    "label": "AB negative"
+                  },
+                  {
+                    "concept": "33bc1cf5-4ae5-49ba-9afd-bcbb9f7b09e5",
+                    "label": "A"
+                  },
+                  {
+                    "concept": "01e7f790-a8fc-40e9-968f-c9d79924eb6d",
+                    "label": "B"
+                  },
+                  {
+                    "concept": "0feab44f-6777-4c4b-a3ed-a3502f996fcb",
+                    "label": "AB"
+                  },
+                  {
+                    "concept": "bf9a31dc-5db4-49c2-aad2-30ec16315b24",
+                    "label": "O"
+                  }
+                ],
+                "showDate": "true",
+                "rendering": "select",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(bloodGroup_test) && isEmpty(myValue)",
+                      "message": "Date result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(bloodGroup_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "TB Test",
+          "questions": [
+            {
+              "label": "Genexpert test (Upload image of the result):",
+              "id": "genexpert_test",
+              "questionOptions": {
+                "concept": "6fa355eb-9321-4850-884c-12594194862a",
+                "showDate": "true",
+                "rendering": "file",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(genexpert_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(genexpert_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "Sputum gene xpert MTB:",
+              "id": "sputumgene_test",
+              "questionOptions": {
+                "concept": "741517cf-8bac-4755-b289-8dd2a2df7962",
+                "answers": [
+                  {
+                    "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "a89a7ae4-1350-11df-a1f1-0026b9348838",
+                    "label": "Indeterminate"
+                  },
+                  {
+                    "concept": "a89c3d8e-1350-11df-a1f1-0026b9348838",
+                    "label": "Poor sample quality"
+                  }
+                ],
+                "showDate": "true",
+                "rendering": "select",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(sputumgene_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(sputumgene_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "Sputum AFB smear:",
+              "id": "sputumafp_test",
+              "questionOptions": {
+                "concept": "a8945d4e-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a8a45ab4-1350-11df-a1f1-0026b9348838",
+                    "label": "1+"
+                  },
+                  {
+                    "concept": "a8a45bd6-1350-11df-a1f1-0026b9348838",
+                    "label": "2+"
+                  },
+                  {
+                    "concept": "a8a45ca8-1350-11df-a1f1-0026b9348838",
+                    "label": "3+"
+                  },
+                  {
+                    "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "a89a7ae4-1350-11df-a1f1-0026b9348838",
+                    "label": "Indeterminate"
+                  },
+                  {
+                    "concept": "a89c3d8e-1350-11df-a1f1-0026b9348838",
+                    "label": "Poor sample quality"
+                  }
+                ],
+                "showDate": "true",
+                "rendering": "select",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(sputumafp_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(sputumafp_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "Sputum culture:",
+              "id": "sputumculture_test",
+              "questionOptions": {
+                "concept": "a8a462a2-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "a89c3d8e-1350-11df-a1f1-0026b9348838",
+                    "label": "Poor sample quality"
+                  },
+                  {
+                    "concept": "0b4e9aa1-e470-46d1-9d2d-0d8a475561b9",
+                    "label": "Mycobacterium tuberculosis"
+                  },
+                  {
+                    "concept": "a01149c4-7f0e-4d27-8f42-dc019e3330ec",
+                    "label": "Non tuberculosis mycobacteria"
+                  }
+                ],
+                "showDate": "true",
+                "rendering": "select",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(sputumculture_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(sputumculture_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "TST (Mantoux test):",
+              "id": "tst_test",
+              "questionOptions": {
+                "concept": "a89d278a-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "a89d2852-1350-11df-a1f1-0026b9348838",
+                    "label": "Strongly positive"
+                  }
+                ],
+                "showDate": "true",
+                "rendering": "select",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(tst_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(tst_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "Chest Xray",
+          "questions": [
+            {
+              "label": "CXR code:",
+              "id": "cxrcode_test",
+              "questionOptions": {
+                "concept": "a8908192-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899e7b4-1350-11df-a1f1-0026b9348838",
+                    "label": "Normal"
+                  },
+                  {
+                    "concept": "a8a6aa3a-1350-11df-a1f1-0026b9348838",
+                    "label": "Cardiomegaly"
+                  },
+                  {
+                    "concept": "a8ae8c1e-1350-11df-a1f1-0026b9348838",
+                    "label": "Cavitary"
+                  },
+                  {
+                    "concept": "a8ae8a66-1350-11df-a1f1-0026b9348838",
+                    "label": "Diffuse abn/non-miliary"
+                  },
+                  {
+                    "concept": "a8ae8980-1350-11df-a1f1-0026b9348838",
+                    "label": "Infiltrate"
+                  },
+                  {
+                    "concept": "a89a77ce-1350-11df-a1f1-0026b9348838",
+                    "label": "Miliary"
+                  },
+                  {
+                    "concept": "a89a76fc-1350-11df-a1f1-0026b9348838",
+                    "label": "PI effusion"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "showDate": "true",
+                "rendering": "select",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(cxrcode_test) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(cxrcode_test)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "Other Lab Tests",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Test result, detailed",
+              "questionOptions": {
+                "concept": "a8a00e1e-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "type": "obs",
+                  "label": "Other test results, specify:",
+                  "id": "otherTestResult",
+                  "questionOptions": {
+                    "concept": "6f5207f4-6785-433b-943e-c2d03e7d3ea7",
+                    "rendering": "text"
+                  },
+                  "validators": []
+                }
+              ],
+              "id": "__o8FwxyxIz"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Assessment",
+      "sections": [
+        {
+          "label": "Clinical Notes",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Please enter the clinical notes below:",
+              "type": "obs",
+              "id": "assNote",
+              "default": "",
+              "questionOptions": {
+                "concept": "23f710cc-7f9c-4255-9b6b-c3e240215dba",
+                "rendering": "textarea",
+                "rows": 5
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Medication Plan",
+      "sections": [
+        {
+          "label": "ART Plan",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "required": "true",
+              "id": "arvPlan",
+              "label": "ART plan:",
+              "questionOptions": {
+                "concept": "a89b75d4-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a89b7908-1350-11df-a1f1-0026b9348838",
+                    "label": "Continue regimen"
+                  },
+                  {
+                    "concept": "a898c938-1350-11df-a1f1-0026b9348838",
+                    "label": "Change dose"
+                  },
+                  {
+                    "concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
+                    "label": "Change regimen"
+                  },
+                  {
+                    "concept": "a89b7ae8-1350-11df-a1f1-0026b9348838",
+                    "label": "Change formulation"
+                  },
+                  {
+                    "concept": "a8a00158-1350-11df-a1f1-0026b9348838",
+                    "label": "Drug substitution"
+                  },
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "Not on ARVS"
+                  },
+                  {
+                    "concept": "a8a00220-1350-11df-a1f1-0026b9348838",
+                    "label": "Restart"
+                  },
+                  {
+                    "concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
+                    "label": "Start ARVs"
+                  },
+                  {
+                    "concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
+                    "label": "Stop all"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b35c-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
+                  "message": "Patient marked as on ART in ART History section. Therefore plan can only be drug substitution, continue regimen, change dose, chage regimen, change"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onArt) && onArt === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
+                  "message": "Patient marked as not on ART in ART History section. Therefore plan can only be None,Start"
+                }
+              ]
+            },
+            {
+              "label": "Reason to start ART:",
+              "id": "arvStartReason",
+              "questionOptions": {
+                "concept": "a89b6ce2-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "c9778159-958b-4f59-9053-a6171074726f",
+                    "label": "CD4 less than 500"
+                  },
+                  {
+                    "concept": "a8af49d8-1350-11df-a1f1-0026b9348838",
+                    "label": "Discordant couple"
+                  },
+                  {
+                    "concept": "a89b27be-1350-11df-a1f1-0026b9348838",
+                    "label": "WHO stage 3"
+                  },
+                  {
+                    "concept": "a89b289a-1350-11df-a1f1-0026b9348838",
+                    "label": "WHO stage 4"
+                  },
+                  {
+                    "concept": "a89fbedc-1350-11df-a1f1-0026b9348838",
+                    "label": "PMTCT"
+                  },
+                  {
+                    "concept": "a8909060-1350-11df-a1f1-0026b9348838",
+                    "label": "Hepatitis"
+                  },
+                  {
+                    "concept": "7fa72118-ef2a-4694-993a-014440024bbc",
+                    "label": "Test and treat"
+                  },
+                  {
+                    "concept": "67f1f202-477a-4469-a2f9-769b339f682f",
+                    "label": "Adherence counselling completed"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(arvPlan) && isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)",
+                  "message": "You indicated patient is (re)starting ART. Please provide reason."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(arvPlan) && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)",
+                  "message": "You indicated patient is not (re)starting ART, therefore no reason for starting should be selected."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "!arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)"
+              }
+            },
+            {
+              "type": "obsGroup",
+              "label": "ART change reason",
+              "questionOptions": {
+                "concept": "a8a07688-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "id": "arvChangeReason",
+                  "label": "Reason for stopping/change/substitution/interruption:",
+                  "questionOptions": {
+                    "concept": "a89b7110-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
+                        "label": "Adherence concerns"
+                      },
+                      {
+                        "concept": "a8981934-1350-11df-a1f1-0026b9348838",
+                        "label": "Clinical treatment failure"
+                      },
+                      {
+                        "concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
+                        "label": "Drug out of stock"
+                      },
+                      {
+                        "concept": "a890a96a-1350-11df-a1f1-0026b9348838",
+                        "label": "Due to new TB"
+                      },
+                      {
+                        "concept": "057dae68-3d6f-4d79-926c-ed75a0ce7fd5",
+                        "label": "Illness/hospitalization"
+                      },
+                      {
+                        "concept": "c6537e06-9fc2-47da-b679-e2a32824407f",
+                        "label": "Immunologic failure"
+                      },
+                      {
+                        "concept": "a8a6f56c-1350-11df-a1f1-0026b9348838",
+                        "label": "Lost to follow-up"
+                      },
+                      {
+                        "concept": "a8a07b10-1350-11df-a1f1-0026b9348838",
+                        "label": "New drug available"
+                      },
+                      {
+                        "concept": "a8b03af0-1350-11df-a1f1-0026b9348838",
+                        "label": "Patient lacks finances"
+                      },
+                      {
+                        "concept": "abe0cbb6-8d08-487a-b18e-7af873945fcc",
+                        "label": "Planned Rx interruption"
+                      },
+                      {
+                        "concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
+                        "label": "Pill burden"
+                      },
+                      {
+                        "concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
+                        "label": "Changing to adult regimen"
+                      },
+                      {
+                        "concept": "a8909e8e-1350-11df-a1f1-0026b9348838",
+                        "label": "Pregnancy"
+                      },
+                      {
+                        "concept": "e38b3e51-8a27-4bf6-b0c8-e0b285e4bb2f",
+                        "label": "Risk of pregnancy"
+                      },
+                      {
+                        "concept": "a89d25fa-1350-11df-a1f1-0026b9348838",
+                        "label": "Other patient desicion"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      },
+                      {
+                        "concept": "4ee08cb4-fc93-44a0-a330-4e3fb45ca625",
+                        "label": "Optimization"
+                      },
+                      {
+                        "concept": "a890d1ba-1350-11df-a1f1-0026b9348838",
+                        "label": "Toxicity"
+                      },
+                      {
+                        "concept": "93fe19e8-fec4-4e4b-85f1-239e1fabd761",
+                        "label": "Virologic failure"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(arvPlan) && isEmpty(myValue) && arrayContains(['a898c938-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], arvPlan)",
+                      "message": "You indicated patient is changing/changing dose/substituting/stopping arvs, reason for changing should be selected."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "!arrayContains(['a898c938-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], arvPlan)"
+                  }
+                },
+                {
+                  "id": "arvToxicityCause",
+                  "label": "If toxicity, please provide cause:",
+                  "questionOptions": {
+                    "concept": "a8a032fe-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
+                        "label": "Anaemia"
+                      },
+                      {
+                        "concept": "a8909060-1350-11df-a1f1-0026b9348838",
+                        "label": "Hepatitis"
+                      },
+                      {
+                        "concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
+                        "label": "IRIS"
+                      },
+                      {
+                        "concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
+                        "label": "Lactic acidosis"
+                      },
+                      {
+                        "concept": "a89cee50-1350-11df-a1f1-0026b9348838",
+                        "label": "Lipo-dystrophy"
+                      },
+                      {
+                        "concept": "a897fe86-1350-11df-a1f1-0026b9348838",
+                        "label": "Neuropathy"
+                      },
+                      {
+                        "concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
+                        "label": "Persistent vomiting"
+                      },
+                      {
+                        "concept": "a895776a-1350-11df-a1f1-0026b9348838",
+                        "label": "Rash"
+                      },
+                      {
+                        "concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
+                        "label": "Steven-Johnson syndrome"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(arvChangeReason)&&isEmpty(myValue) && (arvChangeReason==='a890d1ba-1350-11df-a1f1-0026b9348838')",
+                      "message": "You indicated patient is changing /changing dose/substituting/stopping arvs due to toxicity, cause should be selected."
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(arvChangeReason) && !isEmpty(myValue) && (arvChangeReason!=='a890d1ba-1350-11df-a1f1-0026b9348838')",
+                      "message": "You indicated patient is not changing/dose/substituting/stopping arvs due to toxicity, cause should be selected."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "arvChangeReason!=='a890d1ba-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "If toxicity: Other (specify):",
+                  "id": "arvToxOther",
+                  "type": "obs",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(arvToxicityCause) && isEmpty(myValue) && (arvToxicityCause==='a8aaf3e2-1350-11df-a1f1-0026b9348838')",
+                      "message": "You indicated patient is changing /changing dose/substituting/stopping arvs due to other toxicity, indicate the other cause."
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(arvToxicityCause) && !isEmpty(myValue) && (arvToxicityCause!=='a8aaf3e2-1350-11df-a1f1-0026b9348838')",
+                      "message": "You indicated patient is not changing /changing dose/substituting/stopping arvs due to other toxicity, other cause is not required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "arvToxicityCause!=='a8aaf3e2-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ],
+              "id": "__svwFww7EF"
+            },
+            {
+              "type": "obsGroup",
+              "label": "Eligible for ART",
+              "questionOptions": {
+                "concept": "a8a17a7e-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Eligible for ART but not started:",
+                  "id": "artEligibleNotStarted",
+                  "questionOptions": {
+                    "concept": "a89d26cc-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
+                        "label": "Adherence concerns"
+                      },
+                      {
+                        "concept": "a8a8b26c-1350-11df-a1f1-0026b9348838",
+                        "label": "On TB treatment"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      },
+                      {
+                        "concept": "a89d25fa-1350-11df-a1f1-0026b9348838",
+                        "label": "Patient refused"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "arvPlan !== 'a899e0ac-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "Eligible for ART but not started: Other (specify):",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "id": "eligibleOther",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "artEligibleNotStarted !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ],
+              "id": "__LrLCGwsn9"
+            },
+            {
+              "label": "Plan treatment categories:",
+              "type": "obs",
+              "id": "planCate",
+              "questionOptions": {
+                "concept": "74e3b23f-b94f-49d9-a237-6baaee73f163",
+                "answers": [
+                  {
+                    "concept": "034047bd-3fa1-4b2a-b0f0-2787e9b9f7b3",
+                    "label": "First line regimen"
+                  },
+                  {
+                    "concept": "8f8a715d-e49a-4b2c-aa3a-83fa9d7a4254",
+                    "label": "Second line regimen"
+                  },
+                  {
+                    "concept": "a90ebdd2-351f-485a-b850-4938fcca2729",
+                    "label": "Third line regimen"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "hide": {
+                "hideWhenExpression": "!arrayContains(['a89b7ae8-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a8a00220-1350-11df-a1f1-0026b9348838'],arvPlan)"
+              }
+            },
+            {
+              "label": "ART regimen started, adult:",
+              "id": "artStartedAdult",
+              "questionOptions": {
+                "concept": "a89b6a62-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "18e86e1f-92b8-40cd-8266-0df0ab0a4a50",
+                    "label": "DTG50mg/3TC300mg/TDF300mg"
+                  },
+                  {
+                    "concept": "1c4a75d0-cc91-4752-b0a5-4b833326ff7a",
+                    "label": "TDF300mg/3TC300mg/EFV600mg"
+                  },
+                  {
+                    "concept": "ea501f4e-cbc5-4942-b9c8-0ac415929f08",
+                    "label": "TDF300mg/3TC300mg/EFV400mg"
+                  },
+                  {
+                    "concept": "e78843da-fdb6-446d-8e99-873c278b3540",
+                    "label": "ABC600mg/3TC300mg"
+                  },
+                  {
+                    "concept": "6a73f32d-1870-4527-af6e-74443251ded2",
+                    "label": "NVP200/ZDV300/3TC150"
+                  },
+                  {
+                    "concept": "a89cc876-1350-11df-a1f1-0026b9348838",
+                    "label": "3TC300mg/TDF300mg"
+                  },
+                  {
+                    "concept": "a896758e-1350-11df-a1f1-0026b9348838",
+                    "label": "3TC150mg/ZDV300mg"
+                  },
+                  {
+                    "concept": "a8afcf84-1350-11df-a1f1-0026b9348838",
+                    "label": "Emtri200mg/TDF300(Truvada)"
+                  },
+                  {
+                    "concept": "a897e7c0-1350-11df-a1f1-0026b9348838",
+                    "label": "Aluvia(Kaletra)200mg/LPV50mg"
+                  },
+                  {
+                    "concept": "a8afc066-1350-11df-a1f1-0026b9348838",
+                    "label": "Atazanavir300/Ritonavir100"
+                  },
+                  {
+                    "concept": "dabf36cb-dd9a-4542-a8ef-874c1ee5be4a",
+                    "label": "FTC200mg/RPV25mg/TDF245mg(Eviplera)"
+                  },
+                  {
+                    "concept": "98b0baf6-0b73-4429-9264-6233684b0969",
+                    "label": "Dolutegravir 50mg"
+                  },
+                  {
+                    "concept": "a897f8a0-1350-11df-a1f1-0026b9348838",
+                    "label": "Abacavir300mg"
+                  },
+                  {
+                    "concept": "db3c194b-3e1b-4001-9a1c-a5df1728fc28",
+                    "label": "Efavirenz 200mg"
+                  },
+                  {
+                    "concept": "a89673f4-1350-11df-a1f1-0026b9348838",
+                    "label": "Lamivudine150mg"
+                  },
+                  {
+                    "concept": "a8afbd64-1350-11df-a1f1-0026b9348838",
+                    "label": "Raltegravir 400mg"
+                  },
+                  {
+                    "concept": "a897ea4a-1350-11df-a1f1-0026b9348838",
+                    "label": "Zidovudine300mg"
+                  },
+                  {
+                    "concept": "68a0a5dd-1e91-43a2-8dce-c6e84a14de04",
+                    "label": "Darunavir 600mg"
+                  },
+                  {
+                    "concept": "1baf254e-1429-4fd9-8db1-edf6523cea13",
+                    "label": " Ritonavir 100mg"
+                  },
+                  {
+                    "concept": "42ef7c4d-d6fb-49c0-a46e-019c42dea203",
+                    "label": " Ritonavir 80mg"
+                  },
+                  {
+                    "concept": "38fbba9c-4b26-412d-9659-8dd649514d66",
+                    "label": "Etravirine 100mg"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(arvPlan) && isEmpty(myValue) && arrayContains(['a89b7ae8-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)",
+                  "message": "Based on the plan selected, you must choose a regimen."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(myValue) && !arrayContains(['a89b7ae8-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a8a00220-1350-11df-a1f1-0026b9348838'], arvPlan)",
+                  "message": "Based on the plan selected, you may not choose a regimen."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "!arrayContains(['a89b7ae8-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a8a00220-1350-11df-a1f1-0026b9348838'],arvPlan)"
+              }
+            },
+            {
+              "label": "Indication for DTG based ART:",
+              "historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('3c54aae1-8b94-49b5-9961-b6aa7cacc03b')) ? undefined : HD.getObject('prevEnc').getValue('3c54aae1-8b94-49b5-9961-b6aa7cacc03b')",
+              "id": "dtgIndication",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "3c54aae1-8b94-49b5-9961-b6aa7cacc03b",
+                "answers": [
+                  {
+                    "concept": "971e804e-89f1-41a2-9cfc-82922eed3db2",
+                    "label": "ART intiation"
+                  },
+                  {
+                    "concept": "c9072a63-0075-4f5a-81af-1439d803a510",
+                    "label": "Substitution for EFV intolerance/toxicity"
+                  },
+                  {
+                    "concept": "c3bfde9d-6f9c-4a92-ba74-bbf3af8c7061",
+                    "label": "Substitution for NVP"
+                  },
+                  {
+                    "concept": "a90ebdd2-351f-485a-b850-4938fcca2729",
+                    "label": "Third line regimen"
+                  },
+                  {
+                    "concept": "24d5c8f6-e92c-47fb-becb-9cfac89939c5",
+                    "label": "Substitution for ATV/r in PWID"
+                  },
+                  {
+                    "concept": "30c754b8-e20a-470b-a2cf-b6f1f92c733d",
+                    "label": "Substitution for PI/r in 2nd line with TB disease"
+                  },
+                  {
+                    "concept": "9af59394-f330-4616-b361-86642659808a",
+                    "label": "Alternative for virally suppressed 1st line PI/r based regimen"
+                  },
+                  {
+                    "concept": "0df1b558-9598-4ca4-9678-7a1caae6265f",
+                    "label": "Alternative regimen for pregnant/postpartum women"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ]
+              },
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(artStartedAdult) && arrayContains(artStartedAdult, '98b0baf6-0b73-4429-9264-6233684b0969')",
+                  "message": "DTG indication is required."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "isEmpty(artStartedAdult) || !arrayContains(artStartedAdult, '98b0baf6-0b73-4429-9264-6233684b0969')"
+              }
+            },
+            {
+              "label": "Other (specify):",
+              "id": "otherDtgIndications",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                "rendering": "text"
+              },
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "dtgIndication !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
+              }
+            }
+          ]
+        },
+        {
+          "label": "PCP Prophylaxis Plan",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "required": "true",
+              "id": "pcpProphylaxisPlan",
+              "label": "PCP prophylaxis plan:",
+              "questionOptions": {
+                "concept": "a89b7e12-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a89b7908-1350-11df-a1f1-0026b9348838",
+                    "label": "Continue"
+                  },
+                  {
+                    "concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
+                    "label": "Change regimen"
+                  },
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "Not on PCP prophylaxis"
+                  },
+                  {
+                    "concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
+                    "label": "Start"
+                  },
+                  {
+                    "concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
+                    "label": "Stop"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(pcpProphylaxisCurrent) && !isEmpty(myValue) && !arrayContains(['a899e0ac-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838'],myValue)&&(pcpProphylaxisCurrent==='a899e0ac-1350-11df-a1f1-0026b9348838')",
+                  "message": "Patient marked as not on PCP prophylaxis. Therefore plan can only be none or start."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(pcpProphylaxisCurrent) && !isEmpty(myValue) && arrayContains(['a8989396-1350-11df-a1f1-0026b9348838','a890c9e0-1350-11df-a1f1-0026b9348838'],pcpProphylaxisCurrent)&&!(arrayContains(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838','a89b7908-1350-11df-a1f1-0026b9348838'], myValue))",
+                  "message": "Patient marked as on PCP Prophylaxis. Therefore plan can only be change regimen,continue or stop."
+                }
+              ]
+            },
+            {
+              "type": "obsGroup",
+              "label": "PCP prophylaxis change reason",
+              "questionOptions": {
+                "concept": "a8a07750-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "If change/stop, reason:",
+                  "id": "pcpProphylaxisChangeReason",
+                  "questionOptions": {
+                    "concept": "a89b7eee-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a890d1ba-1350-11df-a1f1-0026b9348838",
+                        "label": "Toxicity"
+                      },
+                      {
+                        "concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
+                        "label": "Pill burden"
+                      },
+                      {
+                        "concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
+                        "label": "Drug out of stock"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(pcpProphylaxisPlan) && isEmpty(myValue) && arrayContains(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan)",
+                      "message": "Patient changed drugs, please select reason."
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(pcpProphylaxisPlan) && !isEmpty(myValue) && (!arrayContains(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan))",
+                      "message": "Patient has not changed drugs, please do not select a reason."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "!arrayContains(['a89b7c50-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan)"
+                  }
+                }
+              ],
+              "id": "__rMyDpFrF8"
+            },
+            {
+              "id": "pcpToxicityCause",
+              "label": "If toxicity, please provide cause:",
+              "questionOptions": {
+                "concept": "a8a032fe-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
+                    "label": "Anaemia"
+                  },
+                  {
+                    "concept": "a8909060-1350-11df-a1f1-0026b9348838",
+                    "label": "Hepatitis"
+                  },
+                  {
+                    "concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
+                    "label": "IRIS"
+                  },
+                  {
+                    "concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
+                    "label": "Lactic acidosis"
+                  },
+                  {
+                    "concept": "a89cee50-1350-11df-a1f1-0026b9348838",
+                    "label": "Lipo-dystrophy"
+                  },
+                  {
+                    "concept": "a897fe86-1350-11df-a1f1-0026b9348838",
+                    "label": "Neuropathy"
+                  },
+                  {
+                    "concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
+                    "label": "Persistent vomiting"
+                  },
+                  {
+                    "concept": "a895776a-1350-11df-a1f1-0026b9348838",
+                    "label": "Rash"
+                  },
+                  {
+                    "concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
+                    "label": "Steven-johnson syndrome"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(pcpProphylaxisChangeReason) && isEmpty(myValue) && (pcpProphylaxisChangeReason==='a890d1ba-1350-11df-a1f1-0026b9348838')",
+                  "message": "You indicated patient is changing /changing dose/substituting/stopping PCP due to toxicity, cause should be selected."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(pcpProphylaxisChangeReason) && !isEmpty(myValue) && (pcpProphylaxisChangeReason!=='a890d1ba-1350-11df-a1f1-0026b9348838')",
+                  "message": "You indicated patient is not changing/dose/substituting/stopping PCP due to toxicity, cause should not be selected."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "pcpProphylaxisChangeReason !== 'a890d1ba-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "If toxicity, please provide cause: Other (specify):",
+              "id": "q25OtherToxicity",
+              "questionOptions": {
+                "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                "rendering": "text"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(pcpToxicityCause) && isEmpty(myValue) && pcpToxicityCause==='a8aaf3e2-1350-11df-a1f1-0026b9348838'",
+                  "message": "You indicated patient is changing /changing dose/substituting/stopping PCP due to other toxicity, indicate the other cause."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "pcpToxicityCause !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "If Start/Change, regimen:",
+              "id": "pcpPlanMedication",
+              "questionOptions": {
+                "concept": "a89b82cc-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a8989396-1350-11df-a1f1-0026b9348838",
+                    "label": "Septrin"
+                  },
+                  {
+                    "concept": "a890c9e0-1350-11df-a1f1-0026b9348838",
+                    "label": "Dapsone 100mg"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(pcpProphylaxisPlan) && isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838', 'a89b7c50-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan)",
+                  "message": "You indicated patient is starting/continuing/changing PCP regimen. Please select regimen."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "!arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838', 'a89b7c50-1350-11df-a1f1-0026b9348838'], pcpProphylaxisPlan)"
+              }
+            }
+          ]
+        },
+        {
+          "label": "TB Prophylaxis Plan",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "TB prophylaxis plan:",
+              "required": "true",
+              "id": "tbpropplan",
+              "questionOptions": {
+                "concept": "a89c1cfa-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "Not on TB prophylaxis"
+                  },
+                  {
+                    "concept": "a89b7908-1350-11df-a1f1-0026b9348838",
+                    "label": "Continue"
+                  },
+                  {
+                    "concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
+                    "label": "Start"
+                  },
+                  {
+                    "concept": "a8a00220-1350-11df-a1f1-0026b9348838",
+                    "label": "Restart"
+                  },
+                  {
+                    "concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
+                    "label": "Stop"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onTbProphylaxis) && onTbProphylaxis === 'a899b35c-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838'], myValue)",
+                  "message": "Patient marked as on TB prophylaxis in History section. Therefore plan can only be continue ,stop"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(onTbProphylaxis) && onTbProphylaxis === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
+                  "message": "Patient marked as not on TB prophylaxis in History section. Therefore plan can only be None,Start,Restart"
+                }
+              ]
+            },
+            {
+              "type": "obsGroup",
+              "label": "stopping reason",
+              "questionOptions": {
+                "concept": "a8a0780e-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "If stopping, reason:",
+                  "required": "true",
+                  "id": "tbpropreasonstop",
+                  "questionOptions": {
+                    "concept": "a89c1e12-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a890a96a-1350-11df-a1f1-0026b9348838",
+                        "label": "Active TB"
+                      },
+                      {
+                        "concept": "a89c1ef8-1350-11df-a1f1-0026b9348838",
+                        "label": "Completed"
+                      },
+                      {
+                        "concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
+                        "label": "Pill burden"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      },
+                      {
+                        "concept": "a890d1ba-1350-11df-a1f1-0026b9348838",
+                        "label": "Toxicity"
+                      },
+                      {
+                        "concept": "a89eb744-1350-11df-a1f1-0026b9348838",
+                        "label": "Lack of drugs"
+                      },
+                      {
+                        "concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
+                        "label": "Poor adherence"
+                      },
+                      {
+                        "concept": "a89eb8c0-1350-11df-a1f1-0026b9348838",
+                        "label": "Side effects (Adverse drug reaction)"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "tbpropplan !== 'a89b7d36-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "If toxicity, please provide cause:",
+                  "id": "toxCause",
+                  "questionOptions": {
+                    "concept": "a8a032fe-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
+                        "label": "Anaemia"
+                      },
+                      {
+                        "concept": "a8909060-1350-11df-a1f1-0026b9348838",
+                        "label": "Hepatitis"
+                      },
+                      {
+                        "concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
+                        "label": "IRIS"
+                      },
+                      {
+                        "concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
+                        "label": "Lactic Acidosis"
+                      },
+                      {
+                        "concept": "a89cee50-1350-11df-a1f1-0026b9348838",
+                        "label": "Lipo-dystrophy"
+                      },
+                      {
+                        "concept": "a897fe86-1350-11df-a1f1-0026b9348838",
+                        "label": "Neuropathy"
+                      },
+                      {
+                        "concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
+                        "label": "Persistent vomiting"
+                      },
+                      {
+                        "concept": "a895776a-1350-11df-a1f1-0026b9348838",
+                        "label": "Rash"
+                      },
+                      {
+                        "concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
+                        "label": "Steven-Johnson syndrome"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "tbpropreasonstop !== 'a890d1ba-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "If toxicity, please provide cause: Other (specify):",
+                  "id": "toxcauseOther",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "toxCause !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ],
+              "id": "__zrqKsvror"
+            },
+            {
+              "label": "TB prophylaxis regimen started:",
+              "questionOptions": {
+                "concept": "a89b83bc-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "162724df-5a66-4ae3-bbf6-5dc6dbba4ebb",
+                    "label": "Isoniazid 100mg (6H)"
+                  },
+                  {
+                    "concept": "b150ccdc-e7ec-4f99-b592-6f3fa73b3aea",
+                    "label": "Isoniazid 300mg (6H)"
+                  },
+                  {
+                    "concept": "aeaed1af-5b0d-401e-a32a-e96cf4072ab5",
+                    "label": "Isoniazid 300mg and Rifapentine 300mg (3HP)"
+                  },
+                  {
+                    "concept": "177635d0-793b-4a66-8324-976c46f795af",
+                    "label": "Rifampicin 150mg and Isonaizid 75mg (3RH)"
+                  },
+                  {
+                    "concept": "e5e24e6d-e6b0-4c81-8f7b-0e366df29426",
+                    "label": "Rifampicin 70mg and Isonaizid 50mg (3RH)"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "id": "prophyReg",
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "!arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], tbpropplan)"
+              }
+            }
+          ]
+        },
+        {
+          "label": "TB Treatment Plan",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "TB Treatment Started, detailed",
+              "type": "obsGroup",
+              "questionOptions": {
+                "concept": "a89fe6f0-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "TB Treatment plan:",
+                  "id": "tbTreatmentPlan",
+                  "required": "true",
+                  "questionOptions": {
+                    "concept": "a89c1fd4-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                        "label": "Not on TB treatment"
+                      },
+                      {
+                        "concept": "a89b7908-1350-11df-a1f1-0026b9348838",
+                        "label": "Continue regimen"
+                      },
+                      {
+                        "concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
+                        "label": "Start induction"
+                      },
+                      {
+                        "concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
+                        "label": "Change to continuation"
+                      },
+                      {
+                        "concept": "a898c938-1350-11df-a1f1-0026b9348838",
+                        "label": "Re-dose"
+                      },
+                      {
+                        "concept": "a8a00158-1350-11df-a1f1-0026b9348838",
+                        "label": "Substitution"
+                      },
+                      {
+                        "concept": "a8a00220-1350-11df-a1f1-0026b9348838",
+                        "label": "Restart"
+                      },
+                      {
+                        "concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
+                        "label": "Stop"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(onTbTreatment) && onTbTreatment === 'a899b35c-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
+                      "message": "Patient marked as on TB in TB History section. Therefore plan can only be drug substitution, continue regimen, change dose, change regimen"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(onTbTreatment) && onTbTreatment === 'a899b42e-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], myValue)",
+                      "message": "Patient marked as not on TB in TB History section. Therefore plan can only be None, start"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(tbstatus) && tbstatus === 'a8af9046-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838'], myValue)",
+                      "message": "Patient marked as confirmed for TB in TB Screening section. Therefore plan can only start"
+                    }
+                  ]
+                }
+              ],
+              "id": "__vIqMGy4uK"
+            },
+            {
+              "type": "obsGroup",
+              "label": "TB Plan Change Reason",
+              "questionOptions": {
+                "concept": "a8a078cc-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "If plan is to stop/change/re-dose/substitute, reason:",
+                  "id": "tbPlanChangeReason",
+                  "questionOptions": {
+                    "concept": "a89c1fd4-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a89c1ef8-1350-11df-a1f1-0026b9348838",
+                        "label": "Completed"
+                      },
+                      {
+                        "concept": "c0c9eab3-46f6-453c-b29d-dc1c242317c5",
+                        "label": "Drug out of stock"
+                      },
+                      {
+                        "concept": "ecafa614-49c5-4eba-84c7-b85b0d9e2c46",
+                        "label": "Pill burden"
+                      },
+                      {
+                        "concept": "a89b7c50-1350-11df-a1f1-0026b9348838",
+                        "label": "Changing to adult regimen"
+                      },
+                      {
+                        "concept": "a8909e8e-1350-11df-a1f1-0026b9348838",
+                        "label": "Pregnancy"
+                      },
+                      {
+                        "concept": "e38b3e51-8a27-4bf6-b0c8-e0b285e4bb2f",
+                        "label": "Risk of pregnancy"
+                      },
+                      {
+                        "concept": "a890d1ba-1350-11df-a1f1-0026b9348838",
+                        "label": "Toxicity"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(tbTreatmentPlan) && isEmpty(myValue) && arrayContains(['a898c938-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)",
+                      "message": "You indicated patient is changing/changing dose/substituting/stopping TB, reason for changing should be selected."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "!arrayContains(['a898c938-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838','a89b7ae8-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a89b7d36-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)"
+                  }
+                },
+                {
+                  "label": "If toxicity, please provide cause:",
+                  "id": "tbToxicityCause",
+                  "questionOptions": {
+                    "concept": "a8a032fe-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a877c7f6-1350-11df-a1f1-0026b9348838",
+                        "label": "Anaemia"
+                      },
+                      {
+                        "concept": "a8909060-1350-11df-a1f1-0026b9348838",
+                        "label": "Hepatitis"
+                      },
+                      {
+                        "concept": "a89d0c0a-1350-11df-a1f1-0026b9348838",
+                        "label": "IRIS"
+                      },
+                      {
+                        "concept": "a8a01dfa-1350-11df-a1f1-0026b9348838",
+                        "label": "Lactic acidosis"
+                      },
+                      {
+                        "concept": "a89cee50-1350-11df-a1f1-0026b9348838",
+                        "label": "Lipo-dystrophy"
+                      },
+                      {
+                        "concept": "a897fe86-1350-11df-a1f1-0026b9348838",
+                        "label": "Neuropathy"
+                      },
+                      {
+                        "concept": "a8ad239c-1350-11df-a1f1-0026b9348838",
+                        "label": "Persistent vomiting"
+                      },
+                      {
+                        "concept": "a895776a-1350-11df-a1f1-0026b9348838",
+                        "label": "Rash"
+                      },
+                      {
+                        "concept": "a8a16d0e-1350-11df-a1f1-0026b9348838",
+                        "label": "Steven-Johnson syndrome"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(tbPlanChangeReason)&&isEmpty(myValue) && (tbPlanChangeReason==='a890d1ba-1350-11df-a1f1-0026b9348838')",
+                      "message": "You indicated patient is changing /changing dose/substituting/stopping arvs due to toxicity, cause should be selected."
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(tbPlanChangeReason) && !isEmpty(myValue) && (tbPlanChangeReason!=='a890d1ba-1350-11df-a1f1-0026b9348838')",
+                      "message": "You indicated patient is not changing/dose/substituting/stopping arvs due to toxicity, cause should be selected."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "tbPlanChangeReason !== 'a890d1ba-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "If restarting, reason:",
+                  "id": "tbRestart",
+                  "type": "obs",
+                  "questionOptions": {
+                    "concept": "749d07cb-4994-4ce9-a39c-8a655a487fdd",
+                    "answers": [
+                      {
+                        "concept": "15316528-adb9-4c33-b21f-2817f0cad769",
+                        "label": "Defaulted"
+                      },
+                      {
+                        "concept": "f6951199-560d-414a-bb5b-1150f07fcea7",
+                        "label": "Failure"
+                      },
+                      {
+                        "concept": "a8a3243c-1350-11df-a1f1-0026b9348838",
+                        "label": "MDR TB regimen"
+                      },
+                      {
+                        "concept": "769822b2-1f1f-4cbb-8371-0e3949e060cc",
+                        "label": "New treatment"
+                      },
+                      {
+                        "concept": "18ac99bf-0805-4929-8d0b-924455850a00",
+                        "label": "Relapse/re-infection"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(tbTreatmentPlan) && arrayContains(['a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan) && isEmpty(myValue)",
+                      "message": "You indicated patient is restarting tb medication, therefore reason should be selected."
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "(isEmpty(tbTreatmentPlan) || !arrayContains(['a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)) && !isEmpty(myValue)",
+                      "message": "You did not indicate restart tb medication, therefore reason should not be selected."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "!arrayContains(['a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)"
+                  }
+                }
+              ],
+              "id": "__6wJyGLGuE"
+            },
+            {
+              "type": "obsGroup",
+              "label": "tbMedPickupSite",
+              "questionOptions": {
+                "concept": "b55a6d42-3189-4d4c-97bf-772dfe17b887",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Site of TB meds pick-up:",
+                  "id": "tbMedPickupSite",
+                  "questionOptions": {
+                    "concept": "16db21cd-10cb-4c31-bb5a-b7619bfbea66",
+                    "answers": [
+                      {
+                        "concept": "a89c2f42-1350-11df-a1f1-0026b9348838",
+                        "label": "This AMPATH site"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "!arrayContains(['a89b7908-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)"
+                  }
+                },
+                {
+                  "label": "Other Specify:",
+                  "id": "medspickOther",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "tbMedPickupSite !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ],
+              "id": "__vyqMwzsEx"
+            },
+            {
+              "label": "TB Treatment Started, detailed",
+              "type": "obsGroup",
+              "questionOptions": {
+                "concept": "a89fe6f0-1350-11df-a1f1-0026b9348838",
+                "rendering": "repeating"
+              },
+              "questions": [
+                {
+                  "label": "TB regimen started:",
+                  "questionOptions": {
+                    "concept": "a89c218c-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a899f51a-1350-11df-a1f1-0026b9348838",
+                        "label": "RHZE"
+                      },
+                      {
+                        "concept": "a897d1a4-1350-11df-a1f1-0026b9348838",
+                        "label": "RHZ"
+                      },
+                      {
+                        "concept": "a8a382ba-1350-11df-a1f1-0026b9348838",
+                        "label": "RHE"
+                      },
+                      {
+                        "concept": "a89b1ca6-1350-11df-a1f1-0026b9348838",
+                        "label": "RH"
+                      },
+                      {
+                        "concept": "a899e19c-1350-11df-a1f1-0026b9348838",
+                        "label": "EH"
+                      },
+                      {
+                        "concept": "a8971c64-1350-11df-a1f1-0026b9348838",
+                        "label": "Ethambutol"
+                      },
+                      {
+                        "concept": "a8a3243c-1350-11df-a1f1-0026b9348838",
+                        "label": "MDR drugs"
+                      },
+                      {
+                        "concept": "a896cc00-1350-11df-a1f1-0026b9348838",
+                        "label": "INH"
+                      },
+                      {
+                        "concept": "a8ac5f2a-1350-11df-a1f1-0026b9348838",
+                        "label": "Pyrazinamide"
+                      },
+                      {
+                        "concept": "a8952e4a-1350-11df-a1f1-0026b9348838",
+                        "label": "Streptomycin"
+                      },
+                      {
+                        "concept": "b8aa06ca-93c6-40ea-b144-c74f841926f4",
+                        "label": "Rifabutin"
+                      },
+                      {
+                        "concept": "a897d0be-1350-11df-a1f1-0026b9348838",
+                        "label": "Rifampicin"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "id": "q26f",
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "!arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a89b7c50-1350-11df-a1f1-0026b9348838', 'a898c938-1350-11df-a1f1-0026b9348838','a8a00158-1350-11df-a1f1-0026b9348838','a8a00220-1350-11df-a1f1-0026b9348838'], tbTreatmentPlan)"
+                  }
+                },
+                {
+                  "label": "tabs/day:",
+                  "questionOptions": {
+                    "concept": "a8a07386-1350-11df-a1f1-0026b9348838",
+                    "max": "30",
+                    "min": "0",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "hide": {
+                    "field": "q26f",
+                    "value": [
+                      "a899f51a-1350-11df-a1f1-0026b9348838",
+                      "a897d1a4-1350-11df-a1f1-0026b9348838",
+                      "a8a382ba-1350-11df-a1f1-0026b9348838"
+                    ]
+                  },
+                  "id": "__rqurICE08"
+                },
+                {
+                  "label": "mg:",
+                  "questionOptions": {
+                    "concept": "a8a063c8-1350-11df-a1f1-0026b9348838",
+                    "max": "2000",
+                    "min": "0",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "hide": {
+                    "field": "q26f",
+                    "value": [
+                      "a899e19c-1350-11df-a1f1-0026b9348838",
+                      "a8ac5f2a-1350-11df-a1f1-0026b9348838",
+                      "a8952e4a-1350-11df-a1f1-0026b9348838"
+                    ]
+                  },
+                  "id": "__18wrGus9M"
+                },
+                {
+                  "label": "mg/day:",
+                  "questionOptions": {
+                    "concept": "a8a0744e-1350-11df-a1f1-0026b9348838",
+                    "max": "2000",
+                    "min": "0",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "hide": {
+                    "field": "q26f",
+                    "value": [
+                      "a896cc00-1350-11df-a1f1-0026b9348838",
+                      "a8971c64-1350-11df-a1f1-0026b9348838"
+                    ]
+                  },
+                  "id": "__xovtzvGwH"
+                },
+                {
+                  "label": "tabs:",
+                  "questionOptions": {
+                    "concept": "a8a0630a-1350-11df-a1f1-0026b9348838",
+                    "max": "180",
+                    "min": "0",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "hide": {
+                    "field": "q26f",
+                    "value": ["b8aa06ca-93c6-40ea-b144-c74f841926f4"]
+                  },
+                  "id": "__Jywyp94Lw"
+                }
+              ],
+              "id": "__LqprxvGCx"
+            }
+          ]
+        },
+        {
+          "label": "Cryptococcal Treatment Plan",
+          "questions": [
+            {
+              "label": "Crag test:",
+              "id": "cragTest",
+              "questionOptions": {
+                "concept": "7243bed9-0bc7-4702-af28-a06ab1981e19",
+                "answers": [
+                  {
+                    "concept": "a896f3a6-1350-11df-a1f1-0026b9348838",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "a896d2cc-1350-11df-a1f1-0026b9348838",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "a89c3d8e-1350-11df-a1f1-0026b9348838",
+                    "label": "Poor sample quality"
+                  }
+                ],
+                "showDate": "true",
+                "rendering": "select",
+                "shownDateOptions": {
+                  "validators": [
+                    {
+                      "type": "date"
+                    },
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "!isEmpty(cragTest) && isEmpty(myValue)",
+                      "message": "Date is result is required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(cragTest)"
+                  }
+                }
+              },
+              "type": "obs",
+              "validators": []
+            },
+            {
+              "label": "Cryptococcal treatment plan",
+              "type": "obs",
+              "questionOptions": {
+                "concept": "a89c2790-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a89b7908-1350-11df-a1f1-0026b9348838",
+                    "label": "Continue"
+                  },
+                  {
+                    "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "a89b77aa-1350-11df-a1f1-0026b9348838",
+                    "label": "Start"
+                  },
+                  {
+                    "concept": "a89b7d36-1350-11df-a1f1-0026b9348838",
+                    "label": "Stop"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(cryptCurrent) && !isEmpty(myValue) && !arrayContains(['a899e0ac-1350-11df-a1f1-0026b9348838','a89b77aa-1350-11df-a1f1-0026b9348838'],myValue)&&(cryptCurrent==='a899e0ac-1350-11df-a1f1-0026b9348838')",
+                  "message": "Patient marked as not on Cryptococcus Treatment. Therefore plan can only be none or start."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(cryptCurrent) && cryptCurrent === 'a8971e12-1350-11df-a1f1-0026b9348838' && !isEmpty(myValue) && arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a899e0ac-1350-11df-a1f1-0026b9348838'], myValue)",
+                  "message": "Patient marked as on crypto in history section. Therefore plan can only be continue regimen and stop."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(cragTest) && !isEmpty(myValue) && !arrayContains(['a89b77aa-1350-11df-a1f1-0026b9348838','a89b7908-1350-11df-a1f1-0026b9348838'],myValue)&&(cragTest==='a896f3a6-1350-11df-a1f1-0026b9348838')",
+                  "message": "Crag test is positive. Therefore patient should be on crypto."
+                }
+              ],
+              "id": "__vxDFqIuGs"
+            }
+          ]
+        },
+        {
+          "label": "Additional Medication Orders",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Additional medication orders",
+              "questionOptions": {
+                "rendering": "repeating",
+                "concept": "a8a0654e-1350-11df-a1f1-0026b9348838"
+              },
+              "questions": [
+                {
+                  "label": "Drug",
+                  "questionOptions": {
+                    "concept": "a8a060c6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "drug"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "id": "__xFuGyGqwt"
+                },
+                {
+                  "label": "Frequency",
+                  "questionOptions": {
+                    "concept": "a8a06184-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "label": "Once a day",
+                        "concept": "a8a05dc4-1350-11df-a1f1-0026b9348838"
+                      },
+                      {
+                        "label": "Twice a day",
+                        "concept": "a8a05aea-1350-11df-a1f1-0026b9348838"
+                      },
+                      {
+                        "label": "Three times a day",
+                        "concept": "a8a05b9e-1350-11df-a1f1-0026b9348838"
+                      },
+                      {
+                        "label": "Four times a day",
+                        "concept": "a8a05cfc-1350-11df-a1f1-0026b9348838"
+                      },
+                      {
+                        "label": "As needed",
+                        "concept": "9c1dcb23-dc0c-46b2-a755-875ab6d78fc2"
+                      },
+                      {
+                        "label": "Other",
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "id": "__ysvKpHHEI"
+                },
+                {
+                  "label": "If tabs, number",
+                  "questionOptions": {
+                    "concept": "a8a0630a-1350-11df-a1f1-0026b9348838",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "id": "__w0txvvuII"
+                },
+                {
+                  "label": "If caps, number",
+                  "questionOptions": {
+                    "concept": "ea404923-fe2b-4812-aec5-3be7fbe712f7",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "id": "__MMwGowJIo"
+                },
+                {
+                  "label": "If mg, number",
+                  "questionOptions": {
+                    "concept": "a8a063c8-1350-11df-a1f1-0026b9348838",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "id": "__t3nHMD5EL"
+                },
+                {
+                  "label": "If ml, number",
+                  "questionOptions": {
+                    "concept": "a8a08286-1350-11df-a1f1-0026b9348838",
+                    "rendering": "number"
+                  },
+                  "type": "obs",
+                  "id": "__EvyGDouC2"
+                }
+              ],
+              "id": "__EyHsyzsFw"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Plan",
+      "sections": [
+        {
+          "label": "Family Planning Plan",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Dispense condom today?",
+              "id": "condomDispensed",
+              "questionOptions": {
+                "concept": "a8b034d8-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','55c74fa8-c810-4b37-a918-14a851bba6f3','44032888-08e1-4900-b9dd-7d236d79276c'], visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Continue modern contraception method?",
+              "id": "contCurrentFP",
+              "questionOptions": {
+                "concept": "9bd08995-617e-407a-bf5d-79f29fbdb289",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "!isEmpty(fpMethod) && isEmpty(myValue) && arrayContains(['a8a713f8-1350-11df-a1f1-0026b9348838', 'a123d949-31f3-4abf-98e3-8504e17ebc00', 'feb48308-a56f-4754-8e8f-8c1698e570cb', 'f8c66a32-3660-4233-ae51-d3a4a1eac44e', '236dba53-1062-46b4-8067-ec8711897dbf', 'a8988b44-1350-11df-a1f1-0026b9348838', 'a897dbd6-1350-11df-a1f1-0026b9348838', 'eaa5796d-0b1c-478b-8c9d-d23cf4c3bddc'], fpMethod)",
+                  "message": "Based on modern contraception method selected, you must answer this question."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || fpMethod === 'a899e0ac-1350-11df-a1f1-0026b9348838' || arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','53b856ad-21ef-4745-9acd-81aca01bba31','44032888-08e1-4900-b9dd-7d236d79276c','55c74fa8-c810-4b37-a918-14a851bba6f3'],visitTypeUuid)"
+              }
+            },
+            {
+              "label": "Does patient wish to start modern contraception method?",
+              "id": "famPlanningPlan",
+              "questionOptions": {
+                "concept": "d1d7056f-42ed-4948-b04f-ef6146c789be",
+                "answers": [
+                  {
+                    "concept": "a899b35c-1350-11df-a1f1-0026b9348838",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a899b42e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(contCurrentFP) && contCurrentFP !== 'a899b35c-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient does not wish to continue with modern contraception method. Please indicate if they wish to start."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "isEmpty(contCurrentFP) && fpMethod !== 'a899e0ac-1350-11df-a1f1-0026b9348838' || contCurrentFP === 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            },
+            {
+              "label": "If yes, modern contraception method chosen:",
+              "id": "famPlanChosen",
+              "questionOptions": {
+                "concept": "2d55cabe-a778-40a3-9b85-613889037a11",
+                "answers": [
+                  {
+                    "concept": "a8a713f8-1350-11df-a1f1-0026b9348838",
+                    "label": "Bilateral tubal ligation"
+                  },
+                  {
+                    "concept": "a123d949-31f3-4abf-98e3-8504e17ebc00",
+                    "label": "3-year implant"
+                  },
+                  {
+                    "concept": "feb48308-a56f-4754-8e8f-8c1698e570cb",
+                    "label": "5-year implant"
+                  },
+                  {
+                    "concept": "f8c66a32-3660-4233-ae51-d3a4a1eac44e",
+                    "label": "IUCD copper"
+                  },
+                  {
+                    "concept": "236dba53-1062-46b4-8067-ec8711897dbf",
+                    "label": "IUCD hormonal"
+                  },
+                  {
+                    "concept": "a8988b44-1350-11df-a1f1-0026b9348838",
+                    "label": "Injectables (Depo)"
+                  },
+                  {
+                    "concept": "a8aff1b2-1350-11df-a1f1-0026b9348838",
+                    "label": "Combined hormone oral contraceptive pills"
+                  },
+                  {
+                    "concept": "a8afeb54-1350-11df-a1f1-0026b9348838",
+                    "label": "Projestin only pills"
+                  },
+                  {
+                    "concept": "eaa5796d-0b1c-478b-8c9d-d23cf4c3bddc",
+                    "label": "Vasectomy"
+                  },
+                  {
+                    "concept": "4a740e33-fee5-4a2b-b679-1904722e3d9e",
+                    "label": "Lactational amenohhrea method"
+                  },
+                  {
+                    "concept": "a8a71588-1350-11df-a1f1-0026b9348838",
+                    "label": "Diaphram/Cervical cap"
+                  },
+                  {
+                    "concept": "b75702a6-908d-491b-9399-6495712c81cc",
+                    "label": "Emergency contraceptive pills"
+                  },
+                  {
+                    "concept": "a8aff284-1350-11df-a1f1-0026b9348838",
+                    "label": "Periodic abstinence"
+                  },
+                  {
+                    "concept": "856a7f0d-8359-4316-97c1-2d37813414f0",
+                    "label": "Undecided"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(famPlanningPlan) && famPlanningPlan === 'a899b35c-1350-11df-a1f1-0026b9348838'",
+                  "message": "Patient wishes to start modern contraception method. Please choose method."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "famPlanningPlan!== 'a899b35c-1350-11df-a1f1-0026b9348838'"
+              }
+            }
+          ]
+        },
+        {
+          "label": "DC Outcome",
+          "questions": [
+            {
+              "label": "Differentiated care plan:",
+              "required": "true",
+              "id": "dcCarePlan",
+              "questionOptions": {
+                "concept": "59f21b48-ccf9-40b8-9fcb-92bdbf90a4dd",
+                "answers": [
+                  {
+                    "concept": "a8af5018-1350-11df-a1f1-0026b9348838",
+                    "label": "Continue in DC"
+                  },
+                  {
+                    "concept": "a8af50f4-1350-11df-a1f1-0026b9348838",
+                    "label": "Exit from DC"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "!arrayContains(['380d79a7-6fb0-41bf-be3d-aa3d25da187c','d4e28d0f-ae28-4eec-8cfc-449b4c5a9f5f'],visitTypeUuid)"
+              }
+            },
+            {
+              "type": "obsGroup",
+              "label": "Reason for exit",
+              "questionOptions": {
+                "concept": "3665d0ef-3718-47b2-9091-8b685bda412d",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Reason for exit:",
+                  "id": "dcExit",
+                  "questionOptions": {
+                    "concept": "a89e3f94-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "6daff4ce-bce7-41f5-9141-17e694155180",
+                        "label": "Self transfer out of facility"
+                      },
+                      {
+                        "concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
+                        "label": "Adherence concerns"
+                      },
+                      {
+                        "concept": "a8ce0d44-8cd4-4eb0-9441-dd27cc328caf",
+                        "label": "High VL"
+                      },
+                      {
+                        "concept": "a89ac184-1350-11df-a1f1-0026b9348838",
+                        "label": "New OI/new chronic illness"
+                      },
+                      {
+                        "concept": "a8909e8e-1350-11df-a1f1-0026b9348838",
+                        "label": "Pregnancy"
+                      },
+                      {
+                        "concept": "5be50fc2-9e50-4d64-8a0c-f08ed7a34bb9",
+                        "label": "Voluntary request to exit"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "multiCheckbox"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(dcCarePlan) || dcCarePlan !== 'a8af50f4-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "label": "Other specify:",
+                  "id": "dcOther",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(dcExit) || !arrayContains(dcExit, 'a8aaf3e2-1350-11df-a1f1-0026b9348838')"
+                  }
+                }
+              ],
+              "id": "__xG3qDqIpq"
+            }
+          ]
+        },
+        {
+          "label": "Test Orders",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Test orders",
+              "questionOptions": {
+                "concept": "af46861e-597a-48a3-b3d4-a134d0b1c5fa",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Tests Ordered",
+                  "id": "order1",
+                  "type": "testOrder",
+                  "questionOptions": {
+                    "rendering": "repeating",
+                    "orderSettingUuid": "6f0c9a92-6f24-11e3-af88-005056821db0",
+                    "orderType": "testorder",
+                    "selectableOrders": [
+                      {
+                        "concept": "a8982474-1350-11df-a1f1-0026b9348838",
+                        "label": "Viral load"
+                      },
+                      {
+                        "concept": "a896cce6-1350-11df-a1f1-0026b9348838",
+                        "label": "CD4"
+                      },
+                      {
+                        "concept": "7243bed9-0bc7-4702-af28-a06ab1981e19",
+                        "label": "Crag test"
+                      },
+                      {
+                        "concept": "57677735-4310-4841-8902-dae4bac24d20",
+                        "label": "DST"
+                      },
+                      {
+                        "concept": "a898fe80-1350-11df-a1f1-0026b9348838",
+                        "label": "HIV DNA PCR "
+                      },
+                      {
+                        "concept": "a8908192-1350-11df-a1f1-0026b9348838",
+                        "label": "CXR"
+                      },
+                      {
+                        "concept": "a8945d4e-1350-11df-a1f1-0026b9348838",
+                        "label": "Sputum AFB"
+                      },
+                      {
+                        "concept": "a897e450-1350-11df-a1f1-0026b9348838",
+                        "label": "Creatinine"
+                      },
+                      {
+                        "concept": "a898f50c-1350-11df-a1f1-0026b9348838",
+                        "label": "CBC"
+                      },
+                      {
+                        "concept": "a896ca48-1350-11df-a1f1-0026b9348838",
+                        "label": "SGPT(ALT)"
+                      },
+                      {
+                        "concept": "a896c8ae-1350-11df-a1f1-0026b9348838",
+                        "label": "AST"
+                      },
+                      {
+                        "concept": "a8970a26-1350-11df-a1f1-0026b9348838",
+                        "label": " CD4 %"
+                      },
+                      {
+                        "concept": "a8999fb6-1350-11df-a1f1-0026b9348838",
+                        "label": "Elisa"
+                      },
+                      {
+                        "concept": "a8999dfe-1350-11df-a1f1-0026b9348838",
+                        "label": "Rapid HIV "
+                      },
+                      {
+                        "concept": "a8a47094-1350-11df-a1f1-0026b9348838",
+                        "label": "TB PCR "
+                      },
+                      {
+                        "concept": "741517cf-8bac-4755-b289-8dd2a2df7962",
+                        "label": "Gene Xpert"
+                      },
+                      {
+                        "concept": "a8908a16-1350-11df-a1f1-0026b9348838",
+                        "label": "Hgb"
+                      },
+                      {
+                        "concept": "a8a462a2-1350-11df-a1f1-0026b9348838",
+                        "label": "TB Culture"
+                      },
+                      {
+                        "concept": "a8945678-1350-11df-a1f1-0026b9348838",
+                        "label": "VDRL"
+                      },
+                      {
+                        "concept": "a894590c-1350-11df-a1f1-0026b9348838",
+                        "label": "Urinalysis"
+                      },
+                      {
+                        "concept": "a8af7520-1350-11df-a1f1-0026b9348838",
+                        "label": "HbA1C"
+                      },
+                      {
+                        "concept": "7129af13-e39a-43b0-9923-6d1de22c9c5e",
+                        "label": "Microalbumin"
+                      },
+                      {
+                        "concept": "a89a7418-1350-11df-a1f1-0026b9348838",
+                        "label": "Potassium"
+                      },
+                      {
+                        "concept": "a89dda72-1350-11df-a1f1-0026b9348838",
+                        "label": "ECGn"
+                      },
+                      {
+                        "concept": "a89dd9aa-1350-11df-a1f1-0026b9348838",
+                        "label": "Echo"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "label": "Test ordered: Other (specify):",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "id": "__wKIqwxMvx"
+                },
+                {
+                  "label": "Viral load justification:",
+                  "type": "obs",
+                  "id": "vljust",
+                  "questionOptions": {
+                    "concept": "0a98f01f-57f1-44b7-aacf-e1121650a967",
+                    "rendering": "select",
+                    "answers": [
+                      {
+                        "concept": "5931c4d4-4406-4d71-b75d-2205d905cc24",
+                        "label": "Routine VL"
+                      },
+                      {
+                        "concept": "e43ddeb6-3984-499c-a280-3bade1039608",
+                        "label": "Confirmation of treatment failure (repeat VL)"
+                      },
+                      {
+                        "concept": "a8981934-1350-11df-a1f1-0026b9348838",
+                        "label": "Clinical failure"
+                      },
+                      {
+                        "concept": "a8a00158-1350-11df-a1f1-0026b9348838",
+                        "label": "Single drug substitution"
+                      },
+                      {
+                        "concept": "3966e139-ca69-47c6-aad3-ebd41bb45e28",
+                        "label": "Baseline VL (for infants diagnsed through EID)"
+                      },
+                      {
+                        "concept": "42cdefa2-c306-4d10-a819-c04131c4934e",
+                        "label": "Confirmation of persistent low level viremia (PLLV)"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ]
+                  },
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "isEmpty(myValue) && !(isEmpty(order1) || !arrayContains(order1, 'a8982474-1350-11df-a1f1-0026b9348838'))",
+                      "message": "Viral load required."
+                    }
+                  ],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(order1) || !arrayContains(order1, 'a8982474-1350-11df-a1f1-0026b9348838')"
+                  }
+                },
+                {
+                  "label": "PMTCT patient category:",
+                  "required": "true",
+                  "type": "obs",
+                  "id": "patCategory1",
+                  "questionOptions": {
+                    "concept": "a89eea66-1350-11df-a1f1-0026b9348838",
+                    "rendering": "select",
+                    "answers": [
+                      {
+                        "concept": "a89d109c-1350-11df-a1f1-0026b9348838",
+                        "label": "Pregnant"
+                      },
+                      {
+                        "concept": "a8a18208-1350-11df-a1f1-0026b9348838",
+                        "label": "Breastfeeding"
+                      },
+                      {
+                        "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                        "label": "None of the above"
+                      }
+                    ]
+                  },
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "(!arrayContains(['02e3ce61-fa24-445e-a1f0-6e3299142966','0b1b6194-d2d5-4e4b-9f7c-c3b778ccc354','42de8e7e-24b2-4c16-b62b-137eb2c55ede','b1a978ca-9315-4ba2-ac2b-84efb9a68c5c','53954785-4d53-4012-8f30-1c37fa870906','53b856ad-21ef-4745-9acd-81aca01bba31'],visitTypeUuid)) || (isEmpty(order1) || !arrayContains(order1, 'a8982474-1350-11df-a1f1-0026b9348838'))"
+                  }
+                }
+              ],
+              "id": "__uJHpvsG95"
+            }
+          ]
+        },
+        {
+          "label": "Positive Health Diginity & Prevention Services",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "PHDP:",
+              "required": "true",
+              "questionOptions": {
+                "concept": "e7819751-a5b0-485d-a2bc-9d4aa69aa1e4",
+                "answers": [
+                  {
+                    "concept": "a8a8b352-1350-11df-a1f1-0026b9348838",
+                    "label": "Adherence counselling"
+                  },
+                  {
+                    "concept": "b76021d2-38c7-42ff-b2eb-0bd558396ef7",
+                    "label": "STI screening"
+                  },
+                  {
+                    "concept": "a2c49302-edb4-4baa-8440-2448eafd0ec1",
+                    "label": "Substance use"
+                  },
+                  {
+                    "concept": "a89accc4-1350-11df-a1f1-0026b9348838",
+                    "label": "Disclosure to sex partner"
+                  },
+                  {
+                    "concept": "a8a4636a-1350-11df-a1f1-0026b9348838",
+                    "label": "Partner testing"
+                  },
+                  {
+                    "concept": "f0a280e8-eb88-41a8-837a-f9949ed1b9cd",
+                    "label": "Condom distribution"
+                  },
+                  {
+                    "concept": "91f43249-73c7-427c-8300-2038fc0d6be8",
+                    "label": "Needle exchange"
+                  },
+                  {
+                    "concept": "05656545-86be-4605-9527-34fb580534b1",
+                    "label": "Targeted risk reduction"
+                  },
+                  {
+                    "concept": "a89adc46-1350-11df-a1f1-0026b9348838",
+                    "label": "Treatment of GBV injuries"
+                  },
+                  {
+                    "concept": "717c50e1-48da-4148-aeee-c49fdd957b64",
+                    "label": "First line support (LIVES)"
+                  },
+                  {
+                    "concept": "b75702a6-908d-491b-9399-6495712c81cc",
+                    "label": "Emergency contraceptives"
+                  },
+                  {
+                    "concept": "a89ad3a4-1350-11df-a1f1-0026b9348838",
+                    "label": "N/A"
+                  }
+                ],
+                "rendering": "multiCheckbox"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": " !arrayContains(['d164c76c-cc91-4ac2-89e9-ab7c29152ee0','824cf3e6-dd16-4767-ba41-2e04dede349e'], visitType.uuid)"
+              },
+              "id": "__FHtz9nGGy"
+            }
+          ]
+        },
+        {
+          "label": "Referrals",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Referrals",
+              "questionOptions": {
+                "concept": "a8a07c8c-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Referrals made to the patient:",
+                  "id": "referrals",
+                  "questionOptions": {
+                    "concept": "a89c2344-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a899e0ac-1350-11df-a1f1-0026b9348838",
+                        "label": "None"
+                      },
+                      {
+                        "concept": "a89fbb12-1350-11df-a1f1-0026b9348838",
+                        "label": "OVC"
+                      },
+                      {
+                        "concept": "a8a066ca-1350-11df-a1f1-0026b9348838",
+                        "label": "ENT"
+                      },
+                      {
+                        "concept": "a8a8b352-1350-11df-a1f1-0026b9348838",
+                        "label": "Adherence counselling"
+                      },
+                      {
+                        "concept": "a2187952-59e0-449b-895f-5102b7aed49c",
+                        "label": "Cardiology"
+                      },
+                      {
+                        "concept": "0fa18f9a-95c8-4ab3-81ed-a1bac69063fa",
+                        "label": "Diabetes"
+                      },
+                      {
+                        "concept": "a89accc4-1350-11df-a1f1-0026b9348838",
+                        "label": "Disclosure counselling"
+                      },
+                      {
+                        "concept": "057dae68-3d6f-4d79-926c-ed75a0ce7fd5",
+                        "label": "Hospitalization"
+                      },
+                      {
+                        "concept": "073ea366-834b-49bd-b4db-ce4e6c61bbc3",
+                        "label": "Oncology"
+                      },
+                      {
+                        "concept": "a8a8b42e-1350-11df-a1f1-0026b9348838",
+                        "label": "Mental health services"
+                      },
+                      {
+                        "concept": "a8a8afd8-1350-11df-a1f1-0026b9348838",
+                        "label": "Nutritional support"
+                      },
+                      {
+                        "concept": "a89e2df6-1350-11df-a1f1-0026b9348838",
+                        "label": "Psychosocial support"
+                      },
+                      {
+                        "concept": "a8a8b26c-1350-11df-a1f1-0026b9348838",
+                        "label": "TB/DOT program"
+                      },
+                      {
+                        "concept": "c65fcd72-1f3f-4450-b93f-90a87ae64d55",
+                        "label": "Surgery"
+                      },
+                      {
+                        "concept": "0d516ea7-218f-43d4-b5c0-58d126529271",
+                        "label": "Dermatology"
+                      },
+                      {
+                        "concept": "a89e2d1a-1350-11df-a1f1-0026b9348838",
+                        "label": "Social work"
+                      },
+                      {
+                        "concept": "7c6f0599-3e3e-4f42-87a2-2ce66f1e96d0",
+                        "label": "Differentiated care program"
+                      },
+                      {
+                        "concept": "a8a06788-1350-11df-a1f1-0026b9348838",
+                        "label": "Ophthalmology "
+                      },
+                      {
+                        "concept": "a8a002e8-1350-11df-a1f1-0026b9348838",
+                        "label": "Reproductive health "
+                      },
+                      {
+                        "concept": "a9431295-9862-405b-b694-534f093ca0ad",
+                        "label": "MDT Program"
+                      },
+                      {
+                        "concept": "7c941f38-ede1-4a94-938f-6c4083339673",
+                        "label": "Resistant clinic"
+                      },
+                      {
+                        "concept": "355b199f-c9c7-4e91-831f-2be17d2c67bd",
+                        "label": "Legal counsel"
+                      },
+                      {
+                        "concept": "5fc2555b-cae1-4bb8-9cd8-e19c2c04fc37",
+                        "label": "Police department"
+                      },
+                      {
+                        "concept": "5a089407-22df-4242-99d8-0b4d4da56b75",
+                        "label": "Child protection services"
+                      },
+                      {
+                        "concept": "a8b02e16-1350-11df-a1f1-0026b9348838",
+                        "label": "Emergency shelter"
+                      },
+                      {
+                        "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                        "label": "Other"
+                      }
+                    ],
+                    "rendering": "multiCheckbox"
+                  },
+                  "type": "obs",
+                  "validators": []
+                },
+                {
+                  "label": "Referrals made to the patient: Other (specify):",
+                  "questionOptions": {
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
+                    "rendering": "text"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "referrals !== 'a8aaf3e2-1350-11df-a1f1-0026b9348838'"
+                  },
+                  "id": "__sut7DsFDD"
+                }
+              ],
+              "id": "__npuq2nDsH"
+            },
+            {
+              "label": "If referred for hospitalization, choose location:",
+              "questionOptions": {
+                "concept": "a89c2420-1350-11df-a1f1-0026b9348838",
+                "answers": [
+                  {
+                    "concept": "a89c25d8-1350-11df-a1f1-0026b9348838",
+                    "label": "Local health centre/hospital"
+                  },
+                  {
+                    "concept": "a89c24fc-1350-11df-a1f1-0026b9348838",
+                    "label": "MTRH"
+                  },
+                  {
+                    "concept": "a8aaf3e2-1350-11df-a1f1-0026b9348838",
+                    "label": "Other"
+                  }
+                ],
+                "rendering": "select"
+              },
+              "type": "obs",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "isEmpty(referrals) || !arrayContains(referrals, '057dae68-3d6f-4d79-926c-ed75a0ce7fd5')"
+              },
+              "id": "__ynFwE4KwM"
+            },
+            {
+              "label": "Reason  for hospitalization",
+              "type": "obsGroup",
+              "questionOptions": {
+                "concept": "a8a07c8c-1350-11df-a1f1-0026b9348838",
+                "rendering": "repeating"
+              },
+              "questions": [
+                {
+                  "label": "Reason for hospitalization:",
+                  "questionOptions": {
+                    "concept": "a8a07a48-1350-11df-a1f1-0026b9348838",
+                    "rendering": "problem"
+                  },
+                  "type": "obs",
+                  "validators": [],
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(referrals) || !arrayContains(referrals, '057dae68-3d6f-4d79-926c-ed75a0ce7fd5')"
+                  },
+                  "id": "__t2tMtxDtD"
+                }
+              ],
+              "id": "__IJyILurpI"
+            }
+          ]
+        },
+        {
+          "label": "Transfer Out",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Transfer care to other centre",
+              "questionOptions": {
+                "concept": "a8a170e2-1350-11df-a1f1-0026b9348838",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Transfer care to other centre:",
+                  "id": "transferOut",
+                  "questionOptions": {
+                    "concept": "a89c2e5c-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "a89c2f42-1350-11df-a1f1-0026b9348838",
+                        "label": "AMPATH"
+                      },
+                      {
+                        "concept": "a89c301e-1350-11df-a1f1-0026b9348838",
+                        "label": "Non-AMPATH"
+                      },
+                      {
+                        "concept": "a8a17d80-1350-11df-a1f1-0026b9348838",
+                        "label": "MCH"
+                      }
+                    ],
+                    "rendering": "select"
+                  },
+                  "type": "obs",
+                  "validators": []
+                },
+                {
+                  "type": "personAttribute",
+                  "label": "Specify name of AMPATH clinic to which patient is being referred:",
+                  "id": "transfered_out_to_ampath",
+                  "required": "false",
+                  "questionOptions": {
+                    "rendering": "ui-select-extended",
+                    "attributeType": "8d87236c-c2cc-11de-8d13-0010c6dffd0f"
+                  },
+                  "hide": {
+                    "hideWhenExpression": "transferOut !== 'a89c2f42-1350-11df-a1f1-0026b9348838'"
+                  }
+                },
+                {
+                  "type": "obs",
+                  "label": "If Non-AMPATH specify where the patient is being referred:",
+                  "id": "transfered_out_to_non_ampath",
+                  "required": "false",
+                  "default": "",
+                  "questionOptions": {
+                    "rendering": "text",
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838"
+                  },
+                  "hide": {
+                    "hideWhenExpression": "transferOut !== 'a89c301e-1350-11df-a1f1-0026b9348838'"
+                  }
+                }
+              ],
+              "id": "__IvyopxLnJ"
+            }
+          ]
+        },
+        {
+          "label": "Next Appointment",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Medication pick up date:",
+              "type": "obs",
+              "id": "medDate",
+              "questionOptions": {
+                "concept": "318a5e8b-218c-4f66-9106-cd581dec1f95",
+                "rendering": "date",
+                "weeksList": [2, 4, 6, 8, 12, 16, 24, 36]
+              },
+              "validators": [
+                {
+                  "type": "date",
+                  "allowFutureDates": "true"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "(new moment(encDate)).isAfter((new moment(myValue)), 'day') || (new moment(encDate)).isSame((new moment(myValue)), 'day')",
+                  "message": "Medication pick up date should be greater than the encounter date."
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "isEmpty(myValue) && arrayContains (['7c6f0599-3e3e-4f42-87a2-2ce66f1e96d0'],referrals)",
+                  "message": "Patient referred for DC, medication pick up date should be required."
+                }
+              ],
+              "hide": {
+                "hideWhenExpression": "!((arrayContains( ['d4ac2aa5-2899-42fb-b08a-d40161815b48'], visitTypeUuid) && arrayContains (['7c6f0599-3e3e-4f42-87a2-2ce66f1e96d0'],referrals)) || (arrayContains( ['380d79a7-6fb0-41bf-be3d-aa3d25da187c','d4e28d0f-ae28-4eec-8cfc-449b4c5a9f5f'], visitTypeUuid)))"
+              }
+            },
+            {
+              "label": "Return to clinic date:",
+              "type": "obs",
+              "required": "true",
+              "id": "rtc",
+              "questionOptions": {
+                "concept": "a8a666ba-1350-11df-a1f1-0026b9348838",
+                "rendering": "date",
+                "weeksList": [2, 4, 6, 8, 12, 16, 20, 24, 36]
+              },
+              "validators": [
+                {
+                  "type": "date",
+                  "allowFutureDates": "true"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "(new moment(encDate)).isAfter((new moment(myValue)), 'day') || (new moment(encDate)).isSame((new moment(myValue)), 'day')",
+                  "message": "Return to clinic date should be greater than the encounter date."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -76,6 +76,10 @@ export class AppComponent implements OnInit {
       searchOptions: this.sampleSearch,
       resolveSelectedValue: this.sampleResolve
     });
+    this.dataSources.registerDataSource('diagnoses', {
+      searchOptions: this.sampleSearch,
+      resolveSelectedValue: this.sampleResolve
+    });
 
     const ds = {
       dataSourceOptions: { concept: undefined },

--- a/src/assets/carbon.select.theme.css
+++ b/src/assets/carbon.select.theme.css
@@ -82,7 +82,7 @@
 
 .ng-select .ng-select-container .ng-value-container {
   align-items: stretch;
-  padding: 0.4375em 0;
+  padding: 0;
   border-top: 0.84375em solid transparent;
 }
 
@@ -106,8 +106,7 @@
 }
 
 .ng-select.ng-select-single .ng-select-container .ng-clear-wrapper {
-  align-self: flex-end;
-  bottom: 7px;
+  align-self: center;
 }
 
 .ng-select.ng-select-multiple.ng-select-disabled

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,9 +266,9 @@
     yargs "^17.0.0"
 
 "@angular/compiler@^12.2.16":
-  version "12.2.16"
-  resolved "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.16.tgz"
-  integrity sha512-nsYEw+yu8QyeqPf9nAmG419i1mtGM4v8+U+S3eQHQFXTgJzLymMykWHYu2ETdjUpNSLK6xcIQDBWtWnWSfJjAA==
+  version "12.2.17"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-12.2.17.tgz#7b40330ed93420be751bfbfe1d4599ecda74996d"
+  integrity sha512-dxM1CxzvEJPk6ShJngkW5j5BejBloxQNi+fJi+F8P/GN/Rj7vJUf0JxL+TUt1+Iv575V4NidJDKKikk6K485CA==
   dependencies:
     tslib "^2.2.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,13 +1434,6 @@
   dependencies:
     tslib "^2.0.0"
 
-"@ngx-translate/http-loader@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz#041393ab5753f50ecf64262d624703046b8c7570"
-  integrity sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==
-  dependencies:
-    tslib "^2.0.0"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary
This PR gives us the ability when we want to disable a field, to have the possibility to chose not to reset its value.
This can be done throw the configuration using the prop  `resetValueOnDisable`. 

The development was made having in mind that the default behavior is for the value to be reset. So, if we have a field with the `disable` prop and we lack the `resetValueOnDisable` the input to be disabled will reset its value.


## Screenshots
<img width="405" alt="image" src="https://user-images.githubusercontent.com/106243905/217569104-82ed69a3-4f76-4a5a-8865-8fcee63a0187.png">



https://github.com/openmrs/openmrs-ngx-formentry/assets/106243905/824b0a04-2d46-4f9c-be0d-ee579c7e4ebd

As you can see the _datepicker_ has the normal behaviour, resets the value on disable, the others don't because of the changes made. 