### PR TITLE
(feat) Allow endpoint datasource to use data source values as extra u…

### DIFF
--- a/projects/ngx-formentry/src/form-entry/data-sources/endpoint-data-source.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/data-sources/endpoint-data-source.spec.ts
@@ -9,7 +9,8 @@ import {
   provideHttpClientTesting
 } from '@angular/common/http/testing';
 
-import { EndpointDataSource } from './endpoint-data-source';
+import { EndpointDataSource, EndpointDataSourceOptions } from './endpoint-data-source';
+import { DataSources } from './data-sources';
 
 describe('EndpointDataSource', () => {
   const endpointUrl = 'https://example.org/ws/rest/v1/provider';
@@ -20,8 +21,8 @@ describe('EndpointDataSource', () => {
     TestBed.configureTestingModule({
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
-        provideHttpClientTesting()
-      ]
+        provideHttpClientTesting(),
+      ],
     });
     http = TestBed.inject(HttpClient);
     httpMock = TestBed.inject(HttpTestingController);
@@ -255,4 +256,72 @@ describe('EndpointDataSource', () => {
     expect(result).toBeUndefined();
     httpMock.expectNone(() => true);
   });
+  it('should fetch extra parameters from otherDataSources if configured', (done) => {
+      const mockOtherDataSources: DataSources = {
+        dataSources: {
+          locationUuid: '14265883-7f89-46ec-bf54-97d7ece56130'
+        }
+      } as any;
+
+      const mockOptions: EndpointDataSourceOptions = {
+          endpointUrl: 'https://api.example.com/patients',
+          valueKey: 'uuid',
+          labelKey: 'display',
+          searchParam: 'q',
+          resultsKey: 'results',
+          limitParam: 'limit',
+          limit: 10
+        };
+
+      const dsWithExtra = new EndpointDataSource(
+        http,
+        {
+          ...mockOptions,
+          extraParams: {
+            location: {
+              source: 'dataSources',
+              sourceKey: 'locationUuid'
+            }
+          }
+        },
+        mockOtherDataSources
+      );
+
+      dsWithExtra.searchOptions('').subscribe(() => done());
+
+      const req = httpMock.expectOne(`${mockOptions.endpointUrl}?limit=10&location=14265883-7f89-46ec-bf54-97d7ece56130`);
+      expect(req.request.params.get('location')).toBe('14265883-7f89-46ec-bf54-97d7ece56130');
+      req.flush([]);
+    });
+
+    it('should not add extra parameters from otherDataSources if extra params is not configured', (done) => {
+      const mockOtherDataSources: DataSources = {
+        dataSources: {
+          locationUuid: '14265883-7f89-46ec-bf54-97d7ece56130'
+        }
+      } as any;
+
+      const mockOptions: EndpointDataSourceOptions = {
+          endpointUrl: 'https://api.example.com/patients',
+          valueKey: 'uuid',
+          labelKey: 'display',
+          searchParam: 'q',
+          resultsKey: 'results',
+          limitParam: 'limit',
+          limit: 20
+        };
+
+      const dsWithExtra = new EndpointDataSource(
+        http,
+        {
+          ...mockOptions
+        },
+        mockOtherDataSources
+      );
+
+      dsWithExtra.searchOptions('').subscribe(() => done());
+
+      const req = httpMock.expectOne(`${mockOptions.endpointUrl}?limit=20`);
+      req.flush([]);
+    });
 });

--- a/projects/ngx-formentry/src/form-entry/data-sources/endpoint-data-source.ts
+++ b/projects/ngx-formentry/src/form-entry/data-sources/endpoint-data-source.ts
@@ -4,6 +4,7 @@ import { map } from 'rxjs/operators';
 
 import { DataSource } from '../question-models/interfaces/data-source';
 import { Option } from '../question-models/select-option';
+import { DataSources } from './data-sources';
 
 const DEFAULT_LIMIT = 20;
 
@@ -33,6 +34,12 @@ export interface EndpointDataSourceOptions {
   /** Allows extra, endpoint-specific options and keeps the shape assignable to the
    * `Record<string, unknown>` used by the DataSource contract. */
   [key: string]: unknown;
+  extraParams?: {
+    [key: string]: {
+      source: string;
+      sourceKey: string;
+    };
+  };
 }
 
 interface ResolvedConfig {
@@ -44,6 +51,12 @@ interface ResolvedConfig {
   limitParam: string;
   limit: number;
   resolveUrlTemplate?: string;
+  extraParams?: {
+    [key: string]: {
+      source: string;
+      sourceKey: string;
+    };
+  };
 }
 
 /**
@@ -59,9 +72,15 @@ interface ResolvedConfig {
  */
 export class EndpointDataSource implements DataSource {
   public dataSourceOptions: EndpointDataSourceOptions;
+  private otherDataSources?:DataSources;
 
-  constructor(private http: HttpClient, options?: EndpointDataSourceOptions) {
+  constructor(
+    private http: HttpClient,
+    options?: EndpointDataSourceOptions,
+    otherDatasources?: DataSources
+  ) {
     this.dataSourceOptions = options ?? ({} as EndpointDataSourceOptions);
+    this.otherDataSources = otherDatasources;
   }
 
   /**
@@ -83,6 +102,15 @@ export class EndpointDataSource implements DataSource {
       params = params.set(config.searchParam, searchText);
     }
     params = params.set(config.limitParam, String(config.limit));
+
+    // add extra params from other data sources
+
+    const otherParams = this.getParamsFromOtherDataSources(config);
+    if (otherParams && Object.keys(otherParams).length > 0) {
+      Object.keys(otherParams).forEach((k) => {
+        params = params.set(k, String(otherParams[k]));
+      });
+    }
 
     return this.http.get(config.endpointUrl, { params }).pipe(
       map((response: any) => {
@@ -157,7 +185,8 @@ export class EndpointDataSource implements DataSource {
       resultsKey: merged.resultsKey ?? 'results',
       limitParam: merged.limitParam ?? 'limit',
       limit: this.sanitizeLimit(merged.limit),
-      resolveUrlTemplate: merged.resolveUrlTemplate
+      resolveUrlTemplate: merged.resolveUrlTemplate,
+      extraParams: merged.extraParams ?? {}
     };
   }
 
@@ -193,5 +222,25 @@ export class EndpointDataSource implements DataSource {
 
   private trimTrailingSlash(url: string): string {
     return url.endsWith('/') ? url.slice(0, -1) : url;
+  }
+  private getParamsFromOtherDataSources(config: ResolvedConfig) {
+    const params: Record<string, any> = {};
+    if (config.extraParams) {
+      const extraParams = Object.keys(config.extraParams);
+      for (let i = 0; i <= extraParams.length - 1; i++) {
+        const extraParamKey = extraParams[i];
+        const extraParamSource = config.extraParams[extraParamKey]?.source;
+        const extraParamSourceKey =
+          config.extraParams[extraParamKey]?.sourceKey;
+        if (extraParamSource === 'dataSources') {
+          const extraParamSourceValue =
+            this.otherDataSources?.dataSources[extraParamSourceKey] ?? null;
+          if (extraParamSourceValue) {
+            params[extraParamKey] = extraParamSourceValue;
+          }
+        }
+      }
+    }
+    return params;
   }
 }

--- a/projects/ngx-formentry/src/form-entry/data-sources/endpoint-registration.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/data-sources/endpoint-registration.spec.ts
@@ -163,7 +163,7 @@ describe('FormRendererComponent data source resolution', () => {
     const message = warnSpy.calls.mostRecent().args[0] as string;
     expect(message).toContain('Available data sources: (none)');
   });
-
+  
   it('warns with the available names when a data source is missing', () => {
     setUpWithHttp();
     const warnSpy = spyOn(console, 'warn');

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -124,7 +124,7 @@ export class FormEntryModule {
     // keep working exactly as before, minus this one data source. A data source
     // a host has already registered under this name is left in place.
     if (dataSources && http && !dataSources.dataSources['endpoint']) {
-      dataSources.registerDataSource('endpoint', new EndpointDataSource(http));
+      dataSources.registerDataSource('endpoint', new EndpointDataSource(http,undefined,dataSources));
     }
   }
 }

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -142,7 +142,7 @@ export class FormRendererComponent implements OnInit, OnChanges {
     let dataSource = this.dataSources.dataSources[dataSourceName];
 
     if (!dataSource && dataSourceName === 'endpoint' && this.http) {
-      dataSource = new EndpointDataSource(this.http);
+      dataSource = new EndpointDataSource(this.http, undefined ,this.dataSources);
       this.dataSources.registerDataSource(dataSourceName, dataSource);
     }
 

--- a/src/app/adult-1.6.json
+++ b/src/app/adult-1.6.json
@@ -8209,7 +8209,13 @@
                           "config": {
                             "endpointUrl": "https://jsonplaceholder.typicode.com/users",
                             "labelKey": "name",
-                            "valueKey": "id"
+                            "valueKey": "id",
+                             "extraParams":{
+                               "patientUuid": {
+                                     "source":  "dataSources",
+                                     "sourceKey": "patientUuid"
+                               }
+                            }
                           }
                         }
                       }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -150,6 +150,8 @@ export class AppComponent implements OnInit {
       mui: '447062073-5',
       nid: '1234567'
     });
+    this.dataSources.registerDataSource('patientUuid', 'd4c05325-0279-4a8c-bf61-79b1e4b41c06');
+    this.dataSources.registerDataSource('visitUuid', '14265883-7f89-46ec-bf54-97d7ece56130');
 
     this.dataSources.registerDataSource('file', {
       fileUpload: (data) => {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR extends the abilities of the endpoint datasource. It allows the endpoint datasource to use values already set in the datasource object and pass them as url params. The datasource property required is specified in the configuration property called extraParams. The key specifies what we want the param name to be; the source specifies it should get data from the datasource, the sourceKey specifies the datasource property to extract the value.

```json
{
  "label": "Doctor",
  "id": "doctor",
  "type": "obs",
  "questionOptions": {
    "concept": "a8a666ba-1350-11df-a1f1-0026b9348838",
    "rendering": "remote-select",
    "datasource": {
      "name": "endpoint",
      "config": {
        "endpointUrl": "https://jsonplaceholder.typicode.com/users",
        "labelKey": "name",
        "valueKey": "id",
         "extraParams":{
           "patientUuid": {
                 "source":  "dataSources",
                 "sourceKey": "patientUuid"
           }
        }
      }
    }
  }
}
```

Given the following datasource

```ts
 this.dataSources.registerDataSource('patientUuid', 'd4c05325-0279-4a8c-bf61-79b1e4b41c06');
```

The resolved URL params will be:

https://jsonplaceholder.typicode.com/users?limit=20&patientUuid=d4c05325-0279-4a8c-bf61-79b1e4b41c06

## Screenshots

<!-- Required if you are making UI changes. -->

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->
