### PR TITLE
(feat) O3-5815: Show ICD-11 codes next to diagnoses in the diagnosis picker

### DIFF
--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.spec.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.spec.ts
@@ -1,0 +1,85 @@
+import { Renderer2 } from '@angular/core';
+import { of } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+
+import { DataSource } from '../../form-entry/question-models/interfaces/data-source';
+import { RemoteSelectComponent } from './ngx-remote-select.component';
+
+describe('RemoteSelectComponent', () => {
+  const createComponent = () =>
+    new RemoteSelectComponent(
+      {} as Renderer2,
+      { instant: (key: string) => key } as TranslateService
+    );
+
+  const createDataSource = (): jasmine.SpyObj<DataSource> => {
+    const dataSource = jasmine.createSpyObj<DataSource>('DataSource', [
+      'searchOptions',
+      'resolveSelectedValue',
+      'fileUpload',
+      'fetchFile'
+    ]);
+    dataSource.searchOptions.and.returnValue(of([]));
+    dataSource.resolveSelectedValue.and.returnValue(
+      of({ value: 'diagnosis-uuid', label: 'Diagnosis' })
+    );
+    return dataSource;
+  };
+
+  it('passes control-specific options to searches on a shared data source', () => {
+    const dataSource = createDataSource();
+    const firstOptions = { conceptSourceUuid: 'source-a' };
+    const secondOptions = { conceptSourceUuid: 'source-b' };
+    const firstComponent = createComponent();
+    const secondComponent = createComponent();
+
+    firstComponent.dataSource = dataSource;
+    firstComponent.dataSourceOptions = firstOptions;
+    firstComponent.ngOnInit();
+    secondComponent.dataSource = dataSource;
+    secondComponent.dataSourceOptions = secondOptions;
+    secondComponent.ngOnInit();
+
+    expect(dataSource.searchOptions).toHaveBeenCalledWith('', firstOptions);
+    expect(dataSource.searchOptions).toHaveBeenCalledWith('', secondOptions);
+  });
+
+  it('passes control-specific options when resolving a selected value', () => {
+    const dataSource = createDataSource();
+    const options = { conceptSourceUuid: 'source-a' };
+    const component = createComponent();
+    component.dataSource = dataSource;
+    component.dataSourceOptions = options;
+
+    component.writeValue('diagnosis-uuid');
+
+    expect(dataSource.resolveSelectedValue).toHaveBeenCalledWith(
+      'diagnosis-uuid',
+      options
+    );
+  });
+
+  it('uses explicit empty options instead of shared data source options', () => {
+    const dataSource = createDataSource();
+    dataSource.dataSourceOptions = { conceptSourceUuid: 'shared-source' };
+    const component = createComponent();
+    component.dataSource = dataSource;
+    component.dataSourceOptions = {};
+
+    component.ngOnInit();
+
+    expect(dataSource.searchOptions).toHaveBeenCalledWith('', {});
+  });
+
+  it('falls back to data source options when no input is provided', () => {
+    const dataSource = createDataSource();
+    const options = { concept: 'concept-uuid' };
+    dataSource.dataSourceOptions = options;
+    const component = createComponent();
+    component.dataSource = dataSource;
+
+    component.ngOnInit();
+
+    expect(dataSource.searchOptions).toHaveBeenCalledWith('', options);
+  });
+});

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -5,7 +5,8 @@ import {
   forwardRef,
   Output,
   EventEmitter,
-  Renderer2, OnDestroy
+  Renderer2,
+  OnDestroy
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { concat, Observable, of, Subject } from 'rxjs';
@@ -23,19 +24,20 @@ import * as _ from 'lodash';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
-    selector: 'ofe-remote-select',
-    templateUrl: 'remote-select.component.html',
-    styleUrls: ['./remote-select.component.scss'],
-    providers: [
-        {
-            provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => RemoteSelectComponent),
-            multi: true
-        }
-    ],
-    standalone: false
+  selector: 'ofe-remote-select',
+  templateUrl: 'remote-select.component.html',
+  styleUrls: ['./remote-select.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => RemoteSelectComponent),
+      multi: true
+    }
+  ],
+  standalone: false
 })
-export class RemoteSelectComponent implements OnInit, ControlValueAccessor, OnDestroy {
+export class RemoteSelectComponent
+  implements OnInit, ControlValueAccessor, OnDestroy {
   // @Input() dataSource: DataSource;
   remoteOptions$: Observable<SelectOption[]>;
   remoteOptionsLoading = false;
@@ -48,6 +50,7 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor, OnDe
   notFoundMsg = this.translate.instant('matchNotFound');
   @Input() placeholder = this.translate.instant('search');
   @Input() componentID: string;
+  @Input() dataSourceOptions?: Record<string, unknown>;
   @Input() disabled = false;
   @Input() theme = 'dark';
   @Input() invalid = 'false';
@@ -91,16 +94,18 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor, OnDe
     if (value && value !== '') {
       if (this.dataSource) {
         this.loading = true;
-        this.dataSource.resolveSelectedValue(value).subscribe(
-          (result: any) => {
-            this.items = [result];
-            this.selectedRemoteOptions = result;
-            this.loading = false;
-          },
-          (error) => {
-            this.loading = false;
-          }
-        );
+        this.dataSource
+          .resolveSelectedValue(value, this.effectiveDataSourceOptions())
+          .subscribe(
+            (result: any) => {
+              this.items = [result];
+              this.selectedRemoteOptions = result;
+              this.loading = false;
+            },
+            (error) => {
+              this.loading = false;
+            }
+          );
       }
     }
   }
@@ -142,7 +147,7 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor, OnDe
   private loadOptions() {
     this.remoteOptions$ = concat(
       this.dataSource
-        .searchOptions('', this.dataSource?.dataSourceOptions ?? {})
+        .searchOptions('', this.effectiveDataSourceOptions())
         ?.pipe(
           catchError((error) => {
             console.error('Error loading initial options:', error);
@@ -156,7 +161,7 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor, OnDe
         }),
         switchMap((term) =>
           this.dataSource
-            .searchOptions(term, this.dataSource?.dataSourceOptions ?? {})
+            .searchOptions(term, this.effectiveDataSourceOptions())
             .pipe(
               catchError((error) => {
                 console.error('Error loading options:', error);
@@ -169,6 +174,10 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor, OnDe
         )
       )
     );
+  }
+
+  private effectiveDataSourceOptions(): Record<string, unknown> {
+    return this.dataSourceOptions ?? this.dataSource?.dataSourceOptions ?? {};
   }
 
   ngOnDestroy() {

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -15,6 +15,7 @@ import {
   distinctUntilChanged,
   finalize,
   switchMap,
+  take,
   tap
 } from 'rxjs/operators';
 import { SelectOption } from '../../form-entry/question-models/interfaces/select-option';
@@ -55,6 +56,11 @@ export class RemoteSelectComponent
   @Input() theme = 'dark';
   @Input() invalid = 'false';
   @Output() done: EventEmitter<any> = new EventEmitter<any>();
+
+  // Results come from server-side typeahead searches. Concept search matches
+  // synonyms and index terms whose display label may not contain the typed
+  // text, so ng-select must not re-filter results by label.
+  keepServerResults = () => true;
 
   private _dataSource: DataSource;
   @Input()
@@ -148,7 +154,10 @@ export class RemoteSelectComponent
     this.remoteOptions$ = concat(
       this.dataSource
         .searchOptions('', this.effectiveDataSourceOptions())
+        // concat only subscribes to the typeahead stream once the initial
+        // load completes, and not every datasource completes its observable
         ?.pipe(
+          take(1),
           catchError((error) => {
             console.error('Error loading initial options:', error);
             return of([]);

--- a/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/ngx-remote-select.component.ts
@@ -25,6 +25,7 @@ import { TranslateService } from '@ngx-translate/core';
 @Component({
     selector: 'ofe-remote-select',
     templateUrl: 'remote-select.component.html',
+    styleUrls: ['./remote-select.component.scss'],
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,

--- a/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
@@ -18,4 +18,20 @@
   (ngModelChange)="selectedRemoteOptions = $event; selected($event)"
   [appendTo]="'form'"
 >
+  <ng-template ng-label-tmp let-item="item">
+    <span class="ofe-remote-select-item">
+      <span class="ofe-remote-select-item-code" *ngIf="item?.code">{{
+        item.code
+      }}</span>
+      <span class="ofe-remote-select-item-label">{{ item?.label }}</span>
+    </span>
+  </ng-template>
+  <ng-template ng-option-tmp let-item="item">
+    <span class="ofe-remote-select-item">
+      <span class="ofe-remote-select-item-code" *ngIf="item?.code">{{
+        item.code
+      }}</span>
+      <span class="ofe-remote-select-item-label">{{ item?.label }}</span>
+    </span>
+  </ng-template>
 </ng-select>

--- a/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.html
@@ -14,6 +14,7 @@
   [loading]="loading"
   [typeToSearchText]="'enterMoreCharacters' | translate"
   [typeahead]="remoteOptionInput$"
+  [searchFn]="keepServerResults"
   [ngModel]="selectedRemoteOptions"
   (ngModelChange)="selectedRemoteOptions = $event; selected($event)"
   [appendTo]="'form'"

--- a/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.scss
+++ b/projects/ngx-formentry/src/components/ngx-remote-select/remote-select.component.scss
@@ -1,0 +1,23 @@
+.ofe-remote-select-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.ofe-remote-select-item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ofe-remote-select-item-code {
+  flex: none;
+  min-width: 4rem;
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: 'IBM Plex Mono', 'Menlo', 'Consolas', monospace;
+  font-weight: 600;
+  color: inherit;
+}

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.spec.ts
@@ -135,6 +135,23 @@ describe('Question Factory', () => {
     }
   };
 
+  const diagnosisSchemaQuestion: any = {
+    type: 'diagnosis',
+    label: 'Final diagnosis:',
+    id: 'finalDiagnosisId',
+    required: 'true',
+    questionOptions: {
+      rendering: 'repeating',
+      rank: 2,
+      datasource: {
+        name: 'diagnoses',
+        config: {
+          conceptSourceUuid: '43aaca5f-d623-43fd-993b-673b5d927cdd'
+        }
+      }
+    }
+  };
+
   const repeatingGroupSchemaQuestion: any = {
     label: 'Other Medications',
     questions: [
@@ -710,6 +727,31 @@ describe('Question Factory', () => {
     expect(converted.label).toEqual(problemSchemaQuestion.label);
     expect(converted.key).toEqual(problemSchemaQuestion.id);
     expect(converted.renderingType).toEqual('remote-select');
+  });
+
+  it('should convert schema diagnosis question to Diagnosis question model', () => {
+    const converted = factory.toDiagnosisQuestion(diagnosisSchemaQuestion);
+    expect(converted.label).toEqual(diagnosisSchemaQuestion.label);
+    expect(converted.key).toEqual(diagnosisSchemaQuestion.id);
+    expect(converted.renderingType).toEqual('remote-select');
+    expect(converted.dataSource).toEqual('diagnoses');
+    expect(converted.dataSourceOptions).toEqual({
+      conceptSourceUuid: '43aaca5f-d623-43fd-993b-673b5d927cdd'
+    });
+  });
+
+  it('should default the diagnosis data source and leave options unset when the schema names none', () => {
+    const converted = factory.toDiagnosisQuestion({
+      type: 'diagnosis',
+      label: 'Primary diagnosis:',
+      id: 'primaryDiagnosisId',
+      questionOptions: {
+        rendering: 'repeating',
+        rank: 1
+      }
+    });
+    expect(converted.dataSource).toEqual('diagnoses');
+    expect(converted.dataSourceOptions).toBeUndefined();
   });
 
   it('should convert schema group question to Group question model', () => {

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -730,8 +730,11 @@ export class QuestionFactory {
     question.renderingType = 'remote-select';
     question.validators = this.addValidators(schemaQuestion);
     question.extras = schemaQuestion;
-    question.dataSource =
-      schemaQuestion.questionOptions.dataSource || 'diagnoses';
+    const dataSourceConfig = this.getDataSourceConfig(schemaQuestion);
+    question.dataSource = dataSourceConfig.name || 'diagnoses';
+    if (Object.keys(dataSourceConfig.options).length > 0) {
+      question.dataSourceOptions = dataSourceConfig.options;
+    }
     const mappings: any = {
       label: 'label',
       required: 'required',

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -157,6 +157,7 @@
 
           <ofe-remote-select [theme]="theme" *ngSwitchCase="'remote-select'"
             [placeholder]="node.question.placeholder | translate" tabindex="0" [dataSource]="dataSource"
+            [dataSourceOptions]="node.question.dataSourceOptions ?? {}"
             [componentID]="node.question.key + 'id'" [formControlName]="node.question.key"
             [id]="node.question.key + 'id'" [invalid]="node.control.touched && !node.control.valid"></ofe-remote-select>
 

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/data-source.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/data-source.ts
@@ -4,7 +4,10 @@ import { Observable } from 'rxjs';
 export interface DataSource {
   dataSourceOptions?: Record<string, unknown>;
   dataFromSourceChanged?: Observable<SelectOption[]>;
-  resolveSelectedValue(value): Observable<SelectOption>;
+  resolveSelectedValue(
+    value,
+    dataSourceOptions?: Record<string, unknown>
+  ): Observable<SelectOption>;
   searchOptions(
     searchText,
     dataSourceOptions?: Record<string, unknown>

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/select-option.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/select-option.ts
@@ -1,4 +1,10 @@
 export interface SelectOption {
   value: any;
   label: string;
+  /**
+   * Optional terminology code (e.g. an ICD-11 code) displayed before the
+   * label in remote-select options and selected values. Purely presentational;
+   * only `value` is persisted.
+   */
+  code?: string;
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,11 +24,31 @@ const adultReturnVisitForm = require('./adult-1.6.json');
 const adultReturnVisitFormObs = require('./mock/obs.json');
 const formOrdersPayload = require('./mock/orders.json');
 
+const sampleSearchItems: Array<any> = [
+  { value: '0', label: 'Aech' },
+  { value: '5b6e58ea-1359-11df-a1f1-0026b9348838', label: 'Art3mis' },
+  { value: '2', label: 'Daito' },
+  { value: '3', label: 'Parzival' },
+  { value: '4', label: 'Shoto' }
+];
+
+const sampleDiagnosesItems: Array<any> = [
+  { value: 'dx1', label: 'Cholera', code: '1A00' },
+  { value: 'dx2', label: 'Typhoid fever', code: '1A07' },
+  { value: 'dx3', label: 'Paratyphoid fever', code: '1A08' },
+  {
+    value: 'dx4',
+    label: 'Typhus fever due to Rickettsia prowazekii',
+    code: '1C30.0'
+  },
+  { value: 'dx5', label: 'Typhoid arthritis' }
+];
+
 @Component({
-    selector: 'app-root',
-    templateUrl: './app.component.html',
-    styleUrls: ['./app.component.scss'],
-    standalone: false
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss'],
+  standalone: false
 })
 export class AppComponent implements OnInit {
   activeTab = 0;
@@ -346,8 +366,10 @@ export class AppComponent implements OnInit {
     return toReturn;
   }
 
-  public sampleResolve(): Observable<any> {
-    const item = { value: '1', label: 'Art3mis' };
+  public sampleResolve(value: string): Observable<any> {
+    const item = [...sampleDiagnosesItems, ...sampleSearchItems].find(
+      (candidate) => candidate.value === value
+    ) ?? { value, label: value };
     return Observable.create((observer: Subject<any>) => {
       setTimeout(() => {
         observer.next(item);
@@ -391,22 +413,11 @@ export class AppComponent implements OnInit {
   }
 
   public sampleDiagnosesSearch(searchText: string): Observable<any> {
-    const items: Array<any> = [
-      { value: '1', label: 'Cholera', code: '1A00' },
-      { value: '2', label: 'Typhoid fever', code: '1A07' },
-      { value: '3', label: 'Paratyphoid fever', code: '1A08' },
-      {
-        value: '4',
-        label: 'Typhus fever due to Rickettsia prowazekii',
-        code: '1C30.0'
-      },
-      { value: '5', label: 'Typhoid arthritis' }
-    ];
     const results = searchText
-      ? items.filter((item) =>
+      ? sampleDiagnosesItems.filter((item) =>
           item.label.toLowerCase().includes(searchText.toLowerCase())
         )
-      : items;
+      : sampleDiagnosesItems;
 
     return Observable.create((observer: Subject<any>) => {
       setTimeout(() => {
@@ -416,17 +427,9 @@ export class AppComponent implements OnInit {
   }
 
   public sampleSearch(searchText: string): Observable<any> {
-    const items: Array<any> = [
-      { value: '0', label: 'Aech' },
-      { value: '5b6e58ea-1359-11df-a1f1-0026b9348838', label: 'Art3mis' },
-      { value: '2', label: 'Daito' },
-      { value: '3', label: 'Parzival' },
-      { value: '4', label: 'Shoto' }
-    ];
-
     return Observable.create((observer: Subject<any>) => {
       setTimeout(() => {
-        observer.next(items);
+        observer.next(sampleSearchItems);
       }, 1000);
     });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -82,7 +82,7 @@ export class AppComponent implements OnInit {
       resolveSelectedValue: this.sampleResolve
     });
     this.dataSources.registerDataSource('diagnoses', {
-      searchOptions: this.sampleSearch,
+      searchOptions: this.sampleDiagnosesSearch,
       resolveSelectedValue: this.sampleResolve
     });
 
@@ -388,6 +388,31 @@ export class AppComponent implements OnInit {
         location.label.toLowerCase().includes(searchText.toLowerCase())
       )
     );
+  }
+
+  public sampleDiagnosesSearch(searchText: string): Observable<any> {
+    const items: Array<any> = [
+      { value: '1', label: 'Cholera', code: '1A00' },
+      { value: '2', label: 'Typhoid fever', code: '1A07' },
+      { value: '3', label: 'Paratyphoid fever', code: '1A08' },
+      {
+        value: '4',
+        label: 'Typhus fever due to Rickettsia prowazekii',
+        code: '1C30.0'
+      },
+      { value: '5', label: 'Typhoid arthritis' }
+    ];
+    const results = searchText
+      ? items.filter((item) =>
+          item.label.toLowerCase().includes(searchText.toLowerCase())
+        )
+      : items;
+
+    return Observable.create((observer: Subject<any>) => {
+      setTimeout(() => {
+        observer.next(results);
+      }, 300);
+    });
   }
 
   public sampleSearch(searchText: string): Observable<any> {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Diagnosis questions can already name a concept source in the O3 standard schema (`datasource.config.conceptSourceUuid`), but the question factory drops the config, so datasources never receive it and no terminology code can be shown next to a diagnosis.

This PR:

- Passes the diagnosis question's datasource config through to `dataSourceOptions`. Both the O3 `datasource: { name, config }` object and the legacy `dataSource` string are supported. Options are only set when the config is non-empty, so questions without a config cannot clobber options on a shared datasource.
- Renders an optional `code` field on remote-select options and selected values. The code appears before the name as bold monospace text that inherits the surrounding text color, matching how KNHTS lists concepts (`{ICD11CODE} {Name}`). Options without a `code` render exactly as they do today.
- Documents the `{ value, label, code? }` option contract on the `SelectOption` interface.
- Wires the demo app's `diagnoses` datasource with coded sample items so the feature can be exercised locally (Primary and Secondary Diagnoses pages).

The code is display metadata only. Search stays name-driven and the persisted payload still contains just the concept UUID. A companion patient-chart PR will make `findDiagnoses` and the diagnosis value resolver return codes from concept mappings so this renders real data in O3.

## Screenshots

https://github.com/user-attachments/assets/7956862c-837f-428d-8bfa-c26567fb7b57

## Related Issue

https://openmrs.atlassian.net/browse/O3-5815

## Other
