### PR TITLE
(chore) Launch browser automatically on `ng serve`

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -76,7 +76,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "ngx-openmrs-formentry:build"
+            "browserTarget": "ngx-openmrs-formentry:build",
+            "open": true
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR tweaks the Angular CLI configuration for the `serve` script to automatically launch the default web browser when `ng serve` is executed.

## Screenshots

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
