### PR TITLE
(fix) Set number input background color to white

### DIFF
--- a/projects/ngx-formentry/src/components/number-input/number-input.component.html
+++ b/projects/ngx-formentry/src/components/number-input/number-input.component.html
@@ -1,7 +1,7 @@
 <div
   data-numberinput
   [attr.data-invalid]="invalid ? true : null"
-  class="cds--number"
+  class="cds--number cds--layer-two"
   [ngClass]="{
     'cds--number--light': theme === 'light',
     'cds--number--nolabel': !label,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
As you may know, this project is widely used as a dependency for the OpenMRS [esm-form-entry-app](https://github.com/openmrs/openmrs-esm-patient-chart/tree/main/packages/esm-form-entry-app) module.

This Pull Request fixes a styling issue where "our custom input of type number" displayed an incorrect gray background (see Figure 1). By applying the `cds--layer-two class`, this change ensures that number inputs have the correct white background, making them visually consistent with other input types (such as text, textarea, etc.) (Figure 2, Figure 3).

### Why it's hidden locally: 

Running this standalone app doesn't immediately show the bug because it overrides the `--cds-field` variable in the root stylesheet. However, the gray background becomes clearly visible when the project is embedded as a dependency inside the [esm-form-entry-app](https://github.com/openmrs/openmrs-esm-patient-chart/tree/main/packages/esm-form-entry-app).

Please remember that the [dev3](https://dev3.openmrs.org/) development environment does not reflect this issue either, because it uses the new [React-based form engine](https://github.com/openmrs/openmrs-esm-patient-chart/tree/main/packages/esm-form-engine-app).


## Screenshots

<!-- Required if you are making UI changes. -->
<img width="524" height="81" alt="image" src="https://github.com/user-attachments/assets/82425420-3bd9-44d4-9bc3-8fbe3ae0dfa1" />

_Figure 1: number input with style bug_


<img width="518" height="85" alt="image" src="https://github.com/user-attachments/assets/5c33676a-613a-4255-bdd4-c6022698f912" />

_Figure 2: number input with style fixed_


<img width="525" height="147" alt="image" src="https://github.com/user-attachments/assets/bad2bbe4-6796-4857-950a-4dbbbe4deffb" />

_Figure 3: textarea for reference (nothing was done here_


## Related Issue

N/A

## Other
Thanks,

