### PR TITLE
(feat) O3-2510: Should be able to launch Add Drug Order workspace from a form

### DIFF
--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.html
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.html
@@ -6,7 +6,7 @@
       [id]="id"
       (click)="handleClick($event)"
     >
-      {{ label }}
+      {{ buttonLabel }}
     </button>
   </div>
 </fieldset>

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.html
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.html
@@ -2,7 +2,8 @@
   <div class="cds--form-item">
     <button
       type="button"
-      class="cds--btn cds--btn--primary"
+      class="cds--btn"
+      [ngClass]="'cds--btn--' + buttonType"
       [id]="id"
       (click)="handleClick()"
     >

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.html
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.html
@@ -1,0 +1,12 @@
+<fieldset class="cds--fieldset">
+  <div class="cds--form-item">
+    <button
+      type="button"
+      class="cds--btn cds--btn--primary"
+      [id]="id"
+      (click)="handleClick($event)"
+    >
+      {{ label }}
+    </button>
+  </div>
+</fieldset>

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.html
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.html
@@ -4,7 +4,7 @@
       type="button"
       class="cds--btn cds--btn--primary"
       [id]="id"
-      (click)="handleClick($event)"
+      (click)="handleClick()"
     >
       {{ buttonLabel }}
     </button>

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
@@ -7,7 +7,12 @@ import { Component, Input, OnInit } from '@angular/core';
 export class WorkspaceLauncherComponent {
   @Input() public id: string;
   @Input() public buttonLabel: string;
+  @Input() public buttonType: string;
   @Input() public workspaceName: string;
+
+  ngOnInit() {
+    console.log('Button type:', this.buttonType);
+  }
 
   public handleClick() {
     // We check that this is defined in question.factory.ts `toWorkspaceLauncher`

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
@@ -7,6 +7,7 @@ import { Component, Input, OnInit } from '@angular/core';
 export class WorkspaceLauncherComponent {
   @Input() public id: string;
   @Input() public buttonLabel: string;
+  @Input() public workspaceName: string;
 
   public handleClick() {
     if (!window['_openmrs_esm_patient_common_lib']) {
@@ -22,7 +23,7 @@ export class WorkspaceLauncherComponent {
       );
     } else {
       window['_openmrs_esm_patient_common_lib'].launchPatientWorkspace(
-        'add-drug-order'
+        this.workspaceName
       );
     }
   }

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
@@ -10,10 +10,6 @@ export class WorkspaceLauncherComponent {
   @Input() public buttonType: string;
   @Input() public workspaceName: string;
 
-  ngOnInit() {
-    console.log('Button type:', this.buttonType);
-  }
-
   public handleClick() {
     // We check that this is defined in question.factory.ts `toWorkspaceLauncher`
     window['_openmrs_esm_patient_common_lib'].launchPatientWorkspace(

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
@@ -13,6 +13,13 @@ export class WorkspaceLauncherComponent {
       console.error(
         "@openmrs/esm-patient-common-lib is not accessible. The 'workspace-launcher' question type can only be used in the context of the O3 patient chart, where the workspace is."
       );
+    } else if (
+      typeof window['_openmrs_esm_patient_common_lib']
+        .launchPatientWorkspace !== 'function'
+    ) {
+      console.error(
+        '@openmrs/esm-patient-common-lib is accessible, but the `launchPatientWorkspace` function is missing. It is likely that the version of @openmrs/esm-patient-common-lib that is being used is not compatible with this version of ngx-formentry.'
+      );
     } else {
       window['_openmrs_esm_patient_common_lib'].launchPatientWorkspace(
         'add-drug-order'

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
@@ -6,7 +6,7 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class WorkspaceLauncherComponent implements OnInit {
   @Input() public id: string;
-  @Input() public label: any;
+  @Input() public buttonLabel: string;
 
   public ngOnInit() {
     // Initialize any properties if necessary
@@ -14,6 +14,6 @@ export class WorkspaceLauncherComponent implements OnInit {
 
   public handleClick(event: any) {
     console.log('You clicked the button!!!');
-    console.log('id', this.id, 'label', this.label);
+    console.log('id', this.id, 'buttonLabel', this.buttonLabel);
   }
 }

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'ofe-workspace-launcher',
+  templateUrl: './workspace-launcher.component.html'
+})
+export class WorkspaceLauncherComponent implements OnInit {
+  @Input() public id: string;
+  @Input() public label: any;
+
+  public ngOnInit() {
+    // Initialize any properties if necessary
+  }
+
+  public handleClick(event: any) {
+    console.log('You clicked the button!!!');
+    console.log('id', this.id, 'label', this.label);
+  }
+}

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
@@ -4,16 +4,19 @@ import { Component, Input, OnInit } from '@angular/core';
   selector: 'ofe-workspace-launcher',
   templateUrl: './workspace-launcher.component.html'
 })
-export class WorkspaceLauncherComponent implements OnInit {
+export class WorkspaceLauncherComponent {
   @Input() public id: string;
   @Input() public buttonLabel: string;
 
-  public ngOnInit() {
-    // Initialize any properties if necessary
-  }
-
-  public handleClick(event: any) {
-    console.log('You clicked the button!!!');
-    console.log('id', this.id, 'buttonLabel', this.buttonLabel);
+  public handleClick() {
+    if (!window['_openmrs_esm_patient_common_lib']) {
+      console.error(
+        "@openmrs/esm-patient-common-lib is not accessible. The 'workspace-launcher' question type can only be used in the context of the O3 patient chart, where the workspace is."
+      );
+    } else {
+      window['_openmrs_esm_patient_common_lib'].launchPatientWorkspace(
+        'add-drug-order'
+      );
+    }
   }
 }

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.component.ts
@@ -10,21 +10,9 @@ export class WorkspaceLauncherComponent {
   @Input() public workspaceName: string;
 
   public handleClick() {
-    if (!window['_openmrs_esm_patient_common_lib']) {
-      console.error(
-        "@openmrs/esm-patient-common-lib is not accessible. The 'workspace-launcher' question type can only be used in the context of the O3 patient chart, where the workspace is."
-      );
-    } else if (
-      typeof window['_openmrs_esm_patient_common_lib']
-        .launchPatientWorkspace !== 'function'
-    ) {
-      console.error(
-        '@openmrs/esm-patient-common-lib is accessible, but the `launchPatientWorkspace` function is missing. It is likely that the version of @openmrs/esm-patient-common-lib that is being used is not compatible with this version of ngx-formentry.'
-      );
-    } else {
-      window['_openmrs_esm_patient_common_lib'].launchPatientWorkspace(
-        this.workspaceName
-      );
-    }
+    // We check that this is defined in question.factory.ts `toWorkspaceLauncher`
+    window['_openmrs_esm_patient_common_lib'].launchPatientWorkspace(
+      this.workspaceName
+    );
   }
 }

--- a/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.module.ts
+++ b/projects/ngx-formentry/src/components/workspace-launcher/workspace-launcher.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { FormsModule } from '@angular/forms';
+import { WorkspaceLauncherComponent } from './workspace-launcher.component';
+
+@NgModule({
+  declarations: [WorkspaceLauncherComponent],
+  exports: [WorkspaceLauncherComponent],
+  imports: [CommonModule, FormsModule]
+})
+export class WorkspaceLauncherModule {}

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -38,6 +38,7 @@ import { NgxRemoteSelectModule } from '../components/ngx-remote-select/ngx-remot
 import { AppointmentsOverviewComponent } from '../components/appointments-overview/appointments-overview.component';
 import { CheckboxModule } from '../components/check-box/checkbox.module';
 import { RadioModule } from '../components/radio-button/radio.module';
+import { WorkspaceLauncherModule } from '../components/workspace-launcher/workspace-launcher.module';
 import { SharedModule } from '../shared.module';
 import { NgxTabSetModule } from '../components/ngx-tabset/modules/ngx-tabset.module';
 import { SelectModule as SelectModuleCarbon } from '../components/select/select.module';
@@ -62,6 +63,7 @@ import { PatientIdentifierAdapter } from './value-adapters/patient-identifier.ad
     RemoteFileUploadModule,
     CheckboxModule,
     RadioModule,
+    WorkspaceLauncherModule,
     NgxDateTimePickerModule,
     SharedModule,
     CustomControlWrapperModule,

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -743,9 +743,15 @@ export class QuestionFactory {
 
   toWorkspaceLauncher(schemaQuestion: any): WorkspaceLauncherQuestion {
     console.log('schemaQuestion:', schemaQuestion);
-    const display = new WorkspaceLauncherQuestion({ type: '', key: '' });
-    display.extras = schemaQuestion;
-    return display;
+    const question = new WorkspaceLauncherQuestion({
+      type: '',
+      key: schemaQuestion.id,
+      label: schemaQuestion.label,
+      buttonLabel: schemaQuestion.questionOptions.buttonLabel,
+    });
+    question.questionIndex = this.quetionIndex;
+    question.extras = schemaQuestion;
+    return question;
   }
 
   getSchemaQuestions(schema: any): any {

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -742,7 +742,6 @@ export class QuestionFactory {
   }
 
   toWorkspaceLauncher(schemaQuestion: any): WorkspaceLauncherQuestion {
-    console.log('schemaQuestion:', schemaQuestion);
     const question = new WorkspaceLauncherQuestion({
       type: '',
       key: schemaQuestion.id,

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -763,10 +763,14 @@ export class QuestionFactory {
       key: schemaQuestion.id,
       label: schemaQuestion.label,
       buttonLabel: schemaQuestion.questionOptions.buttonLabel,
+      buttonType: schemaQuestion.questionOptions.buttonType,
       workspaceName: schemaQuestion.questionOptions.workspaceName
     });
     question.questionIndex = this.quetionIndex;
     question.extras = schemaQuestion;
+    question.extras.questionOptions.buttonType = question.buttonType;
+    question.extras.questionOptions.workspaceName = question.workspaceName;
+
     return question;
   }
 

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -30,6 +30,7 @@ import { CustomControlQuestion } from '../question-models/custom-control-questio
 import { DiagnosisQuestion } from '../question-models/diagnosis-question';
 import { MaxLengthValidationModel } from '../question-models/max-length-validation.model';
 import { MinLengthValidationModel } from '../question-models/min-length-validation.model';
+import { WorkspaceLauncherQuestion } from '../question-models';
 
 @Injectable()
 export class QuestionFactory {
@@ -740,6 +741,13 @@ export class QuestionFactory {
     return question;
   }
 
+  toWorkspaceLauncher(schemaQuestion: any): WorkspaceLauncherQuestion {
+    console.log('schemaQuestion:', schemaQuestion);
+    const display = new WorkspaceLauncherQuestion({ type: '', key: '' });
+    display.extras = schemaQuestion;
+    return display;
+  }
+
   getSchemaQuestions(schema: any): any {
     const listQuestions = new Array();
     this.getQuestions(schema, listQuestions);
@@ -859,6 +867,8 @@ export class QuestionFactory {
         return this.toEncounterProviderQuestion(schema);
       case 'file':
         return this.toFileUploadQuestion(schema);
+      case 'workspace-launcher':
+        return this.toWorkspaceLauncher(schema);
       default:
         console.warn('New Schema Question Type found.........' + renderType);
         return this.toTextQuestion(schema);

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -747,7 +747,8 @@ export class QuestionFactory {
       type: '',
       key: schemaQuestion.id,
       label: schemaQuestion.label,
-      buttonLabel: schemaQuestion.questionOptions.buttonLabel
+      buttonLabel: schemaQuestion.questionOptions.buttonLabel,
+      workspaceName: schemaQuestion.questionOptions.workspaceName
     });
     question.questionIndex = this.quetionIndex;
     question.extras = schemaQuestion;

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -747,7 +747,7 @@ export class QuestionFactory {
       type: '',
       key: schemaQuestion.id,
       label: schemaQuestion.label,
-      buttonLabel: schemaQuestion.questionOptions.buttonLabel,
+      buttonLabel: schemaQuestion.questionOptions.buttonLabel
     });
     question.questionIndex = this.quetionIndex;
     question.extras = schemaQuestion;

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -37,6 +37,7 @@ export class QuestionFactory {
   dataSources: any = {};
   historicalHelperService: HistoricalHelperService = new HistoricalHelperService();
   quetionIndex = 0;
+  checkedForEsmPatientCommonLib = false;
   constructor() {}
 
   createQuestionModel(formSchema: any, form?: Form): QuestionBase {
@@ -742,6 +743,21 @@ export class QuestionFactory {
   }
 
   toWorkspaceLauncher(schemaQuestion: any): WorkspaceLauncherQuestion {
+    if (!this.checkedForEsmPatientCommonLib) {
+      this.checkedForEsmPatientCommonLib = true;
+      if (!window['_openmrs_esm_patient_common_lib']) {
+        console.error(
+          "@openmrs/esm-patient-common-lib is not accessible. The 'workspace-launcher' question type can only be used in the context of the O3 patient chart, where the workspace is."
+        );
+      } else if (
+        typeof window['_openmrs_esm_patient_common_lib']
+          .launchPatientWorkspace !== 'function'
+      ) {
+        console.error(
+          '@openmrs/esm-patient-common-lib is accessible, but the `launchPatientWorkspace` function is missing. It is likely that the version of @openmrs/esm-patient-common-lib that is being used is not compatible with this version of ngx-formentry.'
+        );
+      }
+    }
     const question = new WorkspaceLauncherQuestion({
       type: '',
       key: schemaQuestion.id,

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -288,6 +288,10 @@
           >
           </ofe-number-input>
 
+          <div *ngSwitchCase="'workspace-launcher'">
+            <ofe-workspace-launcher></ofe-workspace-launcher>
+          </div>
+
           <input
             [theme]="theme"
             class="cds--text-input"

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -292,6 +292,7 @@
             <ofe-workspace-launcher
               [id]="node.question.key + 'id'"
               [buttonLabel]="node.question.extras.questionOptions.buttonLabel"
+              [buttonType]="node.question.extras.questionOptions.buttonType"
               [workspaceName]="
                 node.question.extras.questionOptions.workspaceName
               "

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -292,6 +292,9 @@
             <ofe-workspace-launcher
               [id]="node.question.key + 'id'"
               [buttonLabel]="node.question.extras.questionOptions.buttonLabel"
+              [workspaceName]="
+                node.question.extras.questionOptions.workspaceName
+              "
             ></ofe-workspace-launcher>
           </div>
 

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -289,7 +289,10 @@
           </ofe-number-input>
 
           <div *ngSwitchCase="'workspace-launcher'">
-            <ofe-workspace-launcher></ofe-workspace-launcher>
+            <ofe-workspace-launcher
+              [id]="node.question.key + 'id'"
+              [buttonLabel]="node.question.extras.questionOptions.buttonLabel"
+            ></ofe-workspace-launcher>
           </div>
 
           <input

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -91,6 +91,12 @@ export class FormRendererComponent implements OnInit, OnChanges {
         this.node.createChildNode();
       }
     }
+    if (
+      this.node &&
+      this.node.question.renderingType === 'workspace-launcher'
+    ) {
+      console.log('Parent buttonType:', this.node.question);
+    }
   }
 
   public ngOnChanges(changes: SimpleChanges) {

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -91,12 +91,6 @@ export class FormRendererComponent implements OnInit, OnChanges {
         this.node.createChildNode();
       }
     }
-    if (
-      this.node &&
-      this.node.question.renderingType === 'workspace-launcher'
-    ) {
-      console.log('Parent buttonType:', this.node.question);
-    }
   }
 
   public ngOnChanges(changes: SimpleChanges) {

--- a/projects/ngx-formentry/src/form-entry/question-models/index.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/index.ts
@@ -20,3 +20,4 @@ export * from './text-area-input-question';
 export * from './text-input-question';
 export * from './ui-select-question';
 export * from './validation.model';
+export * from './workspace-launcher.model';

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/workspace-launcher-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/workspace-launcher-options.ts
@@ -2,4 +2,5 @@ import { BaseOptions } from '../interfaces/base-options';
 
 export interface WorkspaceLauncherOptions extends BaseOptions {
   buttonLabel: string;
+  workspaceName: string;
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/workspace-launcher-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/workspace-launcher-options.ts
@@ -1,0 +1,5 @@
+import { BaseOptions } from '../interfaces/base-options';
+
+export interface WorkspaceLauncherOptions extends BaseOptions {
+  buttonLabel: string;
+}

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/workspace-launcher-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/workspace-launcher-options.ts
@@ -2,5 +2,6 @@ import { BaseOptions } from '../interfaces/base-options';
 
 export interface WorkspaceLauncherOptions extends BaseOptions {
   buttonLabel: string;
+  buttonType: string;
   workspaceName: string;
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
@@ -4,6 +4,7 @@ import { WorkspaceLauncherOptions } from './interfaces/workspace-launcher-option
 
 export class WorkspaceLauncherQuestion extends QuestionBase {
   buttonLabel: string;
+  buttonType: string;
   workspaceName: string;
 
   constructor(options: WorkspaceLauncherOptions) {
@@ -11,6 +12,7 @@ export class WorkspaceLauncherQuestion extends QuestionBase {
     this.renderingType = 'workspace-launcher';
     this.label = options.label || '';
     this.buttonLabel = options.buttonLabel || '';
+    this.buttonType = options.buttonType || 'primary';
     this.workspaceName = options.workspaceName || 'order-basket';
     this.controlType = AfeControlType.AfeFormControl;
   }

--- a/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
@@ -1,13 +1,16 @@
 import { QuestionBase } from './question-base';
 import { AfeControlType } from '../../abstract-controls-extension/afe-control-type';
-import { BaseOptions } from './interfaces/base-options';
+import { WorkspaceLauncherOptions } from './interfaces/workspace-launcher-options';
 
 export class WorkspaceLauncherQuestion extends QuestionBase {
   buttonLabel: string;
-  constructor(options: BaseOptions) {
+
+  constructor(options: WorkspaceLauncherOptions) {
+    console.log("constructing from ", options);
     super(options);
     this.renderingType = 'workspace-launcher';
-    this.placeholder = options.placeholder || '';
+    this.label = options.label || '';
+    this.buttonLabel = options.buttonLabel || '';
     this.controlType = AfeControlType.AfeFormControl;
   }
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
@@ -7,7 +7,6 @@ export class WorkspaceLauncherQuestion extends QuestionBase {
   workspaceName: string;
 
   constructor(options: WorkspaceLauncherOptions) {
-    console.log('constructing from ', options);
     super(options);
     this.renderingType = 'workspace-launcher';
     this.label = options.label || '';

--- a/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
@@ -1,0 +1,13 @@
+import { QuestionBase } from './question-base';
+import { AfeControlType } from '../../abstract-controls-extension/afe-control-type';
+import { BaseOptions } from './interfaces/base-options';
+
+export class WorkspaceLauncherQuestion extends QuestionBase {
+  buttonLabel: string;
+  constructor(options: BaseOptions) {
+    super(options);
+    this.renderingType = 'workspace-launcher';
+    this.placeholder = options.placeholder || '';
+    this.controlType = AfeControlType.AfeFormControl;
+  }
+}

--- a/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
@@ -6,7 +6,7 @@ export class WorkspaceLauncherQuestion extends QuestionBase {
   buttonLabel: string;
 
   constructor(options: WorkspaceLauncherOptions) {
-    console.log("constructing from ", options);
+    console.log('constructing from ', options);
     super(options);
     this.renderingType = 'workspace-launcher';
     this.label = options.label || '';

--- a/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/workspace-launcher.model.ts
@@ -4,6 +4,7 @@ import { WorkspaceLauncherOptions } from './interfaces/workspace-launcher-option
 
 export class WorkspaceLauncherQuestion extends QuestionBase {
   buttonLabel: string;
+  workspaceName: string;
 
   constructor(options: WorkspaceLauncherOptions) {
     console.log('constructing from ', options);
@@ -11,6 +12,7 @@ export class WorkspaceLauncherQuestion extends QuestionBase {
     this.renderingType = 'workspace-launcher';
     this.label = options.label || '';
     this.buttonLabel = options.buttonLabel || '';
+    this.workspaceName = options.workspaceName || 'order-basket';
     this.controlType = AfeControlType.AfeFormControl;
   }
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This creates a new question type that renders a button that opens whatever workspace is configured.

## Screenshots

![image](https://github.com/openmrs/openmrs-ngx-formentry/assets/1031876/c0ea37af-0445-4b91-8e7a-5586be2cedcc)

https://github.com/openmrs/openmrs-ngx-formentry/assets/1031876/4e99bf91-1608-4b8f-8d58-6506d0210f49

## Related Issue

https://issues.openmrs.org/browse/O3-2510

## Other

**Depends on https://github.com/openmrs/openmrs-esm-patient-chart/pull/1430**