### PR TITLE
(fix) O3-2870: Form navigation fixes

### DIFF
--- a/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.scss
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/ngx-tab-set.component.scss
@@ -116,5 +116,5 @@
 
 .tab-container {
   display: grid;
-  grid-template-columns: 179px auto;
+  grid-template-columns: 179px minmax(0, 1fr);
 }

--- a/projects/ngx-formentry/src/components/ngx-tabset/components/tab.component.css
+++ b/projects/ngx-formentry/src/components/ngx-tabset/components/tab.component.css
@@ -1,5 +1,5 @@
 h4 {
-  padding-left: 1rem;
+  padding-inline-start: 1rem;
   margin-bottom: 0.5rem;
 }
 

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -19,16 +19,21 @@
 
       <!-- Buttons for navigating between tabs -->
       <section *ngIf="this.hasMultiplePages">
-        <div class="cds--btn-set button-set">
+        <div class="button-set">
           <button
             class="cds--btn cds--btn--ghost nav-button"
             [disabled]="i === 0"
             type="button"
           >
-            <a *ngIf="i > 0" (click)="tabSelected(i - 1)" class="nav-link">
+            <a
+              *ngIf="i > 0"
+              (click)="tabSelected(i - 1)"
+              class="nav-link"
+              [title]='node.question.questions[i - 1].label | translate'
+            >
               <label class="nav-label">{{ 'previous' | translate }}</label>
               <span class="nav-link-text">{{
-                node.question.questions[i - 1].label
+                node.question.questions[i - 1].label | translate
               }}</span>
             </a>
           </button>
@@ -41,10 +46,11 @@
               *ngIf="i < node.question.questions.length - 1"
               (click)="tabSelected(i + 1)"
               class="nav-link"
+              [title]='node.question.questions[i + 1].label | translate'
             >
               <label class="nav-label">{{ 'next' | translate }}</label>
               <span class="nav-link-text">{{
-                node.question.questions[i + 1].label
+                node.question.questions[i + 1].label | translate
               }}</span>
             </a>
           </button>

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
@@ -1,4 +1,5 @@
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/spacing';
 
 .button-set {
   margin-top: 1rem;
@@ -9,19 +10,22 @@
   height: 5rem;
   max-width: 50%;
   min-width: 50%;
-  padding-block: 0.25rem;
+  padding-block: spacing.$spacing-02;
 }
 
 .nav-link {
   min-width: 100%;
   display: flex;
-  align-content: flex-start;
-  align-items: baseline;
+  align-items: flex-start;
   flex-direction: column;
 }
 
 .nav-link-text {
   margin-top: 0.125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: calc(100% - #{spacing.$spacing-02});
   @include type.type-style('heading-03');
 }
 

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
@@ -11,6 +11,7 @@
   max-width: 50%;
   min-width: 50%;
   padding-block: spacing.$spacing-02;
+  align-items: center;
 }
 
 .nav-link {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR contains fixes to newly added navigation section:
- translation for prev / next page
- added title/popup with page name on button hover
- correct alignment for RTL
- horizontal scrolling / oveflow

## Screenshots
### Before:
[Video](https://monosnap.com/file/Fn6kAFyIwLh2HKYPADbTkNrSLwLyEQ)

![2024-02-15 14 03 52](https://github.com/openmrs/openmrs-ngx-formentry/assets/17073192/4d3d1b7c-ca28-4cd2-9b3f-102ea0e60c21)

### After:
![2024-02-15 13 52 53](https://github.com/openmrs/openmrs-ngx-formentry/assets/17073192/50d24937-c552-4d55-8bd2-5d727799e8d8)

## Related Issue

[O3-2870](https://openmrs.atlassian.net/browse/O3-2870)
