### PR TITLE
(fix) fix `onIncrement` and `onDecrement` on number input when `max` and `min` value are absent

### DIFF
--- a/projects/ngx-formentry/src/components/number-input/number-input.component.ts
+++ b/projects/ngx-formentry/src/components/number-input/number-input.component.ts
@@ -93,11 +93,11 @@ export class NumberInputComponent implements ControlValueAccessor {
   /**
    * Sets the max length attribute on the `input` element.
    */
-   @Input() maxlength = null;
-   /**
+  @Input() maxlength = null;
+  /**
    * Sets the min length attribute on the `input` element.
    */
-    @Input() minlength = null;
+  @Input() minlength = null;
   /**
    * Sets the text inside the `label` tag.
    */
@@ -201,8 +201,13 @@ export class NumberInputComponent implements ControlValueAccessor {
 
     if (this.max === null || val + this.step <= this.max) {
       this.value = parseFloat((val + this.step).toPrecision(this.precision));
-    } else {
+    }
+
+    if (this.max && this.max > 0 && this.value > this.max) {
       this.value = this.max;
+    }
+    if (this.max === undefined || this.max === '') {
+      this.value = val + this.step;
     }
 
     this.emitChangeEvent();
@@ -216,8 +221,14 @@ export class NumberInputComponent implements ControlValueAccessor {
 
     if (this.min === null || val - this.step >= this.min) {
       this.value = parseFloat((val - this.step).toPrecision(this.precision));
-    } else {
+    }
+
+    if (this.min && this.min > 0 && this.value < this.min) {
       this.value = this.min;
+    }
+
+    if (this.min === undefined || this.min === '') {
+      this.value = val - this.step;
     }
 
     this.emitChangeEvent();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
At the moment when you try to increment a number where the min and max schema values haven't been set, the form engine doesn't increment the value. This PR adds ability to fix this edge case error. It also adds ability to start `inCrement` and `Decrement` on the set `max` and `min` values as defined from the schema.

## Screenshots
![Kapture 2023-03-26 at 12 30 40](https://user-images.githubusercontent.com/28008754/227766999-1d6616e4-2c59-4dd4-9837-a12cd7f5ff13.gif)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
