### PR TITLE
(fix) Resolved issue with incorrect voided diagnosis in generated payload

### DIFF
--- a/projects/ngx-formentry/src/form-entry/value-adapters/diagnosis.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/diagnosis.adapter.ts
@@ -108,7 +108,7 @@ export class DiagnosisValueAdapter implements ValueAdapter {
       }
     });
     this._updatedOldDiagnoses(payload, existingDiagnoses);
-    deletedDiagnoses = this._getDeletedDiagnoses(payload, existingDiagnoses);
+    deletedDiagnoses = this._getDeletedDiagnoses(diagnosisNodes, existingDiagnoses);
     return payload.concat(deletedDiagnoses);
   }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Resolved an issue during encounter editing where the generated payload incorrectly marked existing diagnoses as voided, despite intending to retain them. With this fix, only the diagnoses explicitly removed by the user will be marked as voided in the payload as expected.

This issue had minimal impact as an HTTP 400 error would occur due to an unrelated [problem](https://talk.openmrs.org/t/rest-module-and-multi-valued-attributes/40898) in the OpenMRS core, preventing the editing of existing diagnoses.
