### PR TITLE
(chore) Make `NPM_AUTH_TOKEN` available to CI release job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,3 +122,5 @@ jobs:
 
       - name: Publish release
         run: yarn publish dist/ngx-formentry --tag latest --access public
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

I've restored the NPM_AUTH_TOKEN environment variable to the CI `release` job's execution context. This should fix an issue where cutting a release via the GitHub release UI would [fail](https://github.com/openmrs/openmrs-ngx-formentry/actions/runs/6486097582/job/17613570440).

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*