### PR TITLE
(fix) Display label concept instead of uuid when use previous value  on radio buttons

### DIFF
--- a/projects/ngx-formentry/src/components/radio-button/radio.component.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, forwardRef, OnInit } from '@angular/core';
+import { Component, Input, forwardRef, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
@@ -13,7 +13,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
     }
   ]
 })
-export class RadioButtonControlComponent implements ControlValueAccessor, OnInit {
+export class RadioButtonControlComponent implements ControlValueAccessor, OnInit, OnChanges {
   @Input() public id: String;
   @Input() public options: Array<any>;
   @Input() public selected: any;
@@ -24,14 +24,7 @@ export class RadioButtonControlComponent implements ControlValueAccessor, OnInit
 
   public ngOnInit() {
     this.options = this.options.map((opt) => ({ ...opt, checked: false }));
-
-    if (Boolean(this.selected)) {
-      const maybeOpt = this.options.find((opt) => opt.value === this.selected);
-      if (maybeOpt) {
-        Object.assign(maybeOpt, { checked: true });
-        this.value = this.selected;
-      }
-    }
+    this.updateSelectedOption();
   }
 
   public writeValue(value: any) {
@@ -80,4 +73,20 @@ export class RadioButtonControlComponent implements ControlValueAccessor, OnInit
 
   public onChange = (args) => {};
   public onTouched = () => {};
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.selected) {
+      this.updateSelectedOption();
+    }
+  }
+
+  private updateSelectedOption(): void {
+    if (this.selected) {
+      const maybeOpt = this.options.find(opt => opt.value === this.selected);
+      if (maybeOpt) {
+        this.options.forEach(opt => opt.checked = opt === maybeOpt);
+        this.value = this.selected;
+      }
+    }
+  }
 }

--- a/projects/ngx-formentry/src/form-entry/directives/historical-value.directive.ts
+++ b/projects/ngx-formentry/src/form-entry/directives/historical-value.directive.ts
@@ -55,7 +55,8 @@ export class HistoricalValueDirective {
         if (
           this._node.question.renderingType === 'select' ||
           this._node.question.renderingType === 'multi-select' ||
-          this._node.question.renderingType === 'single-select'
+          this._node.question.renderingType === 'single-select' ||
+          this._node.question.renderingType === 'radio' 
         ) {
           display.text = this.historicalFieldHelper.getDisplayTextFromOptions(
             this._node.question,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This pull request addresses an issue with the `Use Value` button in the `RadioButtonControlComponent`. Previously, when the `Use Value` button was clicked, it displayed the UUID of the previous value inserted, which was not user-friendly.

In this fix, I updated the `RadioButtonControlComponent` to display the label of the previous value instead of the UUID. This change enhances the usability of the component, making it easier for users to understand and interact with the form.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:

<img width="299" alt="image" src="https://user-images.githubusercontent.com/94977371/232460934-17c7392b-fc1d-4974-876d-d9b9b9929921.png">

Now:
![previous_value](https://user-images.githubusercontent.com/94977371/232461098-8ae7e988-349e-4637-a1fb-6489c6fe3eb1.gif)

Thanks,
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
