### PR TITLE
(chore) Reapply v5.1.0 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,14 @@ Then update the version in the `package.json` file:
 yarn version --new-version <major|minor|patch> --no-git-tag-version
 ```
 
-Commit the change and push it to the repository:
+Note that this command only updates the version in the root-level `package.json` file. You must ensure to bump the version in the `package.json` file in the `projects/ngx-formentry` directory as well. To do so, run:
+
+```sh
+cd projects/ngx-formentry
+yarn version --new-version <major|minor|patch> --no-git-tag-version
+```
+
+Commit the changes and push them:
 
 ```sh
 git add .

--- a/projects/ngx-formentry/package.json
+++ b/projects/ngx-formentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/ngx-formentry",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "dependencies": {},
   "peerDependencies": {
     "@angular/animations": "^16.2.12",


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR bumps the Angular form engine library version to the latest minor release, v5.1.0. #138 only bumped the Angular app that consumes the library. I've added some notes to the README that hopefully makes the distinction clear and guides the next person cutting the release so they don't miss this.

## Screenshots

<!-- Required if you are making UI changes. -->

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
