### PR TITLE
(feat) Make datepicker placeholder aware of datePickerFormat input

### DIFF
--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.component.ts
@@ -53,4 +53,14 @@ export class NgxDatetimeComponent implements ControlValueAccessor {
     const currentDate: string = new Date().toString();
     this.onInput({ value: moment(currentDate).add(numberOfWeeks, 'weeks') });
   }
+
+  getPlaceholderValue(): string {
+    if (this.datePickerFormat === 'both') {
+      return 'dd/mm/yyyy hh:mm';
+    } else if (this.datePickerFormat === 'timer') {
+      return 'hh:mm';
+    } else {
+      return 'dd/mm/yyyy';
+    }
+  }
 }

--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
@@ -18,7 +18,7 @@
           [value]="value"
           [owlDateTime]="dt1"
           [ofeOwlDateTimeTrigger]="dt1"
-          placeholder="mm/dd/yyyy"
+          placeholder="{{getPlaceholderValue()}}"
           data-date-picker-input
         />
         <svg


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

The DatePicker component accepts a `datePickerType` prop whose value gets funnelled down to the [NgDatePicker](https://danielykpan.github.io/date-time-picker/) component under the hood. This prop accepts one of [three](https://github.com/DanielYKPan/date-time-picker/blob/5ccf6be2d24c6e074709881d64dd9116c3b6aa14/projects/picker/src/lib/date-time/date-time.class.ts#L17) possible values: 

- `both` which renders both a calendar and a timer
- `calendar` which renders a calendar
- `timer` which renders a timer

Presently, the input placeholder is set to just show `mm/dd/yyyy` for all three cases. This PR amends the placeholder so an appropriate value is shown in each case. 

## Screenshots

> Both

![CleanShot 2024-01-22 at 4  19 12@2x](https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/ed81b4c5-6b58-44c6-9742-958a6836fb7c)

> Timer

![CleanShot 2024-01-22 at 4  19 24@2x](https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/4d027086-3653-4410-8639-534585dd47b1)

> Calendar

![CleanShot 2024-01-22 at 4  20 00@2x](https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/006b6194-6c18-4372-9910-9b4820d8fb66)

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
