### PR TITLE
(fix) Fix overlay stacking context so Datepicker isn't hidden on tablet

### DIFF
--- a/projects/ngx-formentry/styles/picker.min.css
+++ b/projects/ngx-formentry/styles/picker.min.css
@@ -8,7 +8,7 @@
 }
 .cdk-overlay-container {
   position: fixed;
-  z-index: 1000;
+  z-index: 9999;
 }
 .cdk-overlay-container:empty {
   display: none;
@@ -90,6 +90,7 @@
   width: 100%;
   overflow-y: scroll;
 }
+
 .owl-dialog-container {
   position: relative;
   pointer-events: auto;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes a display issue with the DatePicker on tablet devices due to a higher z-index value on its parent container. Additionally, it removes the scrollbar to enhance the user experience by preventing flickering. Below GIF shows the fix and the error

## Screenshots
![Kapture 2023-10-24 at 20 07 55](https://github.com/openmrs/openmrs-ngx-formentry/assets/28008754/c9641dbe-953f-483e-8fa0-d5f87d8b0f17)

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
