### PR TITLE
(fix) Fix lab orders UI in clinical forms

### DIFF
--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -502,7 +502,7 @@
 >
   <!--ARRAY CONTROL-->
   <div [ngSwitch]="node.question.renderingType">
-    <div class="well" style="padding: 2px" *ngSwitchCase="'repeating'">
+    <div class="well" *ngSwitchCase="'repeating'">
       <h4 style="margin: 2px; font-weight: bold">
         {{ node.question.label | translate }}
       </h4>
@@ -519,15 +519,7 @@
           >max: {{ node.question.extras.questionOptions.max }}</label
         >
       </div>
-      <hr
-        style="
-          margin-left: -2px;
-          margin-right: -2px;
-          margin-bottom: 4px;
-          margin-top: 8px;
-          border-width: 2px;
-        "
-      />
+      <hr class="divider" />
       <div [ngSwitch]="node.question.extras.type">
         <div *ngSwitchCase="'testOrder'">
           <div *ngFor="let child of node.children; let i = index">
@@ -539,8 +531,11 @@
               [labelMap]="labelMap"
             >
             </ofe-form-renderer>
-
-            <div>{{ child.orderNumber }}</div>
+            <div *ngIf="child.orderNumber" class="order-number">
+              <span
+                >{{ 'orderNumber' | translate }}: {{ child.orderNumber }}
+              </span>
+            </div>
             <div class="cds--layout">
               <button
                 type="button "
@@ -551,15 +546,7 @@
               </button>
             </div>
             <br />
-            <hr
-              style="
-                margin-left: -2px;
-                margin-right: -2px;
-                margin-bottom: 4px;
-                margin-top: 8px;
-                border-width: 1px;
-              "
-            />
+            <hr class="divider" />
           </div>
         </div>
 
@@ -581,15 +568,7 @@
               {{ 'remove' | translate }}
             </button>
             <br />
-            <hr
-              style="
-                margin-left: -2px;
-                margin-right: -2px;
-                margin-bottom: 4px;
-                margin-top: 8px;
-                border-width: 1px;
-              "
-            />
+            <hr class="divider" />
           </div>
         </div>
 
@@ -613,15 +592,7 @@
               {{ 'remove' | translate }}
             </button>
             <br />
-            <hr
-              style="
-                margin-left: -2px;
-                margin-right: -2px;
-                margin-bottom: 4px;
-                margin-top: 8px;
-                border-width: 1px;
-              "
-            />
+            <hr class="divider" />
           </div>
         </div>
         <div *ngSwitchCase="'diagnosisGroup'" style="margin-bottom: 20px">
@@ -644,15 +615,7 @@
               {{ 'remove' | translate }}
             </button>
             <br />
-            <hr
-              style="
-                margin-left: -2px;
-                margin-right: -2px;
-                margin-bottom: 4px;
-                margin-top: 8px;
-                border-width: 1px;
-              "
-            />
+            <hr class="divider" />
           </div>
         </div>
       </div>

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.scss
@@ -238,3 +238,18 @@ ng-select.form-control {
     border-width: 1px 1px 0 0;
   }
 }
+
+.divider {
+  border-color: #e0e0e0;
+  border-style: solid;
+  border-bottom: none;
+  margin: 0.75rem 0rem;
+}
+
+.order-number {
+  margin: 1rem 0;
+}
+
+.well {
+  margin-bottom: 1rem;
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -40,6 +40,7 @@
   "nextMonth": "Next month",
   "nextYear": "Next year",
   "notFoundMsg": "Match not found",
+  "orderNumber": "Order number",
   "previous": "Previous",
   "previous21Years": "Previous 21 years",
   "previousMonth": "Previous month",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -40,6 +40,7 @@
   "nextMonth": "Mois suivant",
   "nextYear": "Année suivante",
   "notFoundMsg": "Match non trouvé",
+  "orderNumber": "Numéro de commande",
   "previous": "Précédent",
   "previous21Years": "21 dernières années",
   "previousMonth": "Mois précédent",

--- a/src/translations/km.json
+++ b/src/translations/km.json
@@ -48,6 +48,7 @@
   "nextMonth": "ខែក្រោយ",
   "nextYear": "ឆ្នាំក្រោយ",
   "notFoundMsg": "រកមិនឃើញផ្គូផ្គង",
+  "orderNumber": "លេខ​លំដាប់",
   "patientIdentifierDuplication": "ស្ទួនលេខកូដអត្តសញ្ញាណអ្នកជំងឺ",
   "patientIdentifierDuplicationDescription": "លេខកូដអត្តសញ្ញាណដែលបានបញ្ចូល សម្រាប់អ្នកជំងឺមានរួចហើយ។ សូមពិនិត្យមើលលេខកូដអត្តសញ្ញាណ ហើយព្យាយាមម្តងទៀត",
   "previous": "មុន",


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the Orders UI display in clinical forms. Specifically, it targets the following UI inconsistencies:

![CleanShot 2024-03-04 at 8  09 30@2x](https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/6af3bfb7-b4cd-4af3-9c2f-c072e6108aa9)

- The dividers don't look right - they should not have a bottom border, and they're using the wrong colour.
- There's inconsistent spacing across the elements in the section.
- It's not immediately obvious that the text `ORD-701` represents the `Blood urea nitrogen` lab order's unique order number.
- Styling for the order number `div` is rendered regardless of whether an order number exists.
 
## Screenshots

### After

- Elements are spaced out further
- Consistent styling for dividers
- An identifying label for the order number 

![CleanShot 2024-03-04 at 7  48 41@2x](https://github.com/openmrs/openmrs-ngx-formentry/assets/8509731/25393802-03a6-47a3-b75b-66fffd0e7d83)

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
