### PR TITLE
(fix) O3-5818: Center ng-select field content vertically

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -33,10 +33,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.app.json",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": [
-              "src/styles.scss",
-              "projects/ngx-formentry/styles/ngx-formentry.css"
-            ],
+            "styles": ["src/styles.scss"],
             "stylePreprocessorOptions": {
               "includePaths": ["projects/ngx-formentry/styles", "dist"]
             },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/platform-browser-dynamic": "^20.3.21",
     "@angular/router": "^20.3.21",
     "@carbon/styles": "1.x",
-    "@ng-select/ng-select": "^15.1.3",
+    "@ng-select/ng-select": "^20.7.0",
     "@ngx-translate/core": "^16.0.4",
     "@openmrs/ngx-file-uploader": "^20.0.0",
     "core-js": "^2.6.12",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/platform-browser-dynamic": "^20.3.21",
     "@angular/router": "^20.3.21",
     "@carbon/styles": "1.x",
-    "@ng-select/ng-select": "^20.7.0",
+    "@ng-select/ng-select": "20.4.0",
     "@ngx-translate/core": "^16.0.4",
     "@openmrs/ngx-file-uploader": "^20.0.0",
     "core-js": "^2.6.12",

--- a/projects/ngx-formentry/package.json
+++ b/projects/ngx-formentry/package.json
@@ -10,7 +10,7 @@
     "@angular/core": "^20.0.0",
     "@angular/forms": "^20.0.0",
     "@carbon/styles": "1.x",
-    "@ng-select/ng-select": "^20.7.0",
+    "@ng-select/ng-select": "^20.4.0",
     "@ngx-translate/core": "^16.0.4",
     "@openmrs/ngx-file-uploader": "^20.0.0",
     "lodash": "^4.17.21",

--- a/projects/ngx-formentry/package.json
+++ b/projects/ngx-formentry/package.json
@@ -10,7 +10,7 @@
     "@angular/core": "^20.0.0",
     "@angular/forms": "^20.0.0",
     "@carbon/styles": "1.x",
-    "@ng-select/ng-select": "^15.1.3",
+    "@ng-select/ng-select": "^20.7.0",
     "@ngx-translate/core": "^16.0.4",
     "@openmrs/ngx-file-uploader": "^20.0.0",
     "lodash": "^4.17.21",

--- a/projects/ngx-formentry/styles/ngx-formentry.css
+++ b/projects/ngx-formentry/styles/ngx-formentry.css
@@ -66,7 +66,7 @@
 }
 
 .ng-select .ng-select-container {
-  align-items: baseline;
+  align-items: center;
   min-height: 2.5rem;
   padding: 0 1rem;
 }
@@ -86,8 +86,7 @@
 }
 
 .ng-select .ng-select-container .ng-value-container {
-  align-items: stretch;
-  border-top: 0.84375em solid transparent;
+  align-items: center;
 }
 
 .ng-select .ng-select-container .ng-value-container .ng-placeholder {
@@ -197,7 +196,7 @@
 .ng-select.ng-select-multiple
   .ng-select-container.ng-has-value
   .ng-value-container {
-  padding-bottom: 0;
+  padding-bottom: 0.1875em;
   padding-top: 0.1875em;
 }
 
@@ -207,7 +206,7 @@
 .ng-select.ng-select-multiple
   .ng-select-container.ng-has-value
   .ng-arrow-wrapper {
-  border-top: 0.84375em solid transparent;
+  align-self: center;
 }
 
 .ng-select .ng-clear-wrapper {
@@ -247,13 +246,13 @@
 }
 
 .ng-dropdown-panel.ng-select-bottom {
-  top: calc(100% - 1.25em);
+  top: 100%;
   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
     0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
 }
 
 .ng-dropdown-panel.ng-select-top {
-  bottom: calc(100% - 0.84375em);
+  bottom: 100%;
   box-shadow: 0 -5px 5px -3px rgba(0, 0, 0, 0.2),
     0 -8px 10px 1px rgba(0, 0, 0, 0.14), 0 -3px 14px 2px rgba(0, 0, 0, 0.12);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3738,16 +3738,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ng-select/ng-select@npm:^15.1.3":
-  version: 15.2.0
-  resolution: "@ng-select/ng-select@npm:15.2.0"
+"@ng-select/ng-select@npm:^20.7.0":
+  version: 20.7.0
+  resolution: "@ng-select/ng-select@npm:20.7.0"
   dependencies:
     tslib: "npm:^2.8.1"
   peerDependencies:
     "@angular/common": ^20.0.0
     "@angular/core": ^20.0.0
     "@angular/forms": ^20.0.0
-  checksum: 10/8046789b7b0cc6aca8da9ae6bbaeffaa17b6de51943fe2b67c25d20e762f562ffda6321aeaa45b6a7f45ce89dda82976136695afe9a7a99e49198bd29771b18a
+  checksum: 10/d6ebd2ac024f6a9c29259c9d5084442ba8b5ac2fe1d36e4ed02faa1ae799bbe8203acaaa63d253486489d8a05c4492e3e56a951231c806430b518ae1f53ec7b4
   languageName: node
   linkType: hard
 
@@ -3949,7 +3949,7 @@ __metadata:
     "@angular/platform-browser-dynamic": "npm:^20.3.21"
     "@angular/router": "npm:^20.3.21"
     "@carbon/styles": "npm:1.x"
-    "@ng-select/ng-select": "npm:^15.1.3"
+    "@ng-select/ng-select": "npm:^20.7.0"
     "@ngx-translate/core": "npm:^16.0.4"
     "@openmrs/ngx-file-uploader": "npm:^20.0.0"
     "@playwright/test": "npm:^1.61.1"
@@ -4010,7 +4010,7 @@ __metadata:
     "@angular/core": ^20.0.0
     "@angular/forms": ^20.0.0
     "@carbon/styles": 1.x
-    "@ng-select/ng-select": ^15.1.3
+    "@ng-select/ng-select": ^20.7.0
     "@ngx-translate/core": ^16.0.4
     "@openmrs/ngx-file-uploader": ^20.0.0
     lodash: ^4.17.21

--- a/yarn.lock
+++ b/yarn.lock
@@ -3738,16 +3738,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ng-select/ng-select@npm:^20.7.0":
-  version: 20.7.0
-  resolution: "@ng-select/ng-select@npm:20.7.0"
+"@ng-select/ng-select@npm:20.4.0":
+  version: 20.4.0
+  resolution: "@ng-select/ng-select@npm:20.4.0"
   dependencies:
     tslib: "npm:^2.8.1"
   peerDependencies:
     "@angular/common": ^20.0.0
     "@angular/core": ^20.0.0
     "@angular/forms": ^20.0.0
-  checksum: 10/d6ebd2ac024f6a9c29259c9d5084442ba8b5ac2fe1d36e4ed02faa1ae799bbe8203acaaa63d253486489d8a05c4492e3e56a951231c806430b518ae1f53ec7b4
+  checksum: 10/5cc21b3b7071291e203063998a68b2d92afd1503cb9b200cac65539404eed7fa4f51d9cc2bd6b509dc18ce1d6b31ab05a1c7a2ee96249a20e6b290e2cc4aaedd
   languageName: node
   linkType: hard
 
@@ -3949,7 +3949,7 @@ __metadata:
     "@angular/platform-browser-dynamic": "npm:^20.3.21"
     "@angular/router": "npm:^20.3.21"
     "@carbon/styles": "npm:1.x"
-    "@ng-select/ng-select": "npm:^20.7.0"
+    "@ng-select/ng-select": "npm:20.4.0"
     "@ngx-translate/core": "npm:^16.0.4"
     "@openmrs/ngx-file-uploader": "npm:^20.0.0"
     "@playwright/test": "npm:^1.61.1"
@@ -4010,7 +4010,7 @@ __metadata:
     "@angular/core": ^20.0.0
     "@angular/forms": ^20.0.0
     "@carbon/styles": 1.x
-    "@ng-select/ng-select": ^20.7.0
+    "@ng-select/ng-select": ^20.4.0
     "@ngx-translate/core": ^16.0.4
     "@openmrs/ngx-file-uploader": ^20.0.0
     lodash: ^4.17.21


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Selected values in ng-select-based fields (the remote selects for diagnoses, providers, locations, and concept answers) rendered off-center, and single-select values displayed as dark multiple-select-style chips. Two stacked causes, both fixed here:

1. `@ng-select/ng-select` 15.x is not built for Angular 20, and under it the control's conditional host classes stop evaluating entirely: every state class (`ng-select-multiple`, `ng-select-taggable`, `ng-select-opened`) was permanently stuck on, so single selects picked up multiple-mode chip styling and open/closed styling never updated. Upgraded to the Angular 20 pairing, `^20.7.0`, in the demo app and the library peer range. Note for consumers: this raises the ng-select peer requirement, consistent with the engine's existing Angular 20 requirement (ng-select 15 is demonstrably broken under it).

2. The shipped theme derives from ng-select's Material theme and kept Material's floating-label geometry: `align-items: baseline` on the container, a transparent `0.84375em` border-top reserving space for an inline floating label, top-only padding, and dropdown-panel offsets compensating for that strip. This engine renders labels outside the field, so the reserved space only pushed content down. The theme now centers the container and value container, drops the phantom strip, balances the multiple-mode padding, and anchors the dropdown panel to the field edge.

Also stops the demo loading `ngx-formentry.css` twice (angular.json listed it in addition to the `styles.scss` import).

## Screenshots

### Before

<img width="1806" height="282" alt="CleanShot 2026-07-16 at 15 25 19@2x" src="https://github.com/user-attachments/assets/4223acd8-7bf0-45f4-a990-c7ea75fcad52" />

<img width="1704" height="172" alt="CleanShot 2026-07-16 at 15 25 51@2x" src="https://github.com/user-attachments/assets/684c058b-b264-4cc3-89a5-3d1946369b1d" />

<img width="1730" height="486" alt="CleanShot 2026-07-16 at 15 28 46@2x" src="https://github.com/user-attachments/assets/b13e0e6b-466d-4f8b-9cd9-5af6068c1529" />

### After

<img width="1724" height="154" alt="CleanShot 2026-07-16 at 15 26 58@2x" src="https://github.com/user-attachments/assets/bf356f8f-29e9-46c2-8406-01f8577ec02f" />

<img width="1694" height="156" alt="CleanShot 2026-07-16 at 15 27 07@2x" src="https://github.com/user-attachments/assets/86d05df1-36fb-43d6-a3aa-c8947e41a4b1" />

<img width="1732" height="470" alt="CleanShot 2026-07-16 at 15 29 03@2x" src="https://github.com/user-attachments/assets/f2307f41-7dd4-4c50-8daf-f36097f83bf5" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-5818

## Other
