### PR TITLE
(fix) KH-180: Fixed the min and max validator for number inputs to validate value 0

### DIFF
--- a/projects/ngx-formentry/src/form-entry/validators/max.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/max.validator.ts
@@ -3,8 +3,6 @@ import { AfeFormControl } from '../../abstract-controls-extension/afe-form-contr
 export class MaxValidator {
   validate(max: number) {
     return (control: AfeFormControl): { [key: string]: any } => {
-      console.log('maxValue', max, control.value, typeof control.value);
-
       if (control.hidden) {
         return null;
       }
@@ -14,7 +12,6 @@ export class MaxValidator {
       // Case 2: control.value is not a number:
       // if its empty string or null or undefined it will return false else it will pass through for validation
       if (typeof control.value === 'number' || control.value) {
-        console.log('in');
         const v: number = control.value;
         return v <= max
           ? null

--- a/projects/ngx-formentry/src/form-entry/validators/max.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/max.validator.ts
@@ -3,11 +3,18 @@ import { AfeFormControl } from '../../abstract-controls-extension/afe-form-contr
 export class MaxValidator {
   validate(max: number) {
     return (control: AfeFormControl): { [key: string]: any } => {
+      console.log('maxValue', max, control.value, typeof control.value);
+
       if (control.hidden) {
         return null;
       }
 
-      if (control.value && control.value.length !== 0) {
+      // Case 1: control.value is a number
+      // all the numbers should be passed for validation
+      // Case 2: control.value is not a number:
+      // if its empty string or null or undefined it will return false else it will pass through for validation
+      if (typeof control.value === 'number' || control.value) {
+        console.log('in');
         const v: number = control.value;
         return v <= max
           ? null

--- a/projects/ngx-formentry/src/form-entry/validators/min.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/min.validator.ts
@@ -3,8 +3,6 @@ import { AfeFormControl } from '../../abstract-controls-extension/afe-form-contr
 export class MinValidator {
   validate(min: number) {
     return (control: AfeFormControl): { [key: string]: any } => {
-      console.log('minValue', min, control.value, typeof control.value);
-
       if (control.hidden) {
         return null;
       }

--- a/projects/ngx-formentry/src/form-entry/validators/min.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/min.validator.ts
@@ -3,10 +3,17 @@ import { AfeFormControl } from '../../abstract-controls-extension/afe-form-contr
 export class MinValidator {
   validate(min: number) {
     return (control: AfeFormControl): { [key: string]: any } => {
+      console.log('minValue', min, control.value, typeof control.value);
+
       if (control.hidden) {
         return null;
       }
-      if (control.value && control.value.length !== 0) {
+
+      // Case 1: control.value is a number
+      // all the numbers should be passed for validation
+      // Case 2: control.value is not a number:
+      // if its empty string or null or undefined it will return false else it will pass through for validation
+      if (typeof control.value === 'number' || control.value) {
         const v: number = control.value;
         return v >= min
           ? null


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the min and max validators for number inputs to validate value 0.

This is tested out on form-entry-app.

## Screenshots
![image](https://github.com/openmrs/openmrs-ngx-formentry/assets/51502471/61c923fc-5dc0-45d8-849e-0005778eed9c)


## Related Issue
https://issues.openmrs.org/browse/KH-180

## Other
<!-- Anything not covered above -->
