### PR TITLE
(fix) O3-2872: Fix inconsistent data when editing obsGroups in an encounter

### DIFF
--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
@@ -1112,7 +1112,8 @@ describe('Obs Value Adapter Helper: ', () => {
       ],
       uuid: 'some uuid',
       formFieldNamespace: jasmine.stringMatching(/\w+/),
-      formFieldPath: jasmine.stringMatching(/\w+/)
+      formFieldPath: jasmine.stringMatching(/\w+/),
+      voided: false
     });
 
     // CASE 3: New group
@@ -1257,6 +1258,17 @@ describe('Obs Value Adapter Helper: ', () => {
       {
         groupMembers: [
           {
+            uuid: 'uuid 1',
+            concept: {
+              uuid: 'a899e444-1350-11df-a1f1-0026b9348838'
+            },
+            value: {
+              uuid: 'a899f51a-1350-11df-a1f1-0026b9348838'
+            },
+            formFieldNamespace: jasmine.stringMatching(/\w+/),
+            formFieldPath: jasmine.stringMatching(/\w+/)
+          },
+          {
             value: 21,
             uuid: 'uuid 2',
             formFieldNamespace: jasmine.stringMatching(/\w+/),
@@ -1265,7 +1277,8 @@ describe('Obs Value Adapter Helper: ', () => {
         ],
         uuid: 'some uuid 1',
         formFieldNamespace: jasmine.stringMatching(/\w+/),
-        formFieldPath: jasmine.stringMatching(/\w+/)
+        formFieldPath: jasmine.stringMatching(/\w+/),
+        voided: false
       },
       {
         groupMembers: [
@@ -1278,7 +1291,8 @@ describe('Obs Value Adapter Helper: ', () => {
         ],
         concept: 'a8afdb8c-1350-11df-a1f1-0026b9348838',
         formFieldNamespace: jasmine.stringMatching(/\w+/),
-        formFieldPath: jasmine.stringMatching(/\w+/)
+        formFieldPath: jasmine.stringMatching(/\w+/),
+        voided: false
       },
       {
         uuid: 'some uuid 3',
@@ -1369,7 +1383,8 @@ describe('Obs Value Adapter Helper: ', () => {
         ],
         concept: 'a8afdb8c-1350-11df-a1f1-0026b9348838',
         formFieldNamespace: jasmine.stringMatching(/\w+/),
-        formFieldPath: jasmine.stringMatching(/\w+/)
+        formFieldPath: jasmine.stringMatching(/\w+/),
+        voided: false
       },
       {
         groupMembers: [
@@ -1382,7 +1397,8 @@ describe('Obs Value Adapter Helper: ', () => {
         ],
         concept: 'a8afdb8c-1350-11df-a1f1-0026b9348838',
         formFieldNamespace: jasmine.stringMatching(/\w+/),
-        formFieldPath: jasmine.stringMatching(/\w+/)
+        formFieldPath: jasmine.stringMatching(/\w+/),
+        voided: false
       },
       {
         concept: 'a8982474-1350-11df-a1f1-0026b9348838',

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
@@ -1276,7 +1276,7 @@ describe('Obs Value Adapter Helper: ', () => {
             value: 21,
             uuid: 'uuid 2',
             concept: {
-              uuid: 'a8afdb8c-1350-11df-a1f1-0026b9348838'
+              uuid: 'a8a07386-1350-11df-a1f1-0026b9348838'
             },
             formFieldNamespace: jasmine.stringMatching(/\w+/),
             formFieldPath: jasmine.stringMatching(/\w+/)

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
@@ -1143,7 +1143,8 @@ describe('Obs Value Adapter Helper: ', () => {
       ],
       concept: 'a8afdb8c-1350-11df-a1f1-0026b9348838',
       formFieldNamespace: jasmine.stringMatching(/\w+/),
-      formFieldPath: jasmine.stringMatching(/\w+/)
+      formFieldPath: jasmine.stringMatching(/\w+/),
+      voided: false
     });
   });
 

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
@@ -1275,6 +1275,9 @@ describe('Obs Value Adapter Helper: ', () => {
           {
             value: 21,
             uuid: 'uuid 2',
+            concept: {
+              uuid: 'a8afdb8c-1350-11df-a1f1-0026b9348838'
+            },
             formFieldNamespace: jasmine.stringMatching(/\w+/),
             formFieldPath: jasmine.stringMatching(/\w+/)
           }

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.spec.ts
@@ -1103,6 +1103,9 @@ describe('Obs Value Adapter Helper: ', () => {
       groupMembers: [
         {
           uuid: 'some inner uuid',
+          concept: {
+            uuid: 'a899e5f2-1350-11df-a1f1-0026b9348838'
+          },
           value: moment('2016-04-21T16:17:46.000+0300').format(
             'YYYY-MM-DD HH:mm:ss'
           ),
@@ -1323,7 +1326,8 @@ describe('Obs Value Adapter Helper: ', () => {
         ],
         concept: 'a8afdb8c-1350-11df-a1f1-0026b9348838',
         formFieldNamespace: jasmine.stringMatching(/\w+/),
-        formFieldPath: jasmine.stringMatching(/\w+/)
+        formFieldPath: jasmine.stringMatching(/\w+/),
+        voided: false
       }
     ]);
   });

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -490,10 +490,7 @@ export class ObsAdapterHelper {
     const nodeAsGroup: GroupNode = node as GroupNode;
 
     // Get existing obs
-    let childrenPayload =
-      nodeAsGroup.initialValue?.groupMembers?.map((node) =>
-        this.getOldObsPayload(node)
-      ) || [];
+    let childrenPayload = nodeAsGroup.initialValue?.groupMembers?.map((node) => this.getOldObsPayload(node)) || [];
 
     let isGroupChanged: boolean = false;
     _.each(nodeAsGroup.children, (child) => {
@@ -519,7 +516,7 @@ export class ObsAdapterHelper {
       return null;
     }
 
-    const groupPayload = {
+    const groupPayload: any = {
       groupMembers: childrenPayload,
       voided: childrenPayload?.every((member) => member.voided === true)
     };

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -490,12 +490,17 @@ export class ObsAdapterHelper {
     const nodeAsGroup: GroupNode = node as GroupNode;
 
     // Get existing obs
-    let childrenPayload = nodeAsGroup?.initialValue?.groupMembers?.map(node => this.getOldObsPayload(node)) || [];
+    let childrenPayload =
+      nodeAsGroup?.initialValue?.groupMembers?.map((node) =>
+        this.getOldObsPayload(node)
+      ) || [];
     _.each(nodeAsGroup.children, (child) => {
       const payload = this.getObsNodePayload(child);
       if (payload.length > 0) {
         if (payload[0].voided) {
-          childrenPayload.find(obs => obs.uuid == payload[0].uuid).voided = true;
+          childrenPayload.find(
+            (obs) => obs.uuid == payload[0].uuid
+          ).voided = true;
         } else {
           childrenPayload = childrenPayload.concat(payload);
         }
@@ -508,7 +513,7 @@ export class ObsAdapterHelper {
 
     const groupPayload: any = {
       groupMembers: childrenPayload,
-      voided: childrenPayload?.every(member => member.voided === true)
+      voided: childrenPayload?.every((member) => member.voided === true)
     };
 
     if (nodeAsGroup.initialValue) {

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -494,9 +494,14 @@ export class ObsAdapterHelper {
       nodeAsGroup?.initialValue?.groupMembers?.map((node) =>
         this.getOldObsPayload(node)
       ) || [];
+
+    let isGroupChanged: boolean = false;
     _.each(nodeAsGroup.children, (child) => {
       const payload = this.getObsNodePayload(child);
       if (payload.length > 0) {
+        isGroupChanged = true;
+        console.warn('payload', payload);
+        console.warn('isGroupChanged', isGroupChanged);
         if (payload[0].voided) {
           childrenPayload.find(
             (obs) => obs.uuid == payload[0].uuid
@@ -507,7 +512,7 @@ export class ObsAdapterHelper {
       }
     });
 
-    if (childrenPayload.length === 0) {
+    if (!isGroupChanged) {
       return null;
     }
 

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -506,9 +506,8 @@ export class ObsAdapterHelper {
               (obs) => obs.uuid == payload[0].uuid
             ).voided = true;
           } else {
-            childrenPayload.find(
-              (obs) => obs.uuid == payload[0].uuid
-            ).value = payload[0].value;
+            childrenPayload.find((obs) => obs.uuid == payload[0].uuid).value =
+              payload[0].value;
           }
         } else {
           childrenPayload = childrenPayload.concat(payload);

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -579,6 +579,7 @@ export class ObsAdapterHelper {
       formFieldPath: oldObs.formFieldPath
     };
   }
+  
   getObsNodePayload(node: NodeBase): Array<any> {
     let payload = [];
     switch (this.getObsNodeType(node)) {

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -500,12 +500,16 @@ export class ObsAdapterHelper {
       const payload = this.getObsNodePayload(child);
       if (payload.length > 0) {
         isGroupChanged = true;
-        console.warn('payload', payload);
-        console.warn('isGroupChanged', isGroupChanged);
-        if (payload[0].voided) {
-          childrenPayload.find(
-            (obs) => obs.uuid == payload[0].uuid
-          ).voided = true;
+        if (payload[0].uuid) {
+          if (payload[0].voided) {
+            childrenPayload.find(
+              (obs) => obs.uuid == payload[0].uuid
+            ).voided = true;
+          } else {
+            childrenPayload.find(
+              (obs) => obs.uuid == payload[0].uuid
+            ).value = payload[0].value;
+          }
         } else {
           childrenPayload = childrenPayload.concat(payload);
         }

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -491,7 +491,7 @@ export class ObsAdapterHelper {
 
     // Get existing obs
     let childrenPayload =
-      nodeAsGroup?.initialValue?.groupMembers?.map((node) =>
+      nodeAsGroup.initialValue?.groupMembers?.map((node) =>
         this.getOldObsPayload(node)
       ) || [];
 

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -497,15 +497,12 @@ export class ObsAdapterHelper {
       const payload = this.getObsNodePayload(child);
       if (payload.length > 0) {
         isGroupChanged = true;
-        payload.forEach(obs => {
-          if (obs.uuid) {
-            if (obs.voided) {
-              childrenPayload.find(
-                (obs) => obs.uuid == obs.uuid
-              ).voided = true;
+        payload.forEach((obsPayload, index) => {
+          if (obsPayload.uuid) {
+            if (obsPayload.voided) {
+              childrenPayload.find((obs) => obs.uuid == obs.uuid).voided = true;
             } else {
-              childrenPayload.find((obs) => obs.uuid == obs.uuid).value =
-                obs.value;
+              childrenPayload.find((obs) => obs.uuid == obsPayload.uuid).value = obsPayload.value;
             }
           } else {
             childrenPayload = childrenPayload.concat(payload);

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -519,7 +519,7 @@ export class ObsAdapterHelper {
       return null;
     }
 
-    const groupPayload: any = {
+    const groupPayload = {
       groupMembers: childrenPayload,
       voided: childrenPayload?.every((member) => member.voided === true)
     };

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -497,18 +497,20 @@ export class ObsAdapterHelper {
       const payload = this.getObsNodePayload(child);
       if (payload.length > 0) {
         isGroupChanged = true;
-        if (payload[0].uuid) {
-          if (payload[0].voided) {
-            childrenPayload.find(
-              (obs) => obs.uuid == payload[0].uuid
-            ).voided = true;
+        payload.forEach(obs => {
+          if (obs.uuid) {
+            if (obs.voided) {
+              childrenPayload.find(
+                (obs) => obs.uuid == obs.uuid
+              ).voided = true;
+            } else {
+              childrenPayload.find((obs) => obs.uuid == obs.uuid).value =
+                obs.value;
+            }
           } else {
-            childrenPayload.find((obs) => obs.uuid == payload[0].uuid).value =
-              payload[0].value;
+            childrenPayload = childrenPayload.concat(payload);
           }
-        } else {
-          childrenPayload = childrenPayload.concat(payload);
-        }
+        });
       }
     });
 
@@ -576,7 +578,7 @@ export class ObsAdapterHelper {
       formFieldPath: oldObs.formFieldPath
     };
   }
-  
+
   getObsNodePayload(node: NodeBase): Array<any> {
     let payload = [];
     switch (this.getObsNodeType(node)) {

--- a/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/obs-adapter-helper.ts
@@ -489,11 +489,16 @@ export class ObsAdapterHelper {
   getGroupPayload(node: NodeBase) {
     const nodeAsGroup: GroupNode = node as GroupNode;
 
-    let childrenPayload = [];
+    // Get existing obs
+    let childrenPayload = nodeAsGroup?.initialValue?.groupMembers?.map(node => this.getOldObsPayload(node)) || [];
     _.each(nodeAsGroup.children, (child) => {
       const payload = this.getObsNodePayload(child);
       if (payload.length > 0) {
-        childrenPayload = childrenPayload.concat(payload);
+        if (payload[0].voided) {
+          childrenPayload.find(obs => obs.uuid == payload[0].uuid).voided = true;
+        } else {
+          childrenPayload = childrenPayload.concat(payload);
+        }
       }
     });
 
@@ -502,7 +507,8 @@ export class ObsAdapterHelper {
     }
 
     const groupPayload: any = {
-      groupMembers: childrenPayload
+      groupMembers: childrenPayload,
+      voided: childrenPayload?.every(member => member.voided === true)
     };
 
     if (nodeAsGroup.initialValue) {
@@ -551,6 +557,15 @@ export class ObsAdapterHelper {
     return childrenPayload;
   }
 
+  getOldObsPayload(oldObs) {
+    return {
+      uuid: oldObs.uuid,
+      concept: oldObs.concept,
+      value: oldObs.value,
+      formFieldNamespace: oldObs.formFieldNamespace,
+      formFieldPath: oldObs.formFieldPath
+    };
+  }
   getObsNodePayload(node: NodeBase): Array<any> {
     let payload = [];
     switch (this.getObsNodeType(node)) {


### PR DESCRIPTION
Issue: [https://openmrs.atlassian.net/browse/O3-2872](https://openmrs.atlassian.net/browse/O3-2872)
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
On the O3, while editing a question inside of an ObsGroup only the edited questions are saved, voiding the other questions inside of the same ObsGroup. 
This happens because the request only sends the questions that have been changed and the core will void the existing ObsGroup with all the existing questions to create a new one with the questions that came from the request.

In addiction, if an ObsGroup is empty (with all questions voided) it will void the existing ObsGroup and create a new empty one, which doesn't make sense.


1 - Create a form with an ObsGroup
![image](https://github.com/openmrs/openmrs-ngx-formentry/assets/68058940/383ba61d-8829-425f-8ba5-f4162c4ef9b1)
![image](https://github.com/openmrs/openmrs-ngx-formentry/assets/68058940/7794e4bc-aa8f-4db3-91f9-f3d6f705440d)

2 - Edit the `ObsGroup` and you will notice that only the edit concept is there.
![image](https://github.com/openmrs/openmrs-ngx-formentry/assets/68058940/c86fbecb-d755-4333-95f8-5ab1c73300cf)
Request:
```
{
   ...
   "obs":[
      {
         "groupMembers":[
            {
               "concept":"4c2e4613-e438-411e-93fd-f68667fdac21",
               "value":"bf68787c-0074-11ea-8d71-362b9e155667",
               "formFieldNamespace":"O3",
               "formFieldPath":"physicalViolenceVictim~2"
            }
         ],
         "uuid":"1ab651d0-e584-4bae-81d0-3c3259499705",
         "formFieldNamespace":"O3",
         "formFieldPath":"__LpvKGGLHu~3"
      }
   ],
   ...
}
```
![image](https://github.com/openmrs/openmrs-ngx-formentry/assets/68058940/a1792339-a316-4fd8-ab5f-1b24783f5208)

3 - Remove all ObsGroup questions and will notice that an ObsGroup has been saved but has no questions.
![image](https://github.com/openmrs/openmrs-ngx-formentry/assets/68058940/e4cba427-8013-4850-a024-5b392a448849)

Request:
```
{
   ...
   "obs":[
      {
         "value":"1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "uuid":"291ad219-2513-401b-9685-98dde61cf23d",
         "formFieldNamespace":"O3",
         "formFieldPath":"experiencePhysicalEmotionalViolence~2"
      },
      {
         "groupMembers":[
            {
               "uuid":"c89846c6-8bce-4e70-9ae8-24f34b8782fc",
               "voided":true
            }
         ],
         "uuid":"43a492d3-c2e6-4e0d-91f3-9c6f5df181a4",
         "formFieldNamespace":"O3",
         "formFieldPath":"__pFtptGqot~3"
      }
   ],
   ...
}
```
![image](https://github.com/openmrs/openmrs-ngx-formentry/assets/68058940/a4eca8b4-fd75-4dbb-a615-1e3cdccd9a6d)

<!-- Please describe what problems your PR addresses. -->

## Screenshots

<!-- Required if you are making UI changes. -->

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
