### PR TITLE
i18n - Add TranslateModule to testBed

### DIFF
--- a/projects/ngx-formentry/src/form-entry/value-adapters/patient-identifier.adapter.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/patient-identifier.adapter.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
 import { FormFactory } from '../form-factory/form.factory';
 import { FormControlService } from '../form-factory/form-control.service';
 import { ValidationFactory } from '../form-factory/validation.factory';
@@ -19,6 +20,9 @@ describe('Patient identifier Value Adapter:', () => {
     beforeEach(() => {
         adultFormSchema = JSON.parse(JSON.stringify(adultForm));
         TestBed.configureTestingModule({
+            imports: [TranslateModule.forRoot({
+                defaultLanguage: 'en',
+            })],
             providers: [
                 FormFactory,
                 FormControlService,


### PR DESCRIPTION
This PR contains the development done here: https://github.com/openmrs/openmrs-ngx-formentry/pull/42 with tests fixed.

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This pull request adds support for translating error messages and labels within a form. Labels are now provided by a JSON file, following the naming convention "<lang>.json". This update provides a more user-friendly experience for non-native speakers.

Currently, the form supports English and French languages, and in the future, additional languages can be added by creating a new JSON file with the appropriate naming convention.



In addition to updating the form to display translated labels, this pull request also updates some core components, including buttons and error messages, to be translatable. The updated tests ensure that the translation module is properly imported and functioning as expected, improving the overall quality and reliability of the codebase.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

![Pasted Graphic 3](https://user-images.githubusercontent.com/94977371/225369847-17085841-56e3-449f-b67d-4ba56534a860.png)


Thanks, 


