### PR TITLE
(fix) Align engine behavior with the documented schema contract

### DIFF
--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.spec.ts
@@ -657,6 +657,27 @@ describe('Question Factory', () => {
     expect(converted.hide).toEqual(numericSchemaQuestion.hide);
   });
 
+  it('should derive numeric validators for numeric rendering questions', () => {
+    const schemaQuestion: any = {
+      label: 'Number of weeks on treatment:',
+      id: 'ArvWeeks',
+      type: 'obs',
+      questionOptions: {
+        rendering: 'numeric',
+        concept: 'a89add22-1350-11df-a1f1-0026b9348838',
+        min: '0',
+        max: '52',
+        disallowDecimals: true
+      }
+    };
+
+    const converted = factory.toNumericQuestion(schemaQuestion);
+    const types = converted.validators.map((v: any) => v.type);
+    expect(types).toContain('min');
+    expect(types).toContain('max');
+    expect(types).toContain('disallowDecimals');
+  });
+
   it('should convert schema number question to Number question model', () => {
     const converted = factory.toNumberQuestion(numberSchemaQuestion);
     expect(converted.label).toEqual(numberSchemaQuestion.label);

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -1077,6 +1077,7 @@ export class QuestionFactory {
     switch (renderingType) {
       case 'decimal':
       case 'number':
+      case 'numeric':
         if (questionOptions.max && questionOptions.min) {
           validators.push(
             new MaxValidationModel({

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -203,9 +203,7 @@
               [buttonLabel]="node.question.extras.questionOptions.buttonLabel"
               [buttonType]="node.question.extras.questionOptions.buttonType" [workspaceName]="
                 node.question.extras.questionOptions.workspaceName
-              " [additionalProps]="
-                node.question.extras.questionOptions.additionalProps
-              " [node]="node"></ofe-workspace-launcher>
+              " [additionalProps]="node.question.additionalProps" [node]="node"></ofe-workspace-launcher>
           </div>
 
           <input [theme]="theme" class="cds--text-input" ofeTextInput *ngSwitchDefault

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.spec.ts
@@ -1,0 +1,97 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { FormEntryModule } from '../form-entry.module';
+import { Form } from '../form-factory/form';
+import { FormFactory } from '../form-factory/form.factory';
+import { WorkspaceLauncherComponent } from '../../components/workspace-launcher/workspace-launcher.component';
+
+const schema: any = {
+  name: 'Workspace Launcher Test',
+  processor: 'EncounterFormProcessor',
+  uuid: 'workspace-launcher-test-uuid',
+  referencedForms: [],
+  pages: [
+    {
+      label: 'Test Page',
+      sections: [
+        {
+          label: 'Test Section',
+          isExpanded: 'true',
+          questions: [
+            {
+              id: 'orderLauncher',
+              label: 'Order drugs:',
+              questionOptions: {
+                rendering: 'workspace-launcher',
+                workspaceName: 'add-drug-order',
+                buttonLabel: 'Add +',
+                buttonType: 'ghost',
+                workspaceProps: { patientUuid: 'test-patient-uuid' }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+@Component({
+  template: `
+    <form [formGroup]="form.rootNode.control">
+      <ofe-form-renderer
+        [node]="form.rootNode"
+        [labelMap]="{}"
+      ></ofe-form-renderer>
+    </form>
+  `,
+  standalone: false
+})
+class TestHostComponent {
+  form: Form;
+
+  constructor(formFactory: FormFactory) {
+    this.form = formFactory.createForm(schema);
+  }
+}
+
+describe('FormRendererComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestHostComponent],
+      imports: [ReactiveFormsModule, FormEntryModule, TranslateModule.forRoot()],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.autoDetectChanges();
+  });
+
+  it('passes normalized workspaceProps to the workspace launcher', async () => {
+    // The tab set activates its first tab in a setTimeout after content
+    // init, so wait for the zone to settle before tab content renders.
+    await fixture.whenStable();
+
+    const launcher = fixture.debugElement.query(
+      By.directive(WorkspaceLauncherComponent)
+    );
+    expect(launcher).toBeTruthy();
+    expect(launcher.componentInstance.additionalProps).toEqual({
+      patientUuid: 'test-patient-uuid'
+    });
+  });
+});

--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.spec.ts
@@ -71,6 +71,41 @@ describe('JS Expression Helper Service:', () => {
     expect(obsValue).toBe(173);
   });
 
+  it('should preserve falsy control and observation values', () => {
+    const helper: JsExpressionHelper = TestBed.inject(JsExpressionHelper);
+    const encounter = {
+      obs: [
+        {
+          concept: { uuid: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+          value: 0,
+          groupMembers: null
+        }
+      ]
+    };
+
+    // A falsy target control value is still a value
+    expect(
+      helper.getObsFromControlOrEncounter(0, encounter, 'irrelevant-uuid')
+    ).toBe(0);
+    expect(
+      helper.getObsFromControlOrEncounter(false, encounter, 'irrelevant-uuid')
+    ).toBe(false);
+
+    // A falsy observation value is returned rather than null
+    expect(
+      helper.getObsFromControlOrEncounter(
+        null,
+        encounter,
+        '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+      )
+    ).toBe(0);
+
+    // Nothing found still returns null
+    expect(
+      helper.getObsFromControlOrEncounter(null, encounter, 'missing-uuid')
+    ).toBeNull();
+  });
+
   it('should return true if value is empty, null or undefined', () => {
     const helper: JsExpressionHelper = TestBed.inject(JsExpressionHelper);
     let val = '';

--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -308,12 +308,14 @@ export class JsExpressionHelper {
       );
       return result;
     };
+    const hasValue = (value) =>
+      value !== null && value !== undefined && value !== '';
     const obsValue = findObs(rawEncounter?.obs, uuid)?.value;
-    return !!targetControl
+    return hasValue(targetControl)
       ? targetControl
-      : typeof obsValue === 'object'
+      : obsValue !== null && typeof obsValue === 'object'
       ? obsValue.uuid
-      : !!obsValue
+      : hasValue(obsValue)
       ? obsValue
       : null;
   }

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -14,6 +14,7 @@ export class QuestionBase implements BaseOptions {
   historicalDisplay?: any;
   rows?: any;
   showWeeksAdder?: any;
+  additionalProps?: Record<string, unknown>;
   datePickerFormat: string;
   key: string;
   alert?: any;

--- a/projects/ngx-formentry/src/form-entry/validators/conditional-answered.validator.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/conditional-answered.validator.spec.ts
@@ -79,4 +79,39 @@ describe('Conditional Answered Validator:', () => {
     result = validator.validate(model)(control);
     expect(result).toBe(null);
   });
+
+  it('should handle array-valued referenced questions', () => {
+    const validator: ConditionalAnsweredValidator = TestBed.inject(
+      ConditionalAnsweredValidator
+    );
+    const model = new ConditionalValidationModel({
+      type: 'conditionalAnswered',
+      message: 'test message',
+      referenceQuestionId: 'control2',
+      referenceQuestionAnswers: ['a']
+    });
+
+    const control = new AfeFormControl();
+    control.uuid = 'control1';
+    control.setValue('answered');
+    const control2 = new AfeFormControl();
+    control2.uuid = 'control2';
+
+    control.controlRelations.addRelatedControls(control2);
+
+    // A multi-select answer containing an allowed value passes
+    control2.setValue(['a', 'x']);
+    let result = validator.validate(model)(control);
+    expect(result).toBe(null);
+
+    // A multi-select answer without any allowed value fails
+    control2.setValue(['x', 'y']);
+    result = validator.validate(model)(control);
+    expect(result['conditional_answered']).toBeTruthy();
+
+    // An empty multi-select counts as unanswered and fails
+    control2.setValue([]);
+    result = validator.validate(model)(control);
+    expect(result['conditional_answered']).toBeTruthy();
+  });
 });

--- a/projects/ngx-formentry/src/form-entry/validators/conditional-answered.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/conditional-answered.validator.ts
@@ -33,13 +33,28 @@ export class ConditionalAnsweredValidator {
               }
             }
 
-            if (!relationValue) {
-              successCondition = false;
-            } else if (
-              typeof referenceQuestionAnswers === 'object' &&
-              referenceQuestionAnswers.indexOf(relationValue) === -1
+            if (
+              !relationValue ||
+              (Array.isArray(relationValue) && relationValue.length === 0)
             ) {
               successCondition = false;
+            } else if (typeof referenceQuestionAnswers === 'object') {
+              if (Array.isArray(relationValue)) {
+                const values = relationValue.map((v) =>
+                  v && typeof v === 'object' && v.value ? v.value : v
+                );
+                if (
+                  !values.some(
+                    (v) => referenceQuestionAnswers.indexOf(v) !== -1
+                  )
+                ) {
+                  successCondition = false;
+                }
+              } else if (
+                referenceQuestionAnswers.indexOf(relationValue) === -1
+              ) {
+                successCondition = false;
+              }
             }
           });
         }

--- a/projects/ngx-formentry/src/form-entry/validators/disallow-decimals.validator.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/disallow-decimals.validator.spec.ts
@@ -19,4 +19,20 @@ describe('DisallowDecimalsValidator', () => {
 
     expect(formControl.errors['disallowDecimals']).toBe(true);
   });
+
+  it('should return null when a negative integer is provided', () => {
+    const validator: DisallowDecimalsValidator = new DisallowDecimalsValidator();
+
+    const formControl = new AfeFormControl('-42', [validator.validate()]);
+
+    expect(formControl.errors).toBe(null);
+  });
+
+  it('should return an error when a negative decimal is provided', () => {
+    const validator: DisallowDecimalsValidator = new DisallowDecimalsValidator();
+
+    const formControl = new AfeFormControl('-42.5', [validator.validate()]);
+
+    expect(formControl.errors['disallowDecimals']).toBe(true);
+  });
 });

--- a/projects/ngx-formentry/src/form-entry/validators/disallow-decimals.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/disallow-decimals.validator.ts
@@ -8,7 +8,7 @@ export class DisallowDecimalsValidator {
       }
 
       if (control.value && control.value.length !== 0) {
-        const test: boolean = !/^\d+$/.test(control.value);
+        const test: boolean = !/^-?\d+$/.test(control.value);
         return test ? { disallowDecimals: true } : null;
       }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

While auditing the AMPATH Forms documentation against the engine source, five places surfaced where the engine behaves differently than the O3 form schema contract suggests. This PR fixes all five:

- **Workspace launcher props**: the question factory normalizes `questionOptions.workspaceProps ?? questionOptions.additionalProps` into the question model, but the renderer bound the raw schema `additionalProps`, so schemas using `workspaceProps` launched their workspace with an empty props object. The renderer now binds the normalized `node.question.additionalProps`.
- **`numeric` rendering validation**: `numeric` dispatches to the same number input as `number` and `decimal`, but `addValidators` only derived the `min`/`max`, length, and `disallowDecimals` validators for the latter two. `numeric` questions silently lost those constraints; the rendering is now included in the validator derivation.
- **`disallowDecimals` and negative integers**: the validator's `/^\d+$/` pattern rejected any non-digit character, including the minus sign on a valid negative integer. The pattern now accepts an optional leading minus.
- **`conditionalAnswered` with multi-valued references**: the validator compared `referenceQuestionAnswers.indexOf(relationValue)`, which always fails when the referenced question is a checkbox or `multi-select` (array value). Array values now pass when any selected answer is in the allowed set, and an empty array counts as unanswered.
- **Falsy values in `getObsFromControlOrEncounter`**: truthiness checks collapsed valid falsy values (`0`, `false`) to `null` and made a falsy target control fall through to the encounter lookup. Only `null`, `undefined`, and empty string are treated as missing now.

Each fix is covered by a new or extended spec, including a new form-renderer spec that renders a `workspace-launcher` question with `workspaceProps` through the real tab set and asserts the launcher receives the props.

## Screenshots

## Related Issue

## Other
