### PR TITLE
(fix) Fixed issue where checkboxes would lose pre-selected values upon form loading

### DIFF
--- a/projects/ngx-formentry/src/components/check-box/checkbox.component.ts
+++ b/projects/ngx-formentry/src/components/check-box/checkbox.component.ts
@@ -21,7 +21,7 @@ export class CheckboxControlComponent implements OnInit {
   public _value: Array<any> = [];
 
   public ngOnInit() {
-    this.selected = [];
+    this.selected = this.selected || [];
     this.options = this.options.map((option) => {
       if (this.selected.indexOf(option.value) !== -1) {
         Object.assign(option, { checked: true });
@@ -68,7 +68,7 @@ export class CheckboxControlComponent implements OnInit {
         return o !== option.value;
       });
     }
-    
+
     this._value = [...this.selected];
     this.onChange(this._value);
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
When editing an encounter, if there were observations saved using checkboxes within the form, the previously selected values were not appearing as checked. The observations were being saved correctly, the issue was that when opening the form, checkbox values were always reset to an empty array. 