### PR TITLE
(fix) Fix how we load the translation module

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@carbon/styles": "1.x",
     "@ng-select/ng-select": "^7.4.0",
     "@ngx-translate/core": "^13.0.0",
-    "@ngx-translate/http-loader": "^6.0.0",
     "core-js": "^2.5.4",
     "font-awesome": "^4.7.0",
     "hammerjs": "^2.0.8",

--- a/projects/ngx-formentry/package.json
+++ b/projects/ngx-formentry/package.json
@@ -9,6 +9,7 @@
     "@angular/compiler": ">=11.2.14 <=12.0.4",
     "@angular/core": ">=11.2.14 <=12.0.4",
     "@angular/forms": ">=11.2.14 <=12.0.4",
+    "@ngx-translate/core": "^13.0.0",
     "hammerjs": "^2.0.8",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -42,7 +42,6 @@ import { NgxTabSetModule } from '../components/ngx-tabset/modules/ngx-tabset.mod
 import { SelectModule as SelectModuleCarbon } from '../components/select/select.module';
 import { InputModule } from '../components/input/input.module';
 import { CustomControlWrapperModule } from '../components/custom-control-wrapper/custom-control-wrapper..module';
-import { LazyElementsModule } from '@angular-extensions/elements';
 import { CustomComponentWrapperModule } from '../components/custom-component-wrapper/custom-component-wrapper..module';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -66,7 +65,7 @@ import { TranslateModule } from '@ngx-translate/core';
     CustomControlWrapperModule,
     CustomComponentWrapperModule,
     NgxTabSetModule.forRoot(),
-    TranslateModule.forRoot()
+    TranslateModule
   ],
   declarations: [
     FormRendererComponent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,13 +1434,6 @@
   dependencies:
     tslib "^2.0.0"
 
-"@ngx-translate/http-loader@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz#041393ab5753f50ecf64262d624703046b8c7570"
-  integrity sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==
-  dependencies:
-    tslib "^2.0.0"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

Fixes how we load the ngx-translate module and removes the http-loader (since we load translations using a custom implementation).

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->

<img width="680" alt="Translated Form" src="https://user-images.githubusercontent.com/52504170/219081524-e39f45e4-120e-4e1d-83a8-b435b78d58b3.png">

## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
