### PR TITLE
(feat) O3-2531: Enhance form control sizing for improved UX in tablet mode

### DIFF
--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.html
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.html
@@ -1,10 +1,5 @@
-<div
-  [ngClass]="{
-    'tab-container': tabs.length > 1,
-    'tab-container-one-column': tabs.length === 1
-  }"
->
-  <section *ngIf="tabs.length > 1">
+<div class="tab-container">
+  <section>
     <div class="tab">
       <button
         ofeHoverClass="hover"
@@ -15,15 +10,10 @@
       >
         <span>{{ tab.tabTitle }}</span>
       </button>
+      <ng-container *ngTemplateOutlet="formSubmissionTemplate"></ng-container>
     </div>
   </section>
-  <section
-    id="tab"
-    [ngClass]="{
-      'tab-content': tabs.length > 1,
-      'tab-content-no-margin': tabs.length === 1
-    }"
-  >
+  <section id="tab" class="tab-content">
     <ng-content></ng-content>
   </section>
 </div>

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.ts
@@ -8,7 +8,7 @@ import {
   OnChanges,
   SimpleChanges
 } from '@angular/core';
-import type { QueryList } from '@angular/core';
+import type { QueryList, TemplateRef } from '@angular/core';
 
 import { TabComponent } from './tab.component';
 
@@ -24,6 +24,7 @@ export class TabSetComponent implements AfterContentInit, OnChanges {
   @Input() public customNavClass: String = '';
   @Input() public customTabsClass: String = '';
   @Input() public selectedIndex: Number = 0;
+  @Input() formSubmissionTemplate: TemplateRef<unknown>;
 
   @Output() public tabSelect = new EventEmitter();
 

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -1,6 +1,10 @@
 <!--CONTAINERS-->
 <div *ngIf="node.question.renderingType === 'form'">
-  <ofe-tab-set (tabSelect)="tabSelected($event)" [selectedIndex]="activeTab">
+  <ofe-tab-set
+    (tabSelect)="tabSelected($event)"
+    [selectedIndex]="activeTab"
+    [formSubmissionTemplate]="formSubmissionTemplate"
+  >
     <ofe-tab
       [tabTitle]="question.label | translate"
       *ngFor="let question of node.question.questions; let i = index"

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
@@ -200,7 +200,7 @@ ng-select.form-control {
 .question-area {
   margin-bottom: 0.5rem;
   width: 100%;
-  // max-width: 18rem;
+  min-width: 18rem;
   & > label {
     overflow-wrap: break-word;
   }

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
@@ -199,7 +199,8 @@ ng-select.form-control {
 
 .question-area {
   margin-bottom: 0.5rem;
-
+  width: 100%;
+  // max-width: 18rem;
   & > label {
     overflow-wrap: break-word;
   }

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -4,7 +4,8 @@ import {
   Input,
   Inject,
   OnChanges,
-  SimpleChanges
+  SimpleChanges,
+  TemplateRef
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import * as _ from 'lodash';
@@ -25,6 +26,7 @@ import { TranslateService } from '@ngx-translate/core';
   styleUrls: ['../../style/app.css', './form-renderer.component.scss']
 })
 export class FormRendererComponent implements OnInit, OnChanges {
+  @Input() public formSubmissionTemplate: TemplateRef<unknown>;
   @Input() public parentComponent: FormRendererComponent;
   @Input() public node: NodeBase;
   @Input() public parentGroup: AfeFormGroup;

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -43,13 +43,13 @@ export class FormRendererComponent implements OnInit, OnChanges {
   public isNavigation = true;
   public type = 'default';
   inlineDatePicker: Date = new Date();
-
+  private TAB_SELECTION_DELAY_MS = 100;
   constructor(
     private validationFactory: ValidationFactory,
     private dataSources: DataSources,
     private formErrorsService: FormErrorsService,
     public translate: TranslateService,
-    @Inject(DOCUMENT) private document: any
+    @Inject(DOCUMENT) private document: Document
   ) {
     this.activeTab = 0;
   }
@@ -194,6 +194,13 @@ export class FormRendererComponent implements OnInit, OnChanges {
   public tabSelected($event) {
     this.activeTab = $event;
     this.setPreviousTab();
+
+    setTimeout(() => {
+      const sectionHeader = this.document.querySelector('div.pane > h4');
+      if (sectionHeader) {
+        sectionHeader.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }, this.TAB_SELECTION_DELAY_MS);
   }
   public setPreviousTab() {
     if (this.node && this.node.form) {

--- a/src/app/adult-1.6.json
+++ b/src/app/adult-1.6.json
@@ -3100,7 +3100,7 @@
                   "label": "Adherence (TB Prophylaxis): Other (specify):",
                   "questionOptions": {
                     "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838",
-                    "rendering": "text"
+                    "rendering": "textarea"
                   },
                   "type": "obs",
                   "id": "tbProphylaxisOtherAdherence",
@@ -5486,7 +5486,7 @@
                   "id": "otherTestResult",
                   "questionOptions": {
                     "concept": "6f5207f4-6785-433b-943e-c2d03e7d3ea7",
-                    "rendering": "text"
+                    "rendering": "textarea"
                   },
                   "validators": []
                 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,12 +1,15 @@
 <div *ngIf="form && form.rootNode">
   <form [formGroup]="form.rootNode.control">
     <ofe-form-renderer
+      [formSubmissionTemplate]="buttonsTemplate"
       [node]="form.rootNode"
       [labelMap]="labelMap"
-    ></ofe-form-renderer>
+    >
+    </ofe-form-renderer>
   </form>
-
-  <div class="cds--offset-md-2">
+</div>
+<ng-template #buttonsTemplate>
+  <div class="saveAndCloseButtons">
     <button
       (click)="reset($event)"
       class="cds--btn cds--btn--secondary"
@@ -22,4 +25,4 @@
       Save
     </button>
   </div>
-</div>
+</ng-template>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,14 @@
+.saveAndCloseButtons {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  row-gap: 0.625rem;
+  margin-top: 0.25rem;
+  padding-top: 0.625rem;
+
+  border-top: 1px solid #a8a8a8;
+
+  & button {
+    width: 100%;
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,7 +26,7 @@ const formOrdersPayload = require('./mock/orders.json');
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
   data: any;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR contains a number of enhancements, namely add ability to scroll to the top of a section in the event the form contains long sections. Moved the `Save` and `Close` buttons to the side navigation to improve usability on tablet devices.

## Screenshots
https://github.com/openmrs/openmrs-ngx-formentry/assets/28008754/5e8c0da6-e16a-40ad-b56f-f2ae5647e21c

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
