### PR TITLE
(KHP3-4179) Grey out all other options on checkbox when hideExpression is true

### DIFF
--- a/projects/ngx-formentry/src/components/check-box/checkbox.component.html
+++ b/projects/ngx-formentry/src/components/check-box/checkbox.component.html
@@ -10,6 +10,7 @@
       [checked]="option.checked"
       (change)="selectOpt(option, $event)"
       [value]="option.value"
+      [disabled]="option.isDisabled"
     />
     <label [for]="i + id" class="cds--checkbox-label">
       <span class="cds--checkbox-label-text">{{ option.label }}</span>

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -211,7 +211,8 @@ export class QuestionFactory {
     question.options = schemaQuestion.questionOptions.answers.map((obj) => {
       return {
         label: obj.label,
-        value: obj.concept
+        value: obj.concept,
+        disableWhenExpression: obj.disableWhenExpression
       };
     });
     question.options.splice(0, 0);

--- a/src/app/adult-1.6.json
+++ b/src/app/adult-1.6.json
@@ -514,38 +514,43 @@
             {
               "label": "Civil status:",
               "type": "obs",
-              "historicalExpression": "HD.getObject('prevEnc').getValue('a899a9f2-1350-11df-a1f1-0026b9348838')",
               "questionOptions": {
-                "rendering": "select",
+                "rendering": "checkbox",
                 "concept": "a899a9f2-1350-11df-a1f1-0026b9348838",
                 "answers": [
                   {
                     "concept": "a899af10-1350-11df-a1f1-0026b9348838",
-                    "label": "Cohabitating"
+                    "label": "Cohabitating",
+                    "disableWhenExpression":"myValue === 'a899ae34-1350-11df-a1f1-0026b9348838'"
                   },
                   {
                     "concept": "a899ad58-1350-11df-a1f1-0026b9348838",
-                    "label": "Divorced"
+                    "label": "Divorced",
+                    "disableWhenExpression":"myValue === 'a899ae34-1350-11df-a1f1-0026b9348838'"
                   },
                   {
                     "concept": "a8aa76b0-1350-11df-a1f1-0026b9348838",
-                    "label": "Married monogamous"
+                    "label": "Married monogamous",
+                    "disableWhenExpression":"myValue === 'a899ae34-1350-11df-a1f1-0026b9348838'"
                   },
                   {
                     "concept": "a8b03712-1350-11df-a1f1-0026b9348838",
-                    "label": "Married polygamous"
+                    "label": "Married polygamous",
+                    "disableWhenExpression":"myValue === 'a899ae34-1350-11df-a1f1-0026b9348838'"
                   },
                   {
                     "concept": "a899aba0-1350-11df-a1f1-0026b9348838",
-                    "label": "Separated"
+                    "label": "Separated",
+                    "disableWhenExpression":"myValue === 'a899ae34-1350-11df-a1f1-0026b9348838'"
                   },
                   {
                     "concept": "a899ac7c-1350-11df-a1f1-0026b9348838",
-                    "label": "Single"
+                    "label": "Single",
+                    "disableWhenExpression":"myValue === 'a899ae34-1350-11df-a1f1-0026b9348838'"
                   },
                   {
                     "concept": "a899ae34-1350-11df-a1f1-0026b9348838",
-                    "label": "Widowed"
+                    "label": "Other"
                   }
                 ]
               },


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

When `disableWhenExpression` evaluates to true, all other checkbox options are now greyed out. Additionally, any previously selected options are automatically deselected. This functionality is particularly useful in scenarios where selecting an option like none means other options should not be concurrently selected.



## Screenshots

![Peek 2023-10-12 23-31](https://github.com/openmrs/openmrs-ngx-formentry/assets/28008754/731d69e9-6fb4-44b4-86f9-b0440aadb193)


## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
https://thepalladiumgroup.atlassian.net/browse/KHP3-4179

## Other

<!-- Anything not covered above -->
