### PR TITLE
(feat) Add custom api dropdown control

### DIFF
--- a/projects/ngx-formentry/src/components/custom-endpoint-dropdown/custom-endpoint-dropdown.component.ts
+++ b/projects/ngx-formentry/src/components/custom-endpoint-dropdown/custom-endpoint-dropdown.component.ts
@@ -1,0 +1,92 @@
+import { Component, Input, OnInit, forwardRef } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+@Component({
+  selector: 'ofe-custom-endpoint-dropdown',
+  template: `
+    <div>
+      <label [attr.for]="question.key"></label>
+      <ng-select
+        [ngClass]="{
+            'afe-custom': theme === 'light'
+        }"
+        [items]="options$ | async"
+        bindLabel="label"
+        bindValue="value"
+        [multiple]="false"
+        >
+        </ng-select>
+    </div>
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CustomEndpointDropdownComponent),
+      multi: true
+    }
+  ],
+  standalone: false
+})
+export class CustomEndpointDropdownComponent implements OnInit, ControlValueAccessor {
+  @Input() question: any;
+  @Input() theme!:string;
+  value: any = '';
+  disabled = false;
+  onChange: any = () => {};
+  onTouched: any = () => {};
+  endpointUrl = '';
+  valueKey:string = 'uuid';
+  labelKey:string = 'display';
+  options$!: Observable<any[]>
+  
+  constructor(private http:HttpClient){
+
+  }
+
+  ngOnInit() {
+    this.getControlValues();
+    this.setValueObservable();
+  }
+
+  getControlValues(){
+    this.endpointUrl = this.question.extras.questionOptions.renderingOptions?.endpointUrl ?? '';
+    this.valueKey = this.question.extras.questionOptions.renderingOptions?.valueKey ?? 'uuid';
+    this.labelKey = this.question.extras.questionOptions.renderingOptions?.labelKey ?? 'display';
+  }
+  setValueObservable(){
+    if(this.endpointUrl && this.valueKey && this.labelKey){
+      this.options$ = this.http.get(this.endpointUrl)
+      .pipe(
+        map((response: any) => {
+        const dataArray = response.results || response; 
+        if(!dataArray){
+            return [];
+        }else{
+           return dataArray.map((item: any) => ({
+            value: item[`${this.valueKey}`],
+            label: item[`${this.labelKey}`]
+           }));
+        }
+        }),
+        catchError((err) => {
+          console.error('Failed to load data', err);
+          return of([]);
+        })
+       );
+    }
+  
+  }
+
+  onDropdownChange(val: any) {
+    this.value = val;
+    this.onChange(val);
+    this.onTouched();
+  }
+  writeValue(value: any): void { this.value = value || ''; }
+  registerOnChange(fn: any): void { this.onChange = fn; }
+  registerOnTouched(fn: any): void { this.onTouched = fn; }
+  setDisabledState?(isDisabled: boolean): void { this.disabled = isDisabled; }
+}

--- a/projects/ngx-formentry/src/components/custom-endpoint-dropdown/custom-endpoint-dropdown.module.ts
+++ b/projects/ngx-formentry/src/components/custom-endpoint-dropdown/custom-endpoint-dropdown.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { FormsModule } from '@angular/forms';
+import { CustomEndpointDropdownComponent } from './custom-endpoint-dropdown.component';
+import { NgSelectModule } from '@ng-select/ng-select';
+
+@NgModule({
+  declarations: [CustomEndpointDropdownComponent],
+  exports: [CustomEndpointDropdownComponent],
+  imports: [CommonModule, FormsModule, TranslateModule, NgSelectModule]
+})
+export class CustomEndpointDropdownModule {}

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -46,6 +46,7 @@ import { CustomControlWrapperModule } from '../components/custom-control-wrapper
 import { CustomComponentWrapperModule } from '../components/custom-component-wrapper/custom-component-wrapper.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { PatientIdentifierAdapter } from './value-adapters/patient-identifier.adapter';
+import { CustomEndpointDropdownModule } from '../components/custom-endpoint-dropdown/custom-endpoint-dropdown.module';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -67,7 +68,8 @@ import { PatientIdentifierAdapter } from './value-adapters/patient-identifier.ad
     CustomControlWrapperModule,
     CustomComponentWrapperModule,
     NgxTabSetModule.forRoot(),
-    TranslateModule
+    TranslateModule,
+    CustomEndpointDropdownModule
   ],
   declarations: [
     FormRendererComponent,

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -778,6 +778,37 @@ export class QuestionFactory {
     return question;
   }
 
+  toCustomApiQuestion(schemaQuestion: any): UiSelectQuestion {
+    const question = new UiSelectQuestion({
+      options: [],
+      type: '',
+      key: '',
+      searchFunction: function () {},
+      resolveFunction: function () {}
+    });
+    question.questionIndex = this.quetionIndex;
+    question.label = schemaQuestion.label;
+    question.prefix = schemaQuestion.prefix;
+    question.key = schemaQuestion.id;
+    question.renderingType = 'custom-api-dropdown';
+    question.validators = this.addValidators(schemaQuestion);
+    question.extras = schemaQuestion;
+    question.dataSource = '';
+
+    const mappings: any = {
+      label: 'label',
+      required: 'required',
+      id: 'key'
+    };
+    question.componentConfigs = schemaQuestion.componentConfigs || [];
+    this.copyProperties(mappings, schemaQuestion, question);
+    this.addDisableOrHideProperty(schemaQuestion, question);
+    this.addAlertProperty(schemaQuestion, question);
+    this.addHistoricalExpressions(schemaQuestion, question);
+    this.addCalculatorProperty(schemaQuestion, question);
+    return question;
+  }
+
   private getDataSourceConfig(
     schemaQuestion: any
   ): { name: string; options: Record<string, unknown> } {
@@ -990,6 +1021,8 @@ export class QuestionFactory {
         return this.toWorkspaceLauncher(schema);
       case 'remote-select':
         return this.toRemoteSelectQuestion(schema);
+      case 'custom-api-dropdown':
+        return this.toCustomApiQuestion(schema);
       default:
         console.warn('New Schema Question Type found.........' + renderType);
         return this.toTextQuestion(schema);

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -224,6 +224,15 @@
             <ofe-checkbox [id]="node.question.key + 'id' + controlId" [formControlName]="node.question.key"
               [options]="node.question.options" [selected]="node.control.value"></ofe-checkbox>
           </div>
+          <div *ngSwitchCase="'custom-api-dropdown'">
+            <ofe-custom-endpoint-dropdown
+            [theme]="theme"
+            [question]="node.question"
+            [id]="node.question.key + 'id' + controlId" 
+            [formControlName]="node.question.key"
+            >
+          </ofe-custom-endpoint-dropdown>
+          </div>
 
           <div *ngIf="
               node.question.enableHistoricalValue &&

--- a/src/app/adult-1.6.json
+++ b/src/app/adult-1.6.json
@@ -8210,7 +8210,32 @@
                       "validators": []
                     }
                   ]
-                }
+                },
+              {
+              "type": "obsGroup",
+              "label": "Consulting Doctors",
+              "required":"true",
+              "questionOptions": {
+                "concept": "a8a003a6-1350-11df-a1f1-0026b9348838",
+                "rendering": "repeating"
+              },
+                "questions": [
+                   {
+                      "label": "Doctor",
+                      "id": "doctor",
+                      "type": "obs",
+                      "questionOptions": {
+                        "concept": "a8a666ba-1350-11df-a1f1-0026b9348838",
+                        "rendering": "custom-api-dropdown", 
+                        "renderingOptions": {
+                          "endpointUrl": "https://jsonplaceholder.typicode.com/users",
+                          "labelKey": "name",
+                          "valueKey": "id"
+                        }
+                      }
+                    }
+                ]
+            }
               ]
             }
           ]


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR introduces a custom control that is given the endpoint URL of a resource, and once selected if fetches the data from the endpoint and generates a dropdown list based on properties specified in the renderOptions. This allows for making use of existing api endpoints instead of having to create a specific control for that entity. It can be used for OpenMRS endpoints, custom api endpoints, or even public APIs.

## Screenshots
<img width="1470" height="956" alt="Screenshot 2026-07-14 at 11 51 22" src="https://github.com/user-attachments/assets/c1efea6b-9d70-415e-a103-bf25fe035517" />

```json
{
  "label": "Doctor",
  "id": "doctor",
  "type": "obs",
  "questionOptions": {
    "concept": "a8a666ba-1350-11df-a1f1-0026b9348838",
    "rendering": "custom-api-dropdown",
    "renderingOptions": {
      "endpointUrl": "https://jsonplaceholder.typicode.com/users",
      "labelKey": "name",
      "valueKey": "id"
    }
  }
}
```