### PR TITLE
(fix) Fix date picker styles in Form Entry preview

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
 @import '~@carbon/styles/css/styles.min.css';
+@import 'projects/ngx-formentry/styles/picker.min.css';
+@import 'projects/ngx-formentry/styles/ngx-formentry.css';
+
 :root {
   --brand-01: #005d5d;
   --brand-02: #004144;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR resolves the issue of missing styling in the Form Preview (what you see when you run a dev server using `yarn start`) which caused the DatePicker component and other elements to appear incorrectly. 

To fix this, I've added the necessary styles as imports to the global `styles.scss` stylesheet. Additionally, I've tested my changes against the dev3 reference application to ensure that styling isn't broken in the Clinical Forms workspace (see the attached video below).

## Screenshots

> Before (broken styles for the DatePicker)

https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/347f0ba1-3bf7-404d-91e5-55038a850971

> After (fixed styles)

https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/7cb0b776-d36e-46d0-998d-9672d0c7c884

> Verification that the Clinical Forms workspace is unaffected by my changes

https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/e4f1c594-deb2-4bf9-bc2b-212d1e0e0096

## Related Issue

*None*

## Other

*None*

