### PR TITLE
(feat) Add remote-select question type and migrate data sources to o3 schema format

### DIFF
--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -138,17 +138,22 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
 
   private loadOptions() {
     this.remoteOptions$ = concat(
-      of([]), // default items
+      this.dataSource.searchOptions(
+        '',
+        this.dataSource?.dataSourceOptions ?? {}
+      ) ?? of([]), // default items
       this.remoteOptionInput$.pipe(
         distinctUntilChanged(),
         tap(() => {
           this.loading = true;
         }),
         switchMap((term) =>
-          this.dataSource.searchOptions(term).pipe(
-            catchError(() => of([])), // empty list on error
-            tap(() => (this.loading = false))
-          )
+          this.dataSource
+            .searchOptions(term, this.dataSource?.dataSourceOptions ?? {})
+            .pipe(
+              catchError(() => of([])), // empty list on error
+              tap(() => (this.loading = false))
+            )
         )
       )
     );

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -762,7 +762,7 @@ export class QuestionFactory {
     question.validators = this.addValidators(schemaQuestion);
     question.extras = schemaQuestion;
 
-    const mappings: any = {
+    const mappings: Record<string, string> = {
       label: 'label',
       required: 'required',
       id: 'key'
@@ -780,15 +780,15 @@ export class QuestionFactory {
 
   private getDataSourceConfig(
     schemaQuestion: any
-  ): { name: string; options: any } {
+  ): { name: string; options: Record<string, unknown> } {
     const dataSourceName = schemaQuestion.questionOptions?.dataSource;
     const dataSourceOptions = schemaQuestion.questionOptions?.dataSourceOptions;
     // See https://github.com/openmrs/openmrs-contrib-json-schemas/blob/main/form.schema.json
-    const openMrs3DataSource = schemaQuestion.questionOptions?.datasource;
+    const openmrs3DataSource = schemaQuestion.questionOptions?.datasource;
 
     return {
-      name: dataSourceName ?? openMrs3DataSource?.name ?? '',
-      options: dataSourceOptions ?? openMrs3DataSource?.config ?? {}
+      name: dataSourceName ?? openmrs3DataSource?.name ?? '',
+      options: dataSourceOptions ?? openmrs3DataSource?.config ?? {}
     };
   }
 

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/data-source.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/data-source.ts
@@ -2,10 +2,13 @@ import { SelectOption } from './select-option';
 import { Observable } from 'rxjs';
 
 export interface DataSource {
-  dataSourceOptions?: any;
+  dataSourceOptions?: Record<string, unknown>;
   dataFromSourceChanged?: Observable<SelectOption[]>;
   resolveSelectedValue(value): Observable<SelectOption>;
-  searchOptions(searchText): Observable<SelectOption[]>;
+  searchOptions(
+    searchText,
+    dataSourceOptions?: Record<string, unknown>
+  ): Observable<SelectOption[]>;
   fileUpload(data): Observable<any>;
   fetchFile(url: string, fileType?: string): Observable<any>;
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/remote-select-question-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/remote-select-question-options.ts
@@ -1,0 +1,6 @@
+import { BaseOptions } from '../interfaces/base-options';
+
+export interface RemoteSelectQuestionOptions extends BaseOptions {
+  dataSource: string;
+  dataSourceOptions?: Record<string, unknown>;
+}

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -30,7 +30,7 @@ export class QuestionBase implements BaseOptions {
   historicalDataValue?: any;
   extras?: any;
   dataSource?: string;
-  dataSourceOptions?: any;
+  dataSourceOptions?: Record<string, unknown>;
 
   controlType?: AfeControlType;
   validators?: Array<ValidationModel>;

--- a/projects/ngx-formentry/src/form-entry/question-models/remote-select-question.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/remote-select-question.ts
@@ -1,0 +1,16 @@
+import { QuestionBase } from './question-base';
+import { AfeControlType } from '../../abstract-controls-extension/afe-control-type';
+import { RemoteSelectQuestionOptions } from './interfaces/remote-select-question-options';
+
+export class RemoteSelectQuestion extends QuestionBase {
+  rendering: string;
+  options: any[];
+
+  constructor(options: RemoteSelectQuestionOptions) {
+    super(options);
+    this.renderingType = 'select';
+    this.controlType = AfeControlType.AfeFormControl;
+    this.dataSource = options.dataSource || '';
+    this.dataSourceOptions = options.dataSourceOptions || {};
+  }
+}

--- a/src/app/adult-1.6.json
+++ b/src/app/adult-1.6.json
@@ -319,6 +319,23 @@
               }
             },
             {
+              "id": "admitToLocation",
+              "type": "obs",
+              "required": true,
+              "label": "Admit to location",
+              "questionOptions": {
+                "rendering": "remote-select",
+                "required": true,
+                "concept": "CIEL:169403",
+                "datasource": {
+                  "name": "location_datasource",
+                  "config": {
+                    "tag": "Admission Location"
+                  }
+                }
+              }
+            },
+            {
               "type": "encounterLocation",
               "label": "Facility name (site/satellite clinic required):",
               "id": "location",
@@ -3362,7 +3379,9 @@
                   "type": "obs",
                   "hide": {
                     "field": "tb_current",
-                    "value": ["b8aa06ca-93c6-40ea-b144-c74f841926f4"]
+                    "value": [
+                      "b8aa06ca-93c6-40ea-b144-c74f841926f4"
+                    ]
                   },
                   "id": "__ptxCzFD2s"
                 }
@@ -6991,7 +7010,9 @@
                   "type": "obs",
                   "hide": {
                     "field": "q26f",
-                    "value": ["b8aa06ca-93c6-40ea-b144-c74f841926f4"]
+                    "value": [
+                      "b8aa06ca-93c6-40ea-b144-c74f841926f4"
+                    ]
                   },
                   "id": "__Jywyp94Lw"
                 }
@@ -8012,7 +8033,16 @@
               "questionOptions": {
                 "concept": "318a5e8b-218c-4f66-9106-cd581dec1f95",
                 "rendering": "date",
-                "weeksList": [2, 4, 6, 8, 12, 16, 24, 36]
+                "weeksList": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  12,
+                  16,
+                  24,
+                  36
+                ]
               },
               "validators": [
                 {
@@ -8042,7 +8072,17 @@
               "questionOptions": {
                 "concept": "a8a666ba-1350-11df-a1f1-0026b9348838",
                 "rendering": "date",
-                "weeksList": [2, 4, 6, 8, 12, 16, 20, 24, 36]
+                "weeksList": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  12,
+                  16,
+                  20,
+                  24,
+                  36
+                ]
               },
               "validators": [
                 {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -379,15 +379,14 @@ export class AppComponent implements OnInit {
         label: 'Duplix'
       }
     ];
-    if (searchText) {
-      return of(
-        locations.filter((location) =>
-          location.label.toLowerCase().includes(searchText.toLowerCase())
-        )
-      );
+    if (!searchText) {
+      return of(locations);
     }
-
-    return of(locations);
+    return of(
+      locations.filter((location) =>
+        location.label.toLowerCase().includes(searchText.toLowerCase())
+      )
+    );
   }
 
   public sampleSearch(searchText: string): Observable<any> {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -72,6 +72,10 @@ export class AppComponent implements OnInit {
       searchOptions: this.sampleSearch,
       resolveSelectedValue: this.sampleResolve
     });
+    this.dataSources.registerDataSource('location_datasource', {
+      searchOptions: this.sampleLocationSearch,
+      resolveSelectedValue: this.sampleResolve
+    });
     this.dataSources.registerDataSource('provider', {
       searchOptions: this.sampleSearch,
       resolveSelectedValue: this.sampleResolve
@@ -350,7 +354,43 @@ export class AppComponent implements OnInit {
     });
   }
 
-  public sampleSearch(): Observable<any> {
+  public sampleLocationSearch(
+    searchText: string
+  ): Observable<Array<Record<string, string>>> {
+    const locations = [
+      {
+        value: 'ba685651-ed3b-4e63-9b35-78893060758a',
+        label: 'Inpatient Ward'
+      },
+      {
+        value: '184ac7d9-225a-41f8-bac7-c87b1327e1b0',
+        label: 'Ward 1'
+      },
+      {
+        value: '5a7f3c53-6bb4-448b-a966-5e65b397b9f3',
+        label: 'Ward 2'
+      },
+      {
+        value: '2272b8cd-b690-4878-a50c-40d22235b3f3',
+        label: 'Ward 3'
+      },
+      {
+        value: 'db0253bb-8e2e-4b2c-b60c-6c88110e3c2e',
+        label: 'Duplix'
+      }
+    ];
+    if (searchText) {
+      return of(
+        locations.filter((location) =>
+          location.label.toLowerCase().includes(searchText.toLowerCase())
+        )
+      );
+    }
+
+    return of(locations);
+  }
+
+  public sampleSearch(searchText: string): Observable<any> {
     const items: Array<any> = [
       { value: '0', label: 'Aech' },
       { value: '5b6e58ea-1359-11df-a1f1-0026b9348838', label: 'Art3mis' },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,8 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi
+} from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -7,11 +10,17 @@ import { FormEntryModule } from '@openmrs/ngx-formentry';
 import { AppComponent } from './app.component';
 import { NgxTranslateModule } from './translate/translate.module';
 
-@NgModule({ declarations: [AppComponent],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    bootstrap: [AppComponent], imports: [BrowserModule,
-        BrowserAnimationsModule,
-        FormEntryModule,
-        ReactiveFormsModule,
-        NgxTranslateModule], providers: [provideHttpClient(withInterceptorsFromDi())] })
+@NgModule({
+  declarations: [AppComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  bootstrap: [AppComponent],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    FormEntryModule,
+    ReactiveFormsModule,
+    NgxTranslateModule
+  ],
+  providers: [provideHttpClient(withInterceptorsFromDi())]
+})
 export class AppModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3381,6 +3381,13 @@ ajv-formats@3.0.1:
   dependencies:
     ajv "^8.0.0"
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3374,6 +3374,13 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
+ajv-formats@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -3385,6 +3392,16 @@ ajv-keywords@^5.1.0:
   integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
   dependencies:
     fast-deep-equal "^3.1.3"
+
+ajv@8.17.1, ajv@^8.12.0:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ajv@8.17.1, ajv@^8.12.0:
   version "8.17.1"
@@ -3497,6 +3514,11 @@ aria-query@5.3.2:
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
 
+aria-query@5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
+  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
+
 array-buffer-byte-length@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
@@ -3580,6 +3602,11 @@ aws4@^1.8.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
   integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
+
+axobject-query@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
+  integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
 axobject-query@4.1.0:
   version "4.1.0"
@@ -7948,6 +7975,11 @@ picomatch@4.0.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
+picomatch@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -8716,6 +8748,11 @@ selfsigned@^2.4.1:
   dependencies:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
+
+semver@7.6.3, semver@^7.5.4, semver@^7.6.0:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 semver@7.6.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3374,20 +3374,6 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv-formats@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
-  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
-  dependencies:
-    ajv "^8.0.0"
-
-ajv-formats@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
-  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
-  dependencies:
-    ajv "^8.0.0"
-
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -3399,16 +3385,6 @@ ajv-keywords@^5.1.0:
   integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
   dependencies:
     fast-deep-equal "^3.1.3"
-
-ajv@8.17.1, ajv@^8.12.0:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
 
 ajv@8.17.1, ajv@^8.12.0:
   version "8.17.1"
@@ -3521,11 +3497,6 @@ aria-query@5.3.2:
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
 
-aria-query@5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
-  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
-
 array-buffer-byte-length@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
@@ -3609,11 +3580,6 @@ aws4@^1.8.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
   integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
-
-axobject-query@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
-  integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
 axobject-query@4.1.0:
   version "4.1.0"
@@ -7982,11 +7948,6 @@ picomatch@4.0.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
-picomatch@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
-  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
-
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -8755,11 +8716,6 @@ selfsigned@^2.4.1:
   dependencies:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
-
-semver@7.6.3, semver@^7.5.4, semver@^7.6.0:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 semver@7.6.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.3"


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Implements two changes:
1. Updates `dataSources` schema to align with [o3 format](https://github.com/openmrs/openmrs-contrib-json-schemas/blob/36ea64ac4c18a94719ddc380679cca9a6e3cf910/form.schema.json#L574) while maintaining backwards compatibility
2. Adds support for remote-select question type control


#### Sample Schema

```json
{
    "id": "admitToLocation",
    "type": "obs",
    "required": true,
    "label": "Admit to location",
    "questionOptions": {
        "rendering": "remote-select",
        "required": true,
        "concept": "CIEL:169403",
        "datasource": {
            "name": "location_datasource",
            "config": {
                "tag": "Admission Location"
            }
        }
    }
}
```

## Screenshots

![Kapture 2025-01-10 at 18 03 16](https://github.com/user-attachments/assets/e62e4a89-a84e-4c1e-84d2-308058a1ae62)


## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
