### PR TITLE
(fix) Default to using the current date

### DIFF
--- a/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
@@ -152,6 +152,10 @@ export class EncounterAdapter implements ValueAdapter {
       );
     }
 
+    if (!payload.encounterDatetime) {
+      this.setPayloadEncounterDate(payload, form.valueProcessingInfo.encounterDatetime ?? new Date().toISOString(), form.valueProcessingInfo.utcOffset);
+    }
+
     if (form.valueProcessingInfo.formUuid) {
       this.setPayloadFormUuid(payload, form.valueProcessingInfo.formUuid);
     }
@@ -174,6 +178,13 @@ export class EncounterAdapter implements ValueAdapter {
 
   setPayloadEncounterTypeUuid(payload, encounterTypeUuid: string) {
     payload['encounterType'] = encounterTypeUuid;
+  }
+
+  setPayloadEncounterDate(payload, encounterDatetime: string, utcOffset: string) {
+    const dateValue = moment(encounterDatetime).utcOffset(
+      utcOffset || '+0300'
+    );
+    payload['encounterDatetime'] = dateValue.format();
   }
 
   setPayloadFormUuid(payload, formUuid: string) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This merge request is intended to resolve the issue with form saving. Currently, no form on the website can be saved because the encounterType is not being set in the request. While addressing this problem, I discovered that there is also an issue with encounterDatetime. This field is not being added as well, but these changes should rectify it.
Additionally, I found a problem where active visits, which are automatically created during application deployment, cannot work correctly with this date. When starting a visit manually, the date is set correctly, and everything starts working.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-2312

## Other
Should be merged with: https://github.com/openmrs/openmrs-esm-patient-chart/pull/1314
