### PR TITLE
(fix) KH-141: Remote Select dropdown at the end of the form content should display above all content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,13 @@ On the patient chart repo cd into `esm-form-entry-app`
 
 While there, run `yarn link` + the path you copied earlier e.g `/Users/hadijahkyampeire/Desktop/openmrs-ngx-formentry/dist/ngx-formentry`.
 
-The above command should install the local copy of the form entry library into the `esm-form-entry` package. You can check that this worked by opening the `package.json` manifest file entry for `@openmrs/ngx-formentry`.
+The above command should install the local copy of the form entry library into the `esm-form-entry-app` package. You can check that this worked by opening the `package.json` manifest file entry for `@openmrs/ngx-formentry`.
 
-Run `$ yarn run start` in the `esm-form-entry-app` directory  to serve the library. This should fire up a dev server. 
-The key thing to note is that an override for the form entry import map URL is already set up on the dev server.
-Launch the patient chart and then you will be able to test your local changes on the `ngx-formentry repo`.
+When you start the form entry app, it should now be using the local copy of `openmrs-ngx-formentry`
+
+- The key thing to note is that an override for the form entry import map URL is already set up on the dev server.
+
+Launch the patient chart and then you will be able to test your local changes.
 
 Refer to this doc for detailed information [Ampath Forms docs](https://ampath-forms.vercel.app/docs/developer-guide/run-form-engine-in-openmrs3)
 

--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ Which is should be fine if your are not working on custom components (Make sure 
 ### Linking ngx-formentry with form-entry-app in patient chart
 While you have your patient chart and ngx-formentry repo open locally,
 Build the ngx-formentry project by 
-`$running npm run build:lib`
+running `$yarn run build:lib`
 
 Then cd into the `dist/ngx-formentry`  directory created from the previous step.
 Run `$ pwd | pbcopy` to copy that path.
 
 On the patient chart repo cd into `esm-form-entry-app`
 
-While there, run `yarn add + the path you copied earlier` e.g `/Users/hadijahkyampeire/Desktop/openmrs-ngx-formentry/dist/ngx-formentry`.
+While there, run `yarn link` + the path you copied earlier e.g `/Users/hadijahkyampeire/Desktop/openmrs-ngx-formentry/dist/ngx-formentry`.
 
-The above command should install the local copy of the `form entry` library into the `esm-form-entry`  package. You can check that this worked by opening the `package.json` manifest file entry for `@openmrs/ngx-formentry`.
+The above command should install the local copy of the form entry library into the `esm-form-entry` package. You can check that this worked by opening the `package.json` manifest file entry for `@openmrs/ngx-formentry`.
 
 Run `$ yarn run start` in the `esm-form-entry-app` directory  to serve the library. This should fire up a dev server. 
 The key thing to note is that an override for the form entry import map URL is already set up on the dev server.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ Which is should be fine if your are not working on custom components (Make sure 
 
 `$ yarn run build:lib`
 
+### Linking ngx-formentry with form-entry-app in patient chart
+While you have your patient chart and ngx-formentry repo open locally,
+Build the ngx-formentry project by 
+`$running npm run build:lib`
+
+Then cd into the `dist/ngx-formentry`  directory created from the previous step.
+Run `$ pwd | pbcopy` to copy that path.
+
+On the patient chart repo cd into `esm-form-entry-app`
+
+While there, run `yarn add + the path you copied earlier` e.g `/Users/hadijahkyampeire/Desktop/openmrs-ngx-formentry/dist/ngx-formentry`.
+
+The above command should install the local copy of the `form entry` library into the `esm-form-entry`  package. You can check that this worked by opening the `package.json` manifest file entry for `@openmrs/ngx-formentry`.
+
+Run `$ yarn run start` in the `esm-form-entry-app` directory  to serve the library. This should fire up a dev server. 
+The key thing to note is that an override for the form entry import map URL is already set up on the dev server.
+Launch the patient chart and then you will be able to test your local changes on the `ngx-formentry repo`.
+
+Refer to this doc for detailed information [Ampath Forms docs](https://ampath-forms.vercel.app/docs/developer-guide/run-form-engine-in-openmrs3)
+
 ### Usage
 
 `app.component.ts`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The above command should install the local copy of the form entry library into t
 
 When you start the form entry app, it should now be using the local copy of `openmrs-ngx-formentry`
 
-- The key thing to note is that an override for the form entry import map URL is already set up on the dev server.
+The key thing to note is that an override for the form entry import map URL is already set up on the dev server.
 
 Launch the patient chart and then you will be able to test your local changes.
 

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -6,7 +6,8 @@ import {
   ViewChild,
   Output,
   EventEmitter,
-  Renderer2
+  Renderer2,
+  ElementRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { concat, Observable, of, Subject } from 'rxjs';
@@ -43,12 +44,14 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
   loading = false;
   searchText = '';
   notFoundMsg = 'match no found';
-  public appendToBody: boolean = false;
   @Input() placeholder = 'Search...';
   @Input() componentID: string;
   @Input() disabled = false;
   @Input() theme = 'dark';
   @Output() done: EventEmitter<any> = new EventEmitter<any>();
+
+  private elmRef: ElementRef;
+  private appendToParentElement: boolean = false;
 
   private _dataSource: DataSource;
   @Input()
@@ -67,11 +70,13 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
   ngOnInit() {
     this.loadOptions();
     // check if there is enough space at the bottom of the ng-select component
-    const selectElement = document.querySelector('ng-select');
+    const selectElement = this.elmRef.nativeElement.querySelector('ng-select');
     const selectBoundingRect = selectElement.getBoundingClientRect();
-    const bottomSpace = window.innerHeight - selectBoundingRect.bottom;
+    const formElement = this.elmRef.nativeElement.closest('.cds--form-item'); // use closest() to find the closest ancestor matching the selector
+    const formBoundingRect = formElement.getBoundingClientRect();
+    const bottomSpace = formBoundingRect.bottom - selectBoundingRect.bottom;
     if (bottomSpace < 200) { // if less than 200px space at the bottom, set appendToBody to true
-      this.appendToBody = true;
+      this.appendToParentElement = true;
     }
   }
 

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -67,23 +67,18 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
     }
   }
 
-  constructor(private renderer: Renderer2,  private elementRef: ElementRef) {}
+  constructor(private renderer: Renderer2,  private elementRef: ElementRef<HTMLElement>) {}
 
   ngOnInit() {
     this.loadOptions();
-    const selectElement = this.elementRef.nativeElement as HTMLElement;
+    const selectElement = this.elementRef.nativeElement;
 
-    const formRoot = document.querySelector('my-app-root');
-    const ngFormRoot = document.querySelector('app-root');
+    const form = this.elementRef.nativeElement.closest("form");
 
     setTimeout(() => {
       const selectBoundingRect = selectElement.getBoundingClientRect();
-      if (formRoot !== null) {
-        const formRootBoundingRect = formRoot.getBoundingClientRect();
-        const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
-        this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
-      } else if (ngFormRoot) {
-        const formRootBoundingRect = ngFormRoot.getBoundingClientRect();
+      if (form !== null) {
+        const formRootBoundingRect = form.getBoundingClientRect();
         const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
         this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
       }

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -3,11 +3,9 @@ import {
   OnInit,
   Input,
   forwardRef,
-  ViewChild,
   Output,
   EventEmitter,
   Renderer2,
-  ElementRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { concat, Observable, of, Subject } from 'rxjs';
@@ -17,7 +15,6 @@ import {
   switchMap,
   tap
 } from 'rxjs/operators';
-import { NgSelectComponent } from '@ng-select/ng-select';
 import { SelectOption } from '../../form-entry/question-models/interfaces/select-option';
 
 import { DataSource } from '../../form-entry/question-models/interfaces/data-source';
@@ -49,10 +46,6 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
   @Input() disabled = false;
   @Input() theme = 'dark';
   @Output() done: EventEmitter<any> = new EventEmitter<any>();
-
-  private ngSelectElement: ElementRef;
-  private appendToParentElement: string;
-  @ViewChild(NgSelectComponent) mySelect: NgSelectComponent;
 
   private _dataSource: DataSource;
   @Input()

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -75,7 +75,14 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
     const selectBoundingRect = selectElement.getBoundingClientRect();
 
     const formRoot = document.querySelector('my-app-root');
-    const formRootBoundingRect = formRoot.getBoundingClientRect();
+    const ngFormRoot = document.querySelector('app-root');
+
+    if (formRoot) {
+      const formRootBoundingRect = formRoot.getBoundingClientRect();
+      const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
+      this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
+    }
+    const formRootBoundingRect = ngFormRoot.getBoundingClientRect();
     const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
     this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
   }

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -72,19 +72,22 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
   ngOnInit() {
     this.loadOptions();
     const selectElement = this.elementRef.nativeElement as HTMLElement;
-    const selectBoundingRect = selectElement.getBoundingClientRect();
 
     const formRoot = document.querySelector('my-app-root');
     const ngFormRoot = document.querySelector('app-root');
 
-    if (formRoot) {
-      const formRootBoundingRect = formRoot.getBoundingClientRect();
-      const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
-      this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
-    }
-    const formRootBoundingRect = ngFormRoot.getBoundingClientRect();
-    const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
-    this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
+    setTimeout(() => {
+      const selectBoundingRect = selectElement.getBoundingClientRect();
+      if (formRoot !== null) {
+        const formRootBoundingRect = formRoot.getBoundingClientRect();
+        const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
+        this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
+      } else if (ngFormRoot) {
+        const formRootBoundingRect = ngFormRoot.getBoundingClientRect();
+        const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
+        this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
+      }
+    });
   }
 
   subscribeToDataSourceDataChanges() {

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -13,7 +13,6 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { concat, Observable, of, Subject } from 'rxjs';
 import {
   catchError,
-  debounceTime,
   distinctUntilChanged,
   switchMap,
   tap
@@ -67,22 +66,10 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
     }
   }
 
-  constructor(private renderer: Renderer2,  private elementRef: ElementRef<HTMLElement>) {}
+  constructor(private renderer: Renderer2) {}
 
   ngOnInit() {
     this.loadOptions();
-    const selectElement = this.elementRef.nativeElement;
-
-    const form = this.elementRef.nativeElement.closest("form");
-
-    setTimeout(() => {
-      const selectBoundingRect = selectElement.getBoundingClientRect();
-      if (form !== null) {
-        const formRootBoundingRect = form.getBoundingClientRect();
-        const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
-        this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
-      }
-    });
   }
 
   subscribeToDataSourceDataChanges() {

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -18,6 +18,7 @@ import {
   switchMap,
   tap
 } from 'rxjs/operators';
+import { NgSelectComponent } from '@ng-select/ng-select';
 import { SelectOption } from '../../form-entry/question-models/interfaces/select-option';
 
 import { DataSource } from '../../form-entry/question-models/interfaces/data-source';
@@ -50,8 +51,9 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
   @Input() theme = 'dark';
   @Output() done: EventEmitter<any> = new EventEmitter<any>();
 
-  private elmRef: ElementRef;
-  private appendToParentElement: boolean = false;
+  private ngSelectElement: ElementRef;
+  private appendToParentElement: string;
+  @ViewChild(NgSelectComponent) mySelect: NgSelectComponent;
 
   private _dataSource: DataSource;
   @Input()
@@ -65,19 +67,17 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
     }
   }
 
-  constructor(private renderer: Renderer2) {}
+  constructor(private renderer: Renderer2,  private elementRef: ElementRef) {}
 
   ngOnInit() {
     this.loadOptions();
-    // check if there is enough space at the bottom of the ng-select component
-    const selectElement = this.elmRef.nativeElement.querySelector('ng-select');
+    const selectElement = this.elementRef.nativeElement as HTMLElement;
     const selectBoundingRect = selectElement.getBoundingClientRect();
-    const formElement = this.elmRef.nativeElement.closest('.cds--form-item'); // use closest() to find the closest ancestor matching the selector
-    const formBoundingRect = formElement.getBoundingClientRect();
-    const bottomSpace = formBoundingRect.bottom - selectBoundingRect.bottom;
-    if (bottomSpace < 200) { // if less than 200px space at the bottom, set appendToBody to true
-      this.appendToParentElement = true;
-    }
+
+    const formRoot = document.querySelector('my-app-root');
+    const formRootBoundingRect = formRoot.getBoundingClientRect();
+    const bottomSpace = formRootBoundingRect.bottom - selectBoundingRect.bottom;
+    this.appendToParentElement = (bottomSpace < 200) ? 'body' : null;
   }
 
   subscribeToDataSourceDataChanges() {

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -43,6 +43,7 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
   loading = false;
   searchText = '';
   notFoundMsg = 'match no found';
+  public appendToBody: boolean = false;
   @Input() placeholder = 'Search...';
   @Input() componentID: string;
   @Input() disabled = false;
@@ -65,6 +66,13 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
 
   ngOnInit() {
     this.loadOptions();
+    // check if there is enough space at the bottom of the ng-select component
+    const selectElement = document.querySelector('ng-select');
+    const selectBoundingRect = selectElement.getBoundingClientRect();
+    const bottomSpace = window.innerHeight - selectBoundingRect.bottom;
+    if (bottomSpace < 200) { // if less than 200px space at the bottom, set appendToBody to true
+      this.appendToBody = true;
+    }
   }
 
   subscribeToDataSourceDataChanges() {

--- a/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
@@ -13,6 +13,7 @@
     typeToSearchText="Please enter 2 or more characters"
     [typeahead]="remoteOptionInput$"
     [(ngModel)]="selectedRemoteOptions"
+    [appendTo]="'body'"
     (ngModelChange)="selected($event)"
   >
   </ng-select>

--- a/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
@@ -13,7 +13,7 @@
     typeToSearchText="Please enter 2 or more characters"
     [typeahead]="remoteOptionInput$"
     [(ngModel)]="selectedRemoteOptions"
-    [appendTo]="'body'"
+    [appendTo]="'app-root form'"
     (ngModelChange)="selected($event)"
   >
   </ng-select>

--- a/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
@@ -13,7 +13,7 @@
     typeToSearchText="Please enter 2 or more characters"
     [typeahead]="remoteOptionInput$"
     [(ngModel)]="selectedRemoteOptions"
-    [appendTo]="'my-app-fe-wrapper form'"
+    [appendTo]="'form'"
     (ngModelChange)="selected($event)"
   >
   </ng-select>

--- a/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
@@ -13,7 +13,7 @@
     typeToSearchText="Please enter 2 or more characters"
     [typeahead]="remoteOptionInput$"
     [(ngModel)]="selectedRemoteOptions"
-    [appendTo]="'app-root form'"
+    [appendTo]="'my-app-fe-wrapper form'"
     (ngModelChange)="selected($event)"
   >
   </ng-select>

--- a/projects/ngx-formentry/styles/ngx-formentry.css
+++ b/projects/ngx-formentry/styles/ngx-formentry.css
@@ -66,9 +66,6 @@
   background-color: #ffffff;
 }
 
-.ofe-remote-select.ng-select .ng-select-container {
-  background-color: green;
-}
 .ng-select .ng-select-container:after {
   border-bottom: 1px solid #8d8d8d;
   content: '';

--- a/projects/ngx-formentry/styles/ngx-formentry.css
+++ b/projects/ngx-formentry/styles/ngx-formentry.css
@@ -66,6 +66,9 @@
   background-color: #ffffff;
 }
 
+.ofe-remote-select.ng-select .ng-select-container {
+  background-color: green;
+}
 .ng-select .ng-select-container:after {
   border-bottom: 1px solid #8d8d8d;
   content: '';
@@ -229,8 +232,13 @@
 }
 
 .ng-dropdown-panel {
+  margin-top: -1rem;
   background: #fff;
   left: 0;
+}
+
+.ng-select > .ng-dropdown-panel {
+  margin-top: 0;
 }
 
 .ng-dropdown-panel.ng-select-bottom {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR fixes `ng-select` which is inside a `remote-select` and displays the dropdown panel above all content.

## Screenshots
- Before(Ngx-Formentry)
<img width="1440" alt="Screenshot 2023-04-11 at 22 29 33" src="https://user-images.githubusercontent.com/30952856/231273263-c7b7f9ba-db94-4169-8254-78b478a547bd.png">
- Dev3(Patient chart)
<img width="1440" alt="Screenshot 2023-04-14 at 02 16 53 (2)" src="https://user-images.githubusercontent.com/30952856/231903247-b49f3e3d-6866-4b9b-acda-96be657063d8.png">

- Fixed(Ngx-Formentry)
<img width="1440" alt="Screenshot 2023-04-11 at 22 28 39" src="https://user-images.githubusercontent.com/30952856/231273331-d8f887a9-f565-416c-8add-5a528ea22917.png">

- Fixed by this PR(Patient chart)
<img width="1440" alt="Screenshot 2023-04-14 at 02 13 18 (2)" src="https://user-images.githubusercontent.com/30952856/231903330-a5acf462-94ee-43bd-8afd-a024e90c16eb.png">

## Related Issue
- https://issues.openmrs.org/browse/KH-143

## Other
- After merging this we need to test it in the patient chart forms and see if it actually works.
