### PR TITLE
(feat) O3-2312: Cannot Save Diagnoses in Form with encounter endpoint

### DIFF
--- a/projects/ngx-formentry/src/form-entry/value-adapters/diagnosis.adapter.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/diagnosis.adapter.spec.ts
@@ -1,19 +1,19 @@
-import {TestBed} from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 const adultForm = require('../../adult.json');
 const adultFormDiagnoses = require('../../mock/diagnoses.json');
-import {FormFactory} from '../../form-entry/form-factory/form.factory';
-import {FormControlService} from '../../form-entry/form-factory/form-control.service';
-import {ValidationFactory} from '../../form-entry/form-factory/validation.factory';
-import {QuestionFactory} from '../../form-entry/form-factory/question.factory';
-import {OrderValueAdapter} from './order.adapter';
-import {HidersDisablersFactory} from '../../form-entry/form-factory/hiders-disablers.factory';
-import {AlertsFactory} from '../form-factory/show-messages.factory';
-import {ExpressionRunner} from '../../form-entry/expression-runner/expression-runner';
-import {JsExpressionHelper} from '../../form-entry/helpers/js-expression-helper';
-import {ControlRelationsFactory} from '../../form-entry/form-factory/control-relations.factory';
-import {DebugModeService} from './../services/debug-mode.service';
-import {Diagnosis, DiagnosisValueAdapter} from './diagnosis.adapter';
+import { FormFactory } from '../../form-entry/form-factory/form.factory';
+import { FormControlService } from '../../form-entry/form-factory/form-control.service';
+import { ValidationFactory } from '../../form-entry/form-factory/validation.factory';
+import { QuestionFactory } from '../../form-entry/form-factory/question.factory';
+import { OrderValueAdapter } from './order.adapter';
+import { HidersDisablersFactory } from '../../form-entry/form-factory/hiders-disablers.factory';
+import { AlertsFactory } from '../form-factory/show-messages.factory';
+import { ExpressionRunner } from '../../form-entry/expression-runner/expression-runner';
+import { JsExpressionHelper } from '../../form-entry/helpers/js-expression-helper';
+import { ControlRelationsFactory } from '../../form-entry/form-factory/control-relations.factory';
+import { DebugModeService } from './../services/debug-mode.service';
+import { Diagnosis, DiagnosisValueAdapter } from './diagnosis.adapter';
 
 describe('Diagnosis Value Adapter', () => {
   let formFactory: FormFactory;
@@ -55,10 +55,10 @@ describe('Diagnosis Value Adapter', () => {
       diagnosis: {
         coded: {
           uuid: '116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-          display: 'Malarial Fever',
-        },
+          display: 'Malarial Fever'
+        }
       },
-      voided: false,
+      voided: false
     },
     {
       uuid: 'diagnosis-2-uuid5',
@@ -68,10 +68,10 @@ describe('Diagnosis Value Adapter', () => {
       diagnosis: {
         coded: {
           uuid: '113511AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-          display: 'Puerperal Fever',
-        },
+          display: 'Puerperal Fever'
+        }
       },
-      voided: false,
+      voided: false
     }
   ];
 
@@ -88,7 +88,8 @@ describe('Diagnosis Value Adapter', () => {
       let index = 0;
 
       for (const diagnosis of newDiagnoses) {
-        const node = diagnosisValueAdapter.formDiagnosisNodes[diagnosis.rank - 1];
+        const node =
+          diagnosisValueAdapter.formDiagnosisNodes[diagnosis.rank - 1];
         node.createChildNode();
         const value = {};
         value[node.question.key] = diagnosis.diagnosis.coded.uuid;
@@ -98,16 +99,52 @@ describe('Diagnosis Value Adapter', () => {
       }
 
       // Confirm controls where populated with data;
-      expect(diagnosisValueAdapter.formDiagnosisNodes[0].control.value[0].primaryDiagnosisId).toEqual('116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-      expect(diagnosisValueAdapter.formDiagnosisNodes[1].control.value[0].secondaryDiagnosisId).toEqual('113511AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+      expect(
+        diagnosisValueAdapter.formDiagnosisNodes[0].control.value[0]
+          .primaryDiagnosisId
+      ).toEqual('116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+      expect(
+        diagnosisValueAdapter.formDiagnosisNodes[1].control.value[0]
+          .secondaryDiagnosisId
+      ).toEqual('113511AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
 
       // Confirm payload was generated;
-      const payload = diagnosisValueAdapter.generateFormPayload(form);
-      expect(payload.find(p => p.diagnosis.coded == '116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')).toBeTruthy();
-      expect(payload.find(p => p.diagnosis.coded == '113511AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')).toBeTruthy();
+      const payload = diagnosisValueAdapter.generateFormPayload(
+        form,
+        'some-encounterUuid'
+      );
+      expect(
+        payload.find(
+          (p) => p.diagnosis.coded == '116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+        )
+      ).toBeTruthy();
+      expect(
+        payload.find(
+          (p) => p.diagnosis.coded == '113511AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+        )
+      ).toBeTruthy();
+
+      // Confirm payload has correct values
+      expect(payload[0]).toEqual({
+        diagnosis: {
+          coded: '116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+        },
+        certainty: 'CONFIRMED',
+        rank: 1,
+        voided: false,
+        encounter: 'some-encounterUuid',
+        uuid: null,
+        condition: null
+      });
 
       // Confirm deleted diagnoses were added to the payload
-      expect(payload.find(p => p.diagnosis.coded == '5945AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && p.voided)).toBeTruthy();
+      expect(
+        payload.find(
+          (p) =>
+            p.diagnosis.coded == '5945AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' &&
+            p.voided
+        )
+      ).toBeTruthy();
     });
   });
 
@@ -116,12 +153,17 @@ describe('Diagnosis Value Adapter', () => {
       const form = formFactory.createForm(adultForm);
       diagnosisValueAdapter.populateForm(form, adultFormDiagnoses.diagnoses);
 
-      expect(diagnosisValueAdapter.formDiagnosisNodes.filter(n => {
-          return n.control.value.find(v => {
-            return v.secondaryDiagnosisId == '5945AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && v.secondaryDiagnosisId.display == 'FEVER';
+      expect(
+        diagnosisValueAdapter.formDiagnosisNodes.filter((n) => {
+          return n.control.value.find((v) => {
+            return (
+              v.secondaryDiagnosisId ==
+                '5945AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' &&
+              v.secondaryDiagnosisId.display == 'FEVER'
+            );
           });
-        }
-      )).toBeTruthy();
+        })
+      ).toBeTruthy();
     });
   });
 });

--- a/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.spec.ts
@@ -250,9 +250,5 @@ describe('Encounter Value Adapter:', () => {
 
     // check that it generated orders payload
     expect(payload['orders'].length > 0).toBe(true);
-
-    // check that it generated orders payload
-    expect(payload['diagnoses'].find(d => d.diagnosis.coded == '116125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')).toBeTruthy();
-    expect(payload['diagnoses'].find(d => d.diagnosis.coded == '5945AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')).toBeTruthy();
   });
 });

--- a/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
@@ -86,7 +86,6 @@ export class EncounterAdapter implements ValueAdapter {
 
     payload['orders'] = this.ordersAdapter.generateFormPayload(form) || [];
 
-    payload['diagnoses'] = this.diagnosesAdapter.generateFormPayload(form) || [];
 
     return payload;
   }

--- a/projects/ngx-formentry/src/lib/index.ts
+++ b/projects/ngx-formentry/src/lib/index.ts
@@ -59,4 +59,6 @@ export { ErrorRendererComponent } from '../form-entry/error-renderer/error-rende
 export { DatePickerComponent } from '../components/date-time-picker';
 export { TimePickerComponent } from '../components/date-time-picker';
 export { MomentPipe } from '../components/date-time-picker';
-export { PatientIdentifierAdapter } from "../form-entry/value-adapters/patient-identifier.adapter"
+export { PatientIdentifierAdapter } from '../form-entry/value-adapters/patient-identifier.adapter';
+export { DiagnosisValueAdapter } from '../form-entry/value-adapters/diagnosis.adapter';
+export { DiagnosisPayload } from '../form-entry/value-adapters/diagnosis.adapter';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -384,7 +384,7 @@ export class AppComponent implements OnInit {
     };
     if (this.form.valid) {
       this.form.showErrors = false;
-      // const payload = this.encAdapter.generateFormPayload(this.form);
+      const payload = this.encAdapter.generateFormPayload(this.form);
 
       // Alternative is to populate for each as shown below
       // // generate obs payload


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Previously, when saving diagnoses via the encounter endpoint, the data was not persisting properly. This PR addresses this issue by adapting the diagnosis adapter to generate the appropriate payload format. With this change, diagnoses will now be saved consistently using the patientdiagnosis endpoint

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
