### PR TITLE
(feat) bootstrap date component to support showing `time` picker

### DIFF
--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -163,6 +163,7 @@ export class QuestionFactory {
       required: 'required',
       id: 'key'
     };
+    question.datePickerFormat = schemaQuestion.datePickerFormat ?? 'calendar';
 
     this.copyProperties(mappings, schemaQuestion, question);
     this.addDisableOrHideProperty(schemaQuestion, question);

--- a/src/app/adult-1.6.json
+++ b/src/app/adult-1.6.json
@@ -401,6 +401,7 @@
               "label": "If unscheduled, actual scheduled date",
               "id": "actualDate",
               "type": "obs",
+              "datePickerFormat": "timer",
               "required": {
                 "type": "conditionalRequired",
                 "message": "Patient visit marked as unscheduled. Please provide the scheduled date.",


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds ability for obs question type rendering `date` to show time picker. Previously this was supported for `encounterDatetime` control only. 

Sample JSON schema for the feature.
```json
{
    "label": "Time of  visit",
    "id": "timeOfVisit",
    "type": "obs",
    "datePickerFormat": "timer",
    "questionOptions": {
        "rendering": "date",
        "concept": "dc1942b2-5e50-4adc-949d-ad6c905f054e"
    },
    "validators": []
}
```

## Screenshots
https://github.com/openmrs/openmrs-ngx-formentry/assets/28008754/b4e05d1c-3609-4597-8f11-338f2c87038b


## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
