### PR TITLE
(fix) O3-5817: Handle missing data sources gracefully in the form renderer

### DIFF
--- a/projects/ngx-formentry/src/form-entry/data-sources/endpoint-registration.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/data-sources/endpoint-registration.spec.ts
@@ -101,3 +101,83 @@ describe('FormEntryModule endpoint data source registration', () => {
     expect(dataSources.dataSources['endpoint']).toBe(hostEndpoint);
   });
 });
+
+// Render-time lookup: the endpoint data source self-heals and failed lookups warn.
+describe('FormRendererComponent data source resolution', () => {
+  const remoteSelectNode = (dataSource: string): any => ({
+    question: {
+      renderingType: 'remote-select',
+      extras: {},
+      dataSource,
+      key: 'doctor'
+    }
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function setUpWithHttp(): DataSources {
+    TestBed.configureTestingModule({
+      imports: [FormEntryModule, TranslateModule.forRoot()],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
+    TestBed.inject(FormEntryModule);
+    return TestBed.inject(DataSources);
+  }
+
+  it('re-registers the built-in endpoint data source after a host clears it', () => {
+    const dataSources = setUpWithHttp();
+    dataSources.clearDataSource('endpoint');
+    expect(dataSources.dataSources['endpoint']).toBeUndefined();
+
+    const component = TestBed.createComponent(FormRendererComponent)
+      .componentInstance;
+    component.node = remoteSelectNode('endpoint');
+    component.setUpRemoteSelect();
+
+    expect(component.dataSource instanceof EndpointDataSource).toBe(true);
+    expect(
+      dataSources.dataSources['endpoint'] instanceof EndpointDataSource
+    ).toBe(true);
+  });
+
+  it('does not self-heal the endpoint data source without HttpClient', () => {
+    TestBed.configureTestingModule({
+      imports: [FormEntryModule, TranslateModule.forRoot()]
+    });
+    TestBed.inject(FormEntryModule);
+    const dataSources = TestBed.inject(DataSources);
+    const warnSpy = spyOn(console, 'warn');
+
+    const component = TestBed.createComponent(FormRendererComponent)
+      .componentInstance;
+    component.node = remoteSelectNode('endpoint');
+    component.setUpRemoteSelect();
+
+    expect(component.dataSource).toBeUndefined();
+    expect(dataSources.dataSources['endpoint']).toBeUndefined();
+    const message = warnSpy.calls.mostRecent().args[0] as string;
+    expect(message).toContain('Available data sources: (none)');
+  });
+
+  it('warns with the available names when a data source is missing', () => {
+    setUpWithHttp();
+    const warnSpy = spyOn(console, 'warn');
+
+    const component = TestBed.createComponent(FormRendererComponent)
+      .componentInstance;
+    component.node = remoteSelectNode('providerz');
+    component.setUpRemoteSelect();
+
+    expect(component.dataSource).toBeUndefined();
+    const message = warnSpy.calls.mostRecent().args[0] as string;
+    expect(message).toContain(
+      "Data source 'providerz' required by question 'doctor' is unavailable at render time"
+    );
+    expect(message).toContain('Available data sources: endpoint');
+  });
+});

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -4,13 +4,16 @@ import {
   Input,
   Inject,
   OnChanges,
+  Optional,
   SimpleChanges,
   TemplateRef
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
 import * as _ from 'lodash';
 
 import { DataSources } from '../data-sources/data-sources';
+import { EndpointDataSource } from '../data-sources/endpoint-data-source';
 import { NodeBase, LeafNode, GroupNode } from '../form-factory/form-node';
 import { AfeFormGroup } from '../../abstract-controls-extension/afe-form-group';
 import { ValidationFactory } from '../form-factory/validation.factory';
@@ -21,10 +24,10 @@ import { ValidationErrors } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
-    selector: 'ofe-form-renderer',
-    templateUrl: 'form-renderer.component.html',
-    styleUrls: ['../../style/app.css', './form-renderer.component.scss'],
-    standalone: false
+  selector: 'ofe-form-renderer',
+  templateUrl: 'form-renderer.component.html',
+  styleUrls: ['../../style/app.css', './form-renderer.component.scss'],
+  standalone: false
 })
 export class FormRendererComponent implements OnInit, OnChanges {
   @Input() public formSubmissionTemplate: TemplateRef<unknown>;
@@ -54,7 +57,8 @@ export class FormRendererComponent implements OnInit, OnChanges {
     private dataSources: DataSources,
     private formErrorsService: FormErrorsService,
     public translate: TranslateService,
-    @Inject(DOCUMENT) private document: Document
+    @Inject(DOCUMENT) private document: Document,
+    @Optional() private http: HttpClient
   ) {
     this.activeTab = 0;
   }
@@ -118,20 +122,40 @@ export class FormRendererComponent implements OnInit, OnChanges {
       this.node.question.extras &&
       this.node.question.renderingType === 'remote-select'
     ) {
-      this.dataSource = this.dataSources.dataSources[
-        this.node.question.dataSource
-      ];
-      if (!this.dataSource && this.node.question.dataSource) {
-        console.warn(
-          `No data source registered under '${this.node.question.dataSource}' — ` +
-            `the '${this.node.question.key}' question will have no options.`
-        );
-      }
+      this.dataSource = this.resolveDataSource(this.node.question.dataSource);
 
       if (this.dataSource && this.node.question.dataSourceOptions) {
         this.dataSource.dataSourceOptions = this.node.question.dataSourceOptions;
       }
     }
+  }
+
+  /**
+   * Looks up a data source by name. Re-creates the built-in endpoint data source
+   * if a host application has removed it, and warns when the lookup fails.
+   */
+  private resolveDataSource(dataSourceName: string): DataSource | undefined {
+    if (!dataSourceName) {
+      return undefined;
+    }
+
+    let dataSource = this.dataSources.dataSources[dataSourceName];
+
+    if (!dataSource && dataSourceName === 'endpoint' && this.http) {
+      dataSource = new EndpointDataSource(this.http);
+      this.dataSources.registerDataSource(dataSourceName, dataSource);
+    }
+
+    if (!dataSource) {
+      const registered =
+        Object.keys(this.dataSources.dataSources).sort().join(', ') || '(none)';
+      console.warn(
+        `Data source '${dataSourceName}' required by question '${this.node.question.key}' ` +
+          `is unavailable at render time. Available data sources: ${registered}.`
+      );
+    }
+
+    return dataSource;
   }
 
   public setUpFileUpload() {
@@ -140,9 +164,7 @@ export class FormRendererComponent implements OnInit, OnChanges {
       this.node.question.extras &&
       this.node.question.renderingType === 'file'
     ) {
-      this.dataSource = this.dataSources.dataSources[
-        this.node.question.dataSource
-      ];
+      this.dataSource = this.resolveDataSource(this.node.question.dataSource);
     }
   }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Follow-up to #178. The built-in `endpoint` data source is registered once, when `FormEntryModule` is constructed. A host that resets the data source registry (as `esm-form-entry-app` does between form creations) loses it permanently, leaving `remote-select` questions that use it without options.

- The renderer now re-creates the built-in source when a lookup misses on the name `endpoint` and `HttpClient` is available. Hosts without `HttpClient` keep the existing behavior.
- The `remote-select` and `file` lookups share one `resolveDataSource` helper. `file` questions with a missing data source now warn instead of failing silently.
- The missing data source warning names the question and lists the available data sources.

## Screenshots

## Related Issue

https://openmrs.atlassian.net/browse/O3-5817

## Other

Companion O3 wrapper fix: openmrs/openmrs-esm-patient-chart#3490
