### PR TITLE
(fix) Forward setValue options in the AFE form controls

### DIFF
--- a/projects/ngx-formentry/src/abstract-controls-extension/afe-form-array.ts
+++ b/projects/ngx-formentry/src/abstract-controls-extension/afe-form-array.ts
@@ -143,9 +143,9 @@ export class AfeFormArray
     }
   }
 
-  setValue(value: any) {
+  setValue(value: any, options?: { onlySelf?: boolean; emitEvent?: boolean }) {
     if (value !== null) {
-      super.setValue(value);
+      super.setValue(value, options);
     }
   }
 }

--- a/projects/ngx-formentry/src/abstract-controls-extension/afe-form-control.spec.ts
+++ b/projects/ngx-formentry/src/abstract-controls-extension/afe-form-control.spec.ts
@@ -1,0 +1,41 @@
+import { AfeFormControl } from './afe-form-control';
+
+describe('AfeFormControl', () => {
+  it('should not echo a setValue back to the view when emitModelToViewChange is false', () => {
+    const control = new AfeFormControl('');
+    let viewNotified = false;
+    control.registerOnChange(() => {
+      viewNotified = true;
+    });
+
+    control.setValue('some value', { emitModelToViewChange: false });
+
+    expect(control.value).toBe('some value');
+    expect(viewNotified).toBe(false);
+  });
+
+  it('should echo a setValue back to the view by default', () => {
+    const control = new AfeFormControl('');
+    let viewNotified = false;
+    control.registerOnChange(() => {
+      viewNotified = true;
+    });
+
+    control.setValue('some value');
+
+    expect(viewNotified).toBe(true);
+  });
+
+  it('should not emit valueChanges when emitEvent is false', () => {
+    const control = new AfeFormControl('');
+    let emitted = false;
+    control.valueChanges.subscribe(() => {
+      emitted = true;
+    });
+
+    control.setValue('some value', { emitEvent: false });
+
+    expect(control.value).toBe('some value');
+    expect(emitted).toBe(false);
+  });
+});

--- a/projects/ngx-formentry/src/abstract-controls-extension/afe-form-control.ts
+++ b/projects/ngx-formentry/src/abstract-controls-extension/afe-form-control.ts
@@ -150,8 +150,16 @@ class AfeFormControl
     this.alerts.length > 0 && this.updateAlert();
   }
 
-  setValue(value: any) {
-    super.setValue(value);
+  setValue(
+    value: any,
+    options?: {
+      onlySelf?: boolean;
+      emitEvent?: boolean;
+      emitModelToViewChange?: boolean;
+      emitViewToModelChange?: boolean;
+    }
+  ) {
+    super.setValue(value, options);
   }
 }
 export { AfeFormControl };

--- a/projects/ngx-formentry/src/abstract-controls-extension/afe-form-group.ts
+++ b/projects/ngx-formentry/src/abstract-controls-extension/afe-form-group.ts
@@ -110,8 +110,8 @@ export class AfeFormGroup
   updateAlert() {
     this.AlertHelper.evaluateControlAlerts(this);
   }
-  setValue(value: any) {
-    super.setValue(value);
+  setValue(value: any, options?: { onlySelf?: boolean; emitEvent?: boolean }) {
+    super.setValue(value, options);
     if (this.alerts.length > 0) {
       this.updateAlert();
     }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

`AfeFormControl`, `AfeFormGroup`, and `AfeFormArray` override `setValue` with a single-parameter signature, silently dropping the `options` object Angular forms passes through. After a user edit, Angular's view-to-model update calls `setValue(value, { emitModelToViewChange: false })`. Because that flag never reached `FormControl.setValue`, every user edit was echoed back into the control value accessor's `writeValue`.

For most inputs the echo is an invisible no-op. For remote selects it triggers a spurious `resolveSelectedValue` lookup on every selection, and any resolver that returns a different item than what was picked visibly replaces the user's selection (reproducible in the demo app, where the sample resolver returned a hardcoded item). In O3 the real resolver returns the same concept, so the symptom is an unnecessary REST call and loading flicker on each diagnosis selection rather than a visible reset.

This forwards `options` through all three overrides and adds a regression spec asserting that `emitModelToViewChange: false` and `emitEvent: false` are honored.

## Screenshots

### Before

https://github.com/user-attachments/assets/e177def6-74f9-4849-a60d-12247212e109

### After

https://github.com/user-attachments/assets/b574181d-19da-4fc6-bd3f-e03ae440b080


## Related Issue

## Other

Surfaced while testing the diagnosis picker changes in #176.
