### PR TITLE
(feat) Only show navigation buttons on multi-page forms

### DIFF
--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -18,36 +18,38 @@
       </ofe-form-renderer>
 
       <!-- Buttons for navigating between tabs -->
-      <div class="cds--btn-set button-set">
-        <button
-          class="cds--btn cds--btn--ghost nav-button"
-          [disabled]="i === 0"
-          type="button"
-        >
-          <a *ngIf="i > 0" (click)="tabSelected(i - 1)" class="nav-link">
-            <label class="nav-label">{{ 'previous' | translate }}</label>
-            <span class="nav-link-text">{{
-              node.question.questions[i - 1].label
-            }}</span>
-          </a>
-        </button>
-        <button
-          class="cds--btn cds--btn--ghost nav-button"
-          [disabled]="i === node.question.questions.length - 1"
-          type="button"
-        >
-          <a
-            *ngIf="i < node.question.questions.length - 1"
-            (click)="tabSelected(i + 1)"
-            class="nav-link"
+      <section *ngIf="this.hasMultiplePages">
+        <div class="cds--btn-set button-set">
+          <button
+            class="cds--btn cds--btn--ghost nav-button"
+            [disabled]="i === 0"
+            type="button"
           >
-            <label class="nav-label">{{ 'next' | translate }}</label>
-            <span class="nav-link-text">{{
-              node.question.questions[i + 1].label
-            }}</span>
-          </a>
-        </button>
-      </div>
+            <a *ngIf="i > 0" (click)="tabSelected(i - 1)" class="nav-link">
+              <label class="nav-label">{{ 'previous' | translate }}</label>
+              <span class="nav-link-text">{{
+                node.question.questions[i - 1].label
+              }}</span>
+            </a>
+          </button>
+          <button
+            class="cds--btn cds--btn--ghost nav-button"
+            [disabled]="i === node.question.questions.length - 1"
+            type="button"
+          >
+            <a
+              *ngIf="i < node.question.questions.length - 1"
+              (click)="tabSelected(i + 1)"
+              class="nav-link"
+            >
+              <label class="nav-label">{{ 'next' | translate }}</label>
+              <span class="nav-link-text">{{
+                node.question.questions[i + 1].label
+              }}</span>
+            </a>
+          </button>
+        </div>
+      </section>
     </ofe-tab>
 
     <!-- TODO: Figure out why is this code doing the same thing as the ErrorRenderer component -->

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -44,8 +44,10 @@ export class FormRendererComponent implements OnInit, OnChanges {
   public cacheActive = false;
   public isNavigation = true;
   public type = 'default';
+  public hasMultiplePages = false;
   inlineDatePicker: Date = new Date();
   private TAB_SELECTION_DELAY_MS = 100;
+
   constructor(
     private validationFactory: ValidationFactory,
     private dataSources: DataSources,
@@ -92,6 +94,10 @@ export class FormRendererComponent implements OnInit, OnChanges {
       ) {
         this.node.createChildNode();
       }
+    }
+
+    if (this.node.form.schema.pages.length > 1) {
+      this.hasMultiplePages = true;
     }
   }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR tweaks the navigation pattern introduced in #119 so that navigation links are only shown for forms with multiple pages.

## Screenshots

### Before

![CleanShot 2024-01-29 at 10  58 44@2x](https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/7b2fe686-361e-40cc-8419-bcb578da3292)

### After

![CleanShot 2024-01-29 at 10  59 15@2x](https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/5712d9ba-fedc-47c1-a4ed-1d48b869df85)

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
